### PR TITLE
Publish to hakken when necessary env variables are set

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2014, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ */
+
+var fs = require('fs');
+
+function maybeReplaceWithContentsOfFile(obj, field) {
+  var potentialFile = obj[field];
+  if (potentialFile != null && fs.existsSync(potentialFile)) {
+    obj[field] = fs.readFileSync(potentialFile).toString();
+  }
+}
+
+var env = {};
+
+env.httpPort = process.env.PORT;
+
+env.httpsPort = process.env.HTTPS_PORT;
+
+// The https config to pass along to https.createServer.
+var theConfig = process.env.HTTPS_CONFIG;
+env.httpsConfig = null;
+if (theConfig) {
+  env.httpsConfig = JSON.parse(theConfig);
+  maybeReplaceWithContentsOfFile(env.httpsConfig, 'key');
+  maybeReplaceWithContentsOfFile(env.httpsConfig, 'cert');
+  maybeReplaceWithContentsOfFile(env.httpsConfig, 'pfx');
+}
+
+// Make sure we have an HTTPS config if a port is set
+if (env.httpsPort && !env.httpsConfig) {
+  throw new Error('No https config provided, please set HTTPS_CONFIG with at least the certificate to use.');
+}
+
+env.discoveryHost = process.env.DISCOVERY_HOST;
+
+// The service name to expose to discovery
+env.serviceName = process.env.SERVICE_NAME || 'blip';
+
+// The local host to expose to discovery
+env.publishHost = process.env.PUBLISH_HOST;
+
+module.exports = env;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-minify-css": "0.3.3",
     "gulp-template": "0.1.1",
     "gulp-uglify": "0.2.1",
+    "hakken": "0.1.4",
     "jshint-stylish": "0.1.5",
     "lodash": "2.4.1",
     "mkdirp": "0.3.5",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,8 @@
 var http = require('http');
+var https = require('https');
 var connect = require('connect');
+
+var config = require('./env.js');
 
 var buildDir = 'dist';
 
@@ -8,7 +11,39 @@ var app = connect();
 var staticDir = __dirname + '/' + buildDir;
 app.use(connect.static(staticDir));
 
-var server = http.createServer(app).listen(process.env.PORT || 3000, function() {
-  console.log('Connect server started on port', server.address().port);
-  console.log('Serving static directory "' + staticDir + '/"'); 
-});
+// If no ports specified, just start on default HTTP port
+if (!(config.httpPort || config.httpsPort)) {
+  config.httpPort = 3000;
+}
+
+if (config.httpPort) {
+  http.createServer(app).listen(config.httpPort, function() {
+    console.log('Connect server started on port', config.httpPort);
+    console.log('Serving static directory "' + staticDir + '/"');
+  });
+}
+
+if (config.httpsPort) {
+  https.createServer(config.httpsConfig, app).listen(config.httpsPort, function() {
+    console.log('Connect server started on HTTPS port', config.httpsPort);
+    console.log('Serving static directory "' + staticDir + '/"');
+  });
+}
+
+if (config.discoveryHost && config.publishHost) {
+  var hakken = require('hakken')({host: config.discoveryHost}).client();
+  hakken.start();
+
+  var serviceDescriptor = {service: config.serviceName};
+  if (config.httpsPort) {
+    serviceDescriptor['host'] = config.publishHost + ':' + config.httpsPort;
+    serviceDescriptor['protocol'] = 'https';
+  }
+  else if (config.httpPort) {
+    serviceDescriptor['host'] = config.publishHost + ':' + config.httpPort;
+    serviceDescriptor['protocol'] = 'http';
+  }
+
+  console.log('Publishing to service discovery');
+  hakken.publish(serviceDescriptor);
+}


### PR DESCRIPTION
When the necessary env variables are set (i.e. when running on Tidepool platform), `server.js` will publish to Hakken which will take care of redirecting HTTP to HTTPS.

@cheddar do you want to take a quick look? Thanks!
