### PR TITLE
hide feedback link in print view

### DIFF
--- a/app/components/mailto/mailto.less
+++ b/app/components/mailto/mailto.less
@@ -13,6 +13,12 @@
  * not, you can obtain one from Tidepool Project at tidepool.org.
  */
 
+@media print {
+  .mailto {
+    display: none;
+  }
+}
+
 .mailto {
   font-size: 14px;
 }


### PR DESCRIPTION
Just a little something I noticed when testing the new blip-tideline integration.
