### PR TITLE
Add basic JS runtime error notification

### DIFF
--- a/app/start.js
+++ b/app/start.js
@@ -16,13 +16,20 @@
 /* global app */
 
 window.onerror = function myErrorHandler(errorMessage, fileUrl, lineNumber) {
-  var text = [
+  var html = [
+    '<p>',
     'Sorry! Something went wrong. It\'s our fault, not yours.',
-    'We\'re going to go investigate.',
-    'For the time being, try refreshing your browser?',
+    'Could you please send us a note at',
+    '<a style="color: #fff; text-decoration: underline;"',
+    'href="mailto:support@tidepool.org">support@tidepool.org</a>',
+    'and we\'ll try to see what broke?',
+    'In the meantime, could you try refreshing your browser to reload the app?',
+    '</p>',
+    '<p>',
     'Original error message:',
     '"' + errorMessage + '"',
-    '(' + fileUrl + ' at line ' + lineNumber + ')'
+    '(' + fileUrl + ' at line ' + lineNumber + ')',
+    '</p>'
   ].join(' ');
 
   var style = [
@@ -30,14 +37,14 @@ window.onerror = function myErrorHandler(errorMessage, fileUrl, lineNumber) {
     'top: 0;',
     'left: 0;',
     'right: 0;',
-    'padding: 20px;',
+    'padding: 0 20px;',
     'text-align: center;',
     'background: #ff8b7c;',
     'color: #fff;'
   ].join(' ');
 
   var el = document.createElement('div');
-  el.textContent = text;
+  el.innerHTML = html;
   el.setAttribute('style', style);
   document.body.appendChild(el);
 


### PR DESCRIPTION
This adds a notification if a JavaScript runtime error would to occur.

Note that, unlike a **backend API error** (https://github.com/tidepool-org/blip/pull/81), a **JS runtime error** means that the app "crashed" somehow. In the case of a **backend API error**, the client-side should most of the time be able to recover and continue working (i.e. you can still click around). In the case of the **JS runtime error** however, I expect that there won't be much you can do other than close/refresh the window and maybe try again.

The error notification is very simple, and completely separate from the app code (which is the thing that crashes). It's really there to let the user know something unexpected happen, so she's not guessing (you could be staring at a blank screen). These errors hopefully will be extremely rare. If we do get some, it probably means we should have a better test coverage.

If you want to try it out, put something silly in the code somewhere (ex: in the `render()` function of the `Login` page):

``` javascript
var a;
console.log(a.length);
```

@jebeck: A while ago, Tideline would have SVG errors when not enough data (like trying to plot lines with `NaN`). Is that still the case? Because that might trigger this notification (not 100% sure as it's a rendering error not a JS one it seems)...

![screen shot 2014-05-22 at 1 36 36 pm](https://cloud.githubusercontent.com/assets/1306536/3053299/5f39515c-e1a7-11e3-80a7-541338a4faf0.png)
