### PR TITLE
remove nav arrows on settings page

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -128,12 +128,19 @@ var PatientData = React.createClass({
       /* jshint ignore:end */
 
       var panBackClass = '';
-      if (this.state.inTransition || (this.state.chartType === 'settings')) {
+      // TODO: this should be removed when we support navigation across the settings history
+      if (this.state.chartType === 'settings') {
+        panBackClass = 'patient-data-subnav-hidden';
+      }
+      else if (this.state.inTransition) {
         panBackClass = 'patient-data-subnav-disabled';
       }
       var panForwardClass = '';
-      if ((this.state.atMostRecent ||
-           this.state.inTransition || (this.state.chartType === 'settings'))) {
+      // TODO: this should be removed when we support navigation across the settings history
+      if (this.state.chartType === 'settings') {
+        panForwardClass = 'patient-data-subnav-hidden';
+      }
+      else if ((this.state.atMostRecent || this.state.inTransition )) {
         panForwardClass = 'patient-data-subnav-disabled';
       }
 

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -63,6 +63,11 @@
     color: @gray;
     cursor: default;
   }
+
+  // TODO: this should be removed when we support navigation across the settings history
+  &.patient-data-subnav-hidden {
+    display: none;
+  }
 }
 
 .patient-data-subnav a.patient-data-subnav-active {


### PR DESCRIPTION
@skrugman doesn't want the nav arrows disabled on settings page, wants them gone.

This also takes care of the TypeError issue due to the simple fact that you can't click and get a TypeError anymore, but https://github.com/tidepool-org/tideline/pull/130 provides an extra measure of protection as well.
