### PR TITLE
Add logging that shows performance bottlenecks better

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -759,7 +759,9 @@ var AppComponent = React.createClass({
       app.log('Patient device data count', patientData.length);
       app.log('Team notes count', notes.length);
 
+      var now = Date.now();
       patientData = _.union(patientData, notes);
+      app.log('Done unioning patient data in ' + (Date.now() - now) + ' millis.');
 
       patientData = self.processPatientData(patientData);
 

--- a/app/core/api.js
+++ b/app/core/api.js
@@ -457,12 +457,14 @@ api.patientData = {};
 api.patientData.get = function(patientId, cb) {
   api.log('GET /data/' + patientId);
 
+  var now = Date.now();
   tidepool.getDeviceDataForUser(patientId, function(err, data) {
     if (err) {
       return cb(err);
     }
+    api.log('Data received in ' + (Date.now() - now) + ' millis.');
 
-    var now = Date.now();
+    now = Date.now();
     window.inData = data;
     Rx.Observable.fromArray(data)
       .map(function(e){


### PR DESCRIPTION
@nicolashery @jh-bate @jebeck

After the switch away from using node.js for loading data, found out that the current loading speed bottleneck is actually in blip.  This PR has some extra logging that shows what's going on.
