### PR TITLE
Use gatekeeper API for permissions instead of groups

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -41,6 +41,8 @@ api.init = function(cb) {
     }
   });
 
+  api.tidepool = tidepool;
+
   api.log('Initialized');
   cb();
 };

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "rxjs": "2.2.18",
     "superagent": "0.17.0",
     "tideline": "0.0.18",
-    "tidepool-platform-client": "0.2.0"
+    "tidepool-platform-client": "0.3.1"
   }
 }


### PR DESCRIPTION
@nicolashery @jh-bate 

These are changes to blip to use the new platform-client.  I haven't actually tested them yet and bower hasn't been updated to the latest version 'cause I need platform-client merged first (https://github.com/tidepool-org/platform-client/pull/13).

I'm going to call it a day 'cause I'm not feeling well.  If either of you want to test this out on devel, It'll have the services required to do that.  Otherwise, I'll pick it up tomorrow.
