### PR TITLE
proposal for checking for various situations of insufficient data

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -17,6 +17,7 @@
 var React = window.React;
 var _ = window._;
 var moment = window.moment;
+var bows = window.bows;
 var config = window.config;
 
 var utils = require('../../core/utils');
@@ -52,6 +53,8 @@ var PatientData = React.createClass({
       createMessage: null
     };
   },
+
+  log: bows('PatientData'),
 
   render: function() {
     var subnav = this.renderSubnav();
@@ -274,8 +277,26 @@ var PatientData = React.createClass({
   isInsufficientPatientData: function() {
     // add additional checks against data and return false iff:
     // only one datapoint
+    var data = this.props.patientData.data;
+    if (data.length === 1) {
+      this.log('Sorry, you need more than one datapoint.');
+      return true;
+    }
+
     // only two datapoints, less than 24 hours apart
+    var start = moment(data[0].normalTime);
+    var end = moment(data[data.length - 1].normalTime);
+    if (end.diff(start, 'days') < 1) {
+      this.log('Sorry, your data needs to span at least a day.');
+      return true;
+    }
+
     // only messages data
+    if (_.reject(data, function(d) { return d.type === 'message'; }).length === 0) {
+      this.log('Sorry, tideline is kind of pointless with only messages.');
+      return true;
+    }
+    return true;
   },
 
   renderMessagesContainer: function() {


### PR DESCRIPTION
Hi @nicolashery. Sara seemed to have discovered a bug with rendering tideline once recently when she had no data uploaded but had one message coming through the API, and that got me to thinking about various situations of not completely missing, but _insufficient_ data for tideline to render properly. I think these checks belong in blip, as they're rather app-specific, or at least especially the check for messages. I also added some code for tideline to fail loudly (in 6ec03111291be9499ceec6695cb478fcc1b97e63) in two of these situations, but IMO the checks (and subsequent `this.renderNoData()`) should be in blip as well. Let me know what you think.
