### PR TITLE
Use concat not lodash union for patientData

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -769,10 +769,7 @@ var AppComponent = React.createClass({
       app.log('Patient device data count', patientData.length);
       app.log('Team notes count', notes.length);
 
-      var now = Date.now();
-      patientData = _.union(patientData, notes);
-      app.log('Done unioning patient data in ' + (Date.now() - now) + ' millis.');
-
+      patientData = patientData.concat(notes);
       patientData = self.processPatientData(patientData);
 
       self.setState({


### PR DESCRIPTION
Use `Array.prototype.concat` vs. `_.union` to merge device data and notes on client-side.

Quick check: a dataset that used to take ~28 sec to fetch and process now takes ~8 sec.

Credit to where it's due (I didn't do anything really, just change 1 line of code):
- thanks @cheddar for finding the bottleneck
- thanks @jebeck for pointing out that it was silly to use `_.union` there which checks for duplicates

BEFORE:
![screen shot 2014-07-14 at 3 38 07 pm](https://cloud.githubusercontent.com/assets/1306536/3576470/58aee152-0b92-11e4-9453-de133b935427.png)

AFTER:
![screen shot 2014-07-14 at 3 50 27 pm](https://cloud.githubusercontent.com/assets/1306536/3576471/5f128634-0b92-11e4-8564-008887536a42.png)
