### PR TITLE
on creation or updating of message, update patientData and create or move message in tideline

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -563,9 +563,16 @@ var AppComponent = React.createClass({
         onSaveComment={app.api.team.replyToMessageThread.bind(app.api.team)}
         onCreateMessage={app.api.team.startMessageThread.bind(app.api.team)}
         onEditMessage={app.api.team.editMessage.bind(app.api.team)}
+        onUpdatePatientData={this.handleUpdatePatientData}
         trackMetric={trackMetric}/>
     );
     /* jshint ignore:end */
+  },
+
+  handleUpdatePatientData: function(data) {
+    this.setState({
+      patientData: data
+    });
   },
 
   login: function(formValues, cb) {

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -168,6 +168,9 @@ var Daily = React.createClass({
   },
   createMessageThread: function(message) {
     return this.refs.chart.createMessage(message);
+  },
+  editMessageThread: function(message) {
+    return this.refs.chart.editMessage(message);
   }
 });
 
@@ -275,6 +278,9 @@ var DailyChart = React.createClass({
   },
   createMessage: function(message) {
     return this.chart.createMessage(message);
+  },
+  editMessage: function(message) {
+    return this.chart.editMessage(message);
   }
 });
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -42,6 +42,7 @@ var PatientData = React.createClass({
     onSaveComment: React.PropTypes.func,
     onEditMessage: React.PropTypes.func,
     onCreateMessage: React.PropTypes.func,
+    onUpdatePatientData: React.PropTypes.func,
     user: React.PropTypes.object,
     trackMetric: React.PropTypes.func.isRequired
   },
@@ -307,7 +308,8 @@ var PatientData = React.createClass({
         id: message.id
       };
     var transformedMessage = watson.normalize(tidelineMessage);
-    this.refs.tideline.createMessageThread(transformedMessage);
+    var data = this.refs.tideline.createMessageThread(transformedMessage);
+    this.props.onUpdatePatientData(data);
     this.props.trackMetric('Created New Message');
   },
 
@@ -324,6 +326,17 @@ var PatientData = React.createClass({
     if (edit) {
       edit(message, cb);
     }
+    // transform to Tideline's own format
+    var tidelineMessage = {
+        utcTime : message.timestamp,
+        messageText : message.messagetext,
+        parentMessage : message.parentmessage,
+        type: 'message',
+        id: message.id
+      };
+    var transformedMessage = watson.normalize(tidelineMessage);
+    var data = this.refs.tideline.editMessageThread(transformedMessage);
+    this.props.onUpdatePatientData(data);
     this.props.trackMetric('Edit To Message');
   },
 


### PR DESCRIPTION
@jh-bate @nicolashery have a look, please. (And at [tideline PR #141](https://github.com/tidepool-org/tideline/pull/141).)

I wasn't able to do what we discussed - updating `patientData` to trigger a rerender of the chart, because the only thing in `render()` for the (daily) chart component is `<div id="tidelineContainer" className="patient-data-chart"></div>` ([here](https://github.com/tidepool-org/blip/blob/master/app/components/chart/daily.js#L244)) which doesn't include the `patientData` prop, so when the updated prop comes in, React doesn't recognize the need to rerender.

I think the current solution is good enough for now - perhaps we can discuss a more React-y way to manage this in future (data attribute?). Right now I'm updating `patientData` from the return value of the method that updates tideline's data, so they are guaranteed to stay in sync.
