### PR TITLE
make sure footer links are also hidden in print view

### DIFF
--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -188,5 +188,8 @@
 
   .patient-data-footer-outer {
     display: none;
+    a {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
Made one small fix for the 'Device Settings' showing up overlapping with other stuff in print view that I missed before:
![screenshot 2014-05-14 19 11 03](https://cloud.githubusercontent.com/assets/1588547/2979766/3eb355a8-dbd6-11e3-8468-f597d7a5cb6a.png)
