### PR TITLE
Fix artificial data truncation

### DIFF
--- a/app/core/lib/rx/selfjoin.js
+++ b/app/core/lib/rx/selfjoin.js
@@ -33,6 +33,10 @@ Rx.Observable.prototype.tidepoolSelfJoin = function(builderFns) {
   var eventStream = this;
   var handler = null;
 
+  if (!Array.isArray(builderFns)) {
+    builderFns = [builderFns];
+  }
+
   return Rx.Observable.create(
     function (obs) {
       function processEvent(e) {
@@ -65,7 +69,7 @@ Rx.Observable.prototype.tidepoolSelfJoin = function(builderFns) {
           obs.onError(err);
         },
         function () {
-          if (handler != null) {
+          while (handler != null) {
             var handlerRef = handler;
             handler = null;
             handlerRef.completed().forEach(processEvent);


### PR DESCRIPTION
Under certain corner cases, selfJoin wasn't properly processing events.  This fixes that.

@jebeck @nicolashery 

This is a relatively simple fix to some logic that solves an issue we've run into with user data.  There're a number of whitespace changes (primarily in convertbasal.js), so check out the diff with `w=1`.

Merge at will, pls
