### PR TITLE
Change patient team attribute to object

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -632,11 +632,14 @@ var AppComponent = React.createClass({
     self.setState({fetchingPatientData: true});
 
     var loadPatientData = function(cb) {
-      app.api.patientData.get(patientId,cb);
+      app.api.patientData.get(patientId, cb);
     };
 
     var loadTeamNotes = function(cb) {
-      app.api.team.getNotes(teamId,cb);
+      if (!teamId) {
+        return cb(null, []);
+      }
+      app.api.team.getNotes(teamId, cb);
     };
 
     async.parallel({
@@ -656,7 +659,7 @@ var AppComponent = React.createClass({
       app.log('Patient device data count', patientData.length);
       app.log('Team notes count', notes.length);
 
-      patientData = _.union(patientData,notes);
+      patientData = _.union(patientData, notes);
 
       patientData = self.processPatientData(patientData);
 

--- a/app/pages/patient/patient.js
+++ b/app/pages/patient/patient.js
@@ -221,7 +221,9 @@ var Patient = React.createClass({
   },
 
   renderTeamMembers: function() {
-    var members = this.props.patient && this.props.patient.team;
+    var members = this.props.patient &&
+                  this.props.patient.team &&
+                  this.props.patient.team.members;
 
     if (_.isEmpty(members)) {
       /* jshint ignore:start */

--- a/data/sample/patients/11.json
+++ b/data/sample/patients/11.json
@@ -5,8 +5,11 @@
   "birthday": "1987-03-08",
   "diagnosisDate": "1994-02-01",
   "aboutMe": "Loves swimming and fishing. Owns a bakery in San Francisco. Favorite color is orange.",
-  "team": [
-    {"id": "5", "firstName": "June", "lastName": "Alaniz"},
-    {"id": "6", "firstName": "Donald", "lastName": "Carter"}
-  ]
+  "team": {
+    "id": "99",
+    "members": [
+      {"id": "5", "firstName": "June", "lastName": "Alaniz"},
+      {"id": "6", "firstName": "Donald", "lastName": "Carter"}
+    ]
+  }
 }

--- a/mock/api.js
+++ b/mock/api.js
@@ -277,7 +277,7 @@ var createPatch = function(options) {
     api.team.getNotes = function(groupId,callback){
       api.log('[mock] GET /message/notes/' + groupId);
 
-      var messages = data.messagenotes[99];
+      var messages = data.messagenotes[groupId] || [];
 
       messages = _.map(messages, function(message) {
         return {


### PR DESCRIPTION
@jh-bate Here is what I propose the `api.patient.get()` returns. Example:

``` javascript
{
  "id": "11",
  "firstName": "Mary",
  "lastName": "Smith",
  // ...
  "team": {
    "id": "99",
    "members": [
      {"id": "5", "firstName": "June", "lastName": "Alaniz"},
      {"id": "6", "firstName": "Donald", "lastName": "Carter"}
    ]
  }
}
```

That way you can access `patient.team.id` to get the notes, and the `Patient` page can access `patient.team.members` to display the patient's team members.

What do you think?
