### PR TITLE
Use compiled assets when deploying with shio

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,3 +3,4 @@
 rm -rf node_modules
 npm install .
 ./node_modules/.bin/bower install
+./node_modules/.bin/gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,6 +116,7 @@ gulp.task('scripts', [
     ]);
   }
   src = src.concat([
+    'app/tidepoolplatform.js',
     'dist/tmp/app.js',
     'app/start.js'
   ]);

--- a/server.js
+++ b/server.js
@@ -5,8 +5,10 @@ var buildDir = 'dist';
 
 var app = connect();
 
-app.use(connect.static(__dirname + '/' + buildDir));
+var staticDir = __dirname + '/' + buildDir;
+app.use(connect.static(staticDir));
 
-http.createServer(app).listen(3000);
-console.log('Connect server started on port 3000');
-console.log('Serving static directory "' + buildDir + '/"'); 
+var server = http.createServer(app).listen(process.env.PORT || 3000, function() {
+  console.log('Connect server started on port', server.address().port);
+  console.log('Serving static directory "' + staticDir + '/"'); 
+});

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 #! /bin/bash -eu
 
 . config/env.sh
-exec node develop
+exec node server


### PR DESCRIPTION
I'd like to use the production build (created with `gulp`) for deployment. The `develop.js` script is really only meant to be used for local development.

@cheddar Do you mind taking a look at this and if it looks ok deploying it?

@bewest This should close your #5, I changed `server.js` so port is set through the `PORT` environment variable, and the static dir served uses `__dirname` so should work from anywhere.

Changes:
- Add `tidepoolplatform.js` to build process
- Modify `server.js` to run on other port values
- Add build step and run static connect server in shio scripts
