### PR TITLE
Allow username and password change

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -708,12 +708,22 @@ var AppComponent = React.createClass({
     user = _.assign(_.cloneDeep(this.state.user), user);
 
     // Optimistic update
-    self.setState({user: user});
+    self.setState({user: _.omit(user, 'password')});
+
+    // If username hasn't changed, don't try to update
+    // or else backend will respond with "already taken" error
+    if (user.username === previousUser.username) {
+      user = _.omit(user, 'username');
+    }
 
     app.api.user.put(user, function(err, user) {
       if (err) {
+        var message = (err.body && err.body.msg) || '';
         self.setState({
-          notification: 'An error occured while saving user.'
+          notification: [
+            'An error occured while updating user account.',
+            message
+          ].join(' ')
         });
         // Rollback
         self.setState({user: previousUser});

--- a/app/core/api.js
+++ b/app/core/api.js
@@ -38,7 +38,6 @@ api.init = function(cb) {
     uploadApi: config.UPLOAD_API
   });
 
-  _.extend(api.user, tidepoolPlatformApi.user);
   _.extend(api.patientData,  tidepoolPlatformApi.patientData);
   api.getUploadUrl = tidepoolPlatformApi.getUploadUrl;
 
@@ -107,21 +106,23 @@ api.user.login = function(user, cb) {
 api.user.signup = function(user, cb) {
   api.log('POST /user');
 
+  var newAccount = accountFromUser(user);
+  var newProfile = profileFromUser(user);
+
   // First, create user account
-  tidepool.signup(user, function(err, data) {
+  tidepool.signup(newAccount, function(err, account) {
     if (err) {
       return cb(err);
     }
 
-    var token = data.token;
-    var userId = data.userid;
+    var token = account.token;
+    var userId = account.userid;
     saveSession(userId, token);
 
     // Then, add additional user info (first name, etc.) to profile
-    var profile = _.omit(user, 'username', 'password');
-    profile.id = userId;
+    newProfile.id = userId;
     var createUserProfile = function(cb) {
-      tidepool.addOrUpdateProfile(profile, token, cb);
+      tidepool.addOrUpdateProfile(newProfile, token, cb);
     };
 
     // Finally, create necessary groups for a new user account
@@ -141,10 +142,11 @@ api.user.signup = function(user, cb) {
         return cb(err);
       }
 
-      var data = results.profile;
-      // Add back some account info to profile for response
-      data.id = userId;
-      data.username = user.username;
+      var data = userFromAccountAndProfile({
+        account: account,
+        profile: results.profile
+      });
+
       cb(null, data);
     });
   });
@@ -169,6 +171,95 @@ api.user.logout = function(cb) {
     cb();
   });
 };
+
+api.user.get = function(cb) {
+  api.log('GET /user');
+
+  var token = api.token;
+  var userId = api.userId;
+
+  // Fetch user account data (username, etc.)...
+  var getAccount = tidepool.getCurrentUser.bind(tidepool, token);
+
+  // ...and user profile information (first name, last name, etc.)
+  var getProfile = tidepool.findProfile.bind(tidepool, userId, token);
+
+  async.parallel({
+    account: getAccount,
+    profile: getProfile
+  },
+  function(err, results) {
+    if (err) {
+      return cb(err);
+    }
+
+    var user = userFromAccountAndProfile(results);
+
+    cb(null, user);
+  });
+};
+
+api.user.put = function(user, cb) {
+  api.log('PUT /user');
+
+  var token = api.token;
+  var userId = api.userId;
+
+  var account = accountFromUser(user);
+  var updateAccount =
+    tidepool.updateCurrentUser.bind(tidepool, account, token);
+
+  var profile = profileFromUser(user);
+  var updateProfile =
+    tidepool.addOrUpdateProfile.bind(tidepool, profile, token);
+
+  async.parallel({
+    account: updateAccount,
+    profile: updateProfile
+  },
+  function(err, results) {
+    if (err) {
+      return cb(err);
+    }
+
+    var user = userFromAccountAndProfile(results);
+
+    cb(null, user);
+  });
+};
+
+function accountFromUser(user) {
+  var account = _.pick(user, 'username', 'password');
+
+  if (account.username) {
+    account.emails = [user.username];
+  }
+
+  return account;
+}
+
+function profileFromUser(user) {
+  var profile = _.omit(user, 'username', 'password', 'emails');
+  return profile;
+}
+
+function userFromAccountAndProfile(results) {
+  var account = results.account;
+  var profile = results.profile;
+
+  var user = _.assign({}, profile, {
+    id: account.userid,
+    username: account.username
+  });
+
+  // If user profile has patient data, just give the "patient id"
+  // (which is the same as the userid for this backend)
+  if (user.patient != null) {
+    user.patient = {id: user.id};
+  }
+
+  return user;
+}
 
 // ----- Patient -----
 

--- a/app/pages/profile/profile.js
+++ b/app/pages/profile/profile.js
@@ -1,15 +1,15 @@
 /** @jsx React.DOM */
 /**
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  */
@@ -155,6 +155,7 @@ var Profile = React.createClass({
   submitFormValues: function(formValues) {
     var self = this;
     var submit = this.props.onSubmit;
+    formValues = _.omit(formValues, 'passwordConfirm');
 
     // Save optimistically
     submit(formValues);

--- a/app/tidepool/tidepoolplatform.js
+++ b/app/tidepool/tidepoolplatform.js
@@ -10,8 +10,6 @@ module.exports = function(options){
   var uploadApi = options.uploadApi;
 
   var api = {
-    user: {},
-    patient: {},
     patientData: {}
   };
 
@@ -21,93 +19,8 @@ module.exports = function(options){
   var token = null;
   var userid = null;
 
-  var PATIENT_GETALL_NOT_IMPLEMENTED = true;
-
   function makeUrl(path) {
     return apiHost + path;
-  }
-
-  function setupUser(api) {
-    api.get = function(cb) {
-      if (token == null || userid == null) {
-        return cb({ message: 'Not logged in' });
-      }
-
-      // First fetch user account data (username)
-      var uri = '/auth/user';
-      log('GET ' + uri);
-      superagent.get(makeUrl(uri))
-        .set(sessionTokenHeader, token)
-        .end(function(err, res) {
-          if (err != null) {
-            return cb(err);
-          }
-
-          if (res.status !== 200) {
-            return cb({status: res.status, response: res.body});
-          }
-
-          var user = res.body;
-          // Then fetch user profile information (first name, last name, etc.)
-          uri = '/metadata/' + userid + '/profile';
-          log('GET ' + uri);
-          superagent.get(makeUrl(uri))
-            .set(sessionTokenHeader, token)
-            .end(function(err, res) {
-              if (err != null) {
-                return cb(err);
-              }
-
-              if (res.status !== 200) {
-                return cb({status: res.status, response: res.body});
-              }
-
-              var data = res.body;
-              data.id = userid;
-              data.username = user.username;
-              // If user profile has patient data, just give the "patient id"
-              // (which is the same as the userid for this backend)
-              if (data.patient != null) {
-                data.patient = {id: userid};
-              }
-              cb(null, data);
-            });
-        });
-    };
-
-    api.put = function(user, cb) {
-      if (token == null || userid == null) {
-        return cb({ message: 'Not logged in' });
-      }
-
-      // NOTE: Current backend does not yet support changing
-      // username or password, only profile info
-      var profile = _.omit(user, 'username', 'password');
-      var uri = '/metadata/' + userid + '/profile';
-      log('POST ' + uri);
-      superagent.post(makeUrl(uri))
-        .set(sessionTokenHeader, token)
-        .send(profile)
-        .end(function(err, res) {
-          if (err != null) {
-            return cb(err);
-          }
-
-          if (res.status !== 200) {
-            return cb({status: res.status, response: res.body});
-          }
-
-          var data = res.body;
-          data.id = userid;
-          data.username = user.username;
-          // If user profile has patient data, just give the "patient id"
-          // (which is the same as the userid for this backend)
-          if (data.patient != null) {
-            data.patient = {id: userid};
-          }
-          cb(null, data);
-        });
-    };
   }
 
   function setupPatientData(api) {
@@ -175,7 +88,6 @@ module.exports = function(options){
     };
   }
 
-  setupUser(api.user);
   setupPatientData(api.patientData);
   setupUpload(api);
 


### PR DESCRIPTION
**NOTE**: this depends on https://github.com/tidepool-org/platform-client/pull/5
- From "account" page (click on user in top right of navbar), can now change your username (email) and/or password (previously could only change first and last name), thanks to @kentquirk's new `PUT /auth/user` endpoint
- If an error occurs (ex: the email is already tied to an account), show the error message sent back from server
- Moved user API code from `app/tidepool/` (to be deprecated), into `app/core/api.js` and use [platform-client](https://github.com/tidepool-org/platform-client)

![screen shot 2014-04-08 at 4 35 35 pm](https://cloud.githubusercontent.com/assets/1306536/2644848/967751b6-bf2c-11e3-993c-854071644515.png)

![screen shot 2014-04-08 at 4 32 44 pm](https://cloud.githubusercontent.com/assets/1306536/2644852/9ddffb2e-bf2c-11e3-8a13-03a95eea5bc6.png)
