### PR TITLE
Fix datahelpers unit tests

### DIFF
--- a/test/unit/datahelpers_test.js
+++ b/test/unit/datahelpers_test.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -31,20 +31,20 @@ describe('dataHelpers', function(){
       rx.Observable.fromArray(
         [{
            _id: 'abcd', deviceTime: '2014-01-01T01:00:00', value: 3.6,
-           type: 'bolus', subType: 'dual/normal', groupId: 'myJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'myJoinKey'
          },
          {
            _id: 'abcde', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'myJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'myJoinKey',
            duration: 14400000
          },
          {
            _id: '1234', deviceTime: '2014-01-01T01:00:00', value: 0.1,
-           type: 'bolus', subType: 'dual/normal', groupId: 'yourJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'yourJoinKey'
          },
          {
            _id: '12345', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'yourJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'yourJoinKey',
            duration: 14400000
          }])
         .tidepoolConvertBolus()
@@ -74,20 +74,20 @@ describe('dataHelpers', function(){
       rx.Observable.fromArray(
           [{
              _id: 'abcd', deviceTime: '2014-01-01T01:00:00', value: 3.6,
-             type: 'bolus', subType: 'dual/normal', groupId: 'myJoinKey'
+             type: 'bolus', subType: 'dual/normal', joinKey: 'myJoinKey'
            },
            {
              _id: '1234', deviceTime: '2014-01-01T01:00:00', value: 0.1,
-             type: 'bolus', subType: 'dual/normal', groupId: 'yourJoinKey'
+             type: 'bolus', subType: 'dual/normal', joinKey: 'yourJoinKey'
            },
            {
              _id: 'abcde', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-             type: 'bolus', subType: 'dual/square', groupId: 'myJoinKey',
+             type: 'bolus', subType: 'dual/square', joinKey: 'myJoinKey',
              duration: 14400000
            },
            {
              _id: '12345', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-             type: 'bolus', subType: 'dual/square', groupId: 'yourJoinKey',
+             type: 'bolus', subType: 'dual/square', joinKey: 'yourJoinKey',
              duration: 14400000
            }])
         .tidepoolConvertBolus()
@@ -109,20 +109,20 @@ describe('dataHelpers', function(){
       rx.Observable.fromArray(
         [{
            _id: 'abcd', deviceTime: '2014-01-01T01:00:00', value: 3.6,
-           type: 'bolus', subType: 'dual/normal', groupId: 'myJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'myJoinKey'
          },
          {
            _id: '12345', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'yourJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'yourJoinKey',
            duration: 14400000
          },
          {
            _id: '1234', deviceTime: '2014-01-01T01:00:00', value: 0.1,
-           type: 'bolus', subType: 'dual/normal', groupId: 'yourJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'yourJoinKey'
          },
          {
            _id: 'abcde', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'myJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'myJoinKey',
            duration: 14400000
          }])
         .tidepoolConvertBolus()
@@ -144,16 +144,16 @@ describe('dataHelpers', function(){
       rx.Observable.fromArray(
         [{
            _id: 'abcd', deviceTime: '2014-01-01T01:00:00', value: 3.6,
-           type: 'bolus', subType: 'dual/normal', groupId: 'myJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'myJoinKey'
          },
          {
            _id: 'abcde', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'myJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'myJoinKey',
            duration: 14400000
          },
          {
            _id: '1234', deviceTime: '2014-01-01T01:00:00', value: 0.1,
-           type: 'bolus', subType: 'dual/normal', groupId: 'yourJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'yourJoinKey'
          }])
         .tidepoolConvertBolus()
         .toArray()
@@ -168,7 +168,7 @@ describe('dataHelpers', function(){
              },
              {
                _id: '1234', deviceTime: '2014-01-01T01:00:00', value: 0.1,
-               type: 'bolus', subType: 'dual/normal', groupId: 'yourJoinKey',
+               type: 'bolus', subType: 'dual/normal', joinKey: 'yourJoinKey',
                _unmatched: true
              }]
           );
@@ -181,24 +181,24 @@ describe('dataHelpers', function(){
       rx.Observable.fromArray(
         [{
            _id: 'abcd', deviceTime: '2014-01-01T01:00:00', value: 3.6,
-           type: 'bolus', subType: 'dual/normal', groupId: 'myJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'myJoinKey'
          },
          { _id: 'billy', type: 'howdy-ho'},
          {
            _id: 'abcde', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'myJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'myJoinKey',
            duration: 14400000
          },
          { _id: 'sally', type: 'you\'re cute'},
          {
            _id: '1234', deviceTime: '2014-01-01T01:00:00', value: 0.1,
-           type: 'bolus', subType: 'dual/normal', groupId: 'yourJoinKey'
+           type: 'bolus', subType: 'dual/normal', joinKey: 'yourJoinKey'
          },
          { _id: 'billy2', type: 'well, thank you.  Here\'s my number, call me maybe?'},
          { _id: 'sally2', type: 'Ok Maybe.  I\'m Sally'},
          {
            _id: '12345', deviceTime: '2014-01-01T01:00:00Z', value: 1.7,
-           type: 'bolus', subType: 'dual/square', groupId: 'yourJoinKey',
+           type: 'bolus', subType: 'dual/square', joinKey: 'yourJoinKey',
            duration: 14400000
          },
          { _id: 'billy3', type: 'Do you consider yourself a comedian?' }])
@@ -237,22 +237,22 @@ describe('dataHelpers', function(){
         [{
            _id: 'abcd', type: 'basal', deliveryType: 'scheduled',
            deviceTime: '2014-03-07T01:00:00', value: 0.65,
-           scheduleName: 'night-shift'
+           scheduleName: 'night-shift', source: 'carelink'
          },
          {
            _id: 'abcde', type: 'basal', deliveryType: 'temp',
            deviceTime: '2014-03-07T01:38:27', value: 1.7,
-           duration: 3600000
+           duration: 3600000, source: 'carelink'
          },
          {
            _id: 'abcdef', type: 'basal', deliveryType: 'scheduled',
            deviceTime: '2014-03-07T04:00:00', value: 0.32,
-           scheduleName: 'night-shift'
+           scheduleName: 'night-shift', source: 'carelink'
          },
          {
            _id: 'abcdefg', type: 'basal', deliveryType: 'scheduled',
            deviceTime: '2014-03-07T12:00:00', value: 1.02,
-           scheduleName: 'night-shift'
+           scheduleName: 'night-shift', source: 'carelink'
          }])
         .tidepoolConvertBasal()
         .toArray()
@@ -263,25 +263,25 @@ describe('dataHelpers', function(){
                _id: 'abcd', type: 'basal-rate-segment', deliveryType: 'scheduled',
                deviceTime: '2014-03-07T01:00:00', start: '2014-03-07T01:00:00',
                end: '2014-03-07T04:00:00', value: 0.65,
-               scheduleName: 'night-shift'
+               scheduleName: 'night-shift', source: 'carelink'
              },
              {
                _id: 'abcde', type: 'basal-rate-segment', deliveryType: 'temp',
                deviceTime: '2014-03-07T01:38:27', start: '2014-03-07T01:38:27',
                end: '2014-03-07T02:38:27', value: 1.7,
-               duration: 3600000
+               duration: 3600000, source: 'carelink'
              },
              {
                _id: 'abcdef', type: 'basal-rate-segment', deliveryType: 'scheduled',
                deviceTime: '2014-03-07T04:00:00', start: '2014-03-07T04:00:00',
                end: '2014-03-07T12:00:00', value: 0.32,
-               scheduleName: 'night-shift'
+               scheduleName: 'night-shift', source: 'carelink'
              },
              {
                _id: 'abcdefg', type: 'basal-rate-segment', deliveryType: 'scheduled',
                deviceTime: '2014-03-07T12:00:00', start: '2014-03-07T12:00:00',
                end: null, value: 1.02,
-               scheduleName: 'night-shift'
+               scheduleName: 'night-shift', source: 'carelink'
              }
             ]
           );


### PR DESCRIPTION
- Use `joinKey` instead of `groupId` when combining boluses
- Only combine `source === 'carelink'` basals
