### PR TITLE
add window.stringifiedData variable

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -800,6 +800,7 @@ var AppComponent = React.createClass({
     if (!(data && data.length)) {
       return null;
     }
+    window.stringifiedData = JSON.stringify(data);
 
     var processData = chartUtil.processData(data);
     window.tidelineData = processData;


### PR DESCRIPTION
I used to do this on a local branch, but Ian would like to use it now too. This adds a variable `window.stringifiedData` that a developer can log to the console in blip as a poor man's way of exporting real data and saving it as a JSON file that we can load into the tideline example when developing and/or putting examples into the tideline GitHub pages "gallery."

Process:
`console.log(window.strignifiedData)` in the console after logging in and fetching data in blip. Copy and paste the console results into your fav text editor, clean it up by deleting any non-data stuff that was logged to the console, save it as JSON. Best to save it as `blip-output.json` in tideline's `example/data/` because that path is on the .gitignore to prevent accidentally checking in any real data.

@nicolashery can you OK and merge?
