### PR TITLE
disable tabular basal settings by default; show them with ?showbasalsettings[=true]

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -121,6 +121,7 @@ var AppComponent = React.createClass({
       showingAcceptTerms: false,
       showingWelcomeMessage: false,
       dismissedBrowserWarning: false,
+      queryParams: queryString.parseTypes(window.location.search)
     };
   },
 
@@ -557,6 +558,7 @@ var AppComponent = React.createClass({
         patientData={this.state.patientData}
         fetchingPatientData={this.state.fetchingPatientData}
         isUserPatient={this.isSamePersonUserAndPatient()}
+        queryParams={this.state.queryParams}
         uploadUrl={api.getUploadUrl()}
         onRefresh={this.fetchCurrentPatientData}
         onFetchMessageThread={this.fetchMessageThread}

--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -18,7 +18,7 @@ var TidelineHeader = React.createClass({
     onClickNext: React.PropTypes.func,
     onClickOneDay: React.PropTypes.func,
     onClickTwoWeeks: React.PropTypes.func,
-    onClickSettings: React.PropTypes.func.isRequired
+    onClickSettings: React.PropTypes.func
   },
   render: function() {
     var dayLinkClass = cx({

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -36,6 +36,7 @@ var PatientData = React.createClass({
     patient: React.PropTypes.object,
     fetchingPatientData: React.PropTypes.bool,
     isUserPatient: React.PropTypes.bool,
+    queryParams: React.PropTypes.object.isRequired,
     uploadUrl: React.PropTypes.string,
     onRefresh: React.PropTypes.func,
     onFetchMessageThread: React.PropTypes.func,
@@ -53,7 +54,7 @@ var PatientData = React.createClass({
         bgUnits: 'mg/dL',
         hiddenPools: {
           // pass null here to *completely* disable the tabular display of basal settings
-          basalSettings: true
+          basalSettings: null
         }
       },
       chartType: 'daily',
@@ -63,6 +64,19 @@ var PatientData = React.createClass({
       initialDatetimeLocation: null,
       messages: null
     };
+  },
+
+  componentWillMount: function() {
+    var params = this.props.queryParams;
+    if (!_.isEmpty(params) && params.showbasalsettings !== undefined) {
+      this.setState({
+        chartPrefs: {
+          hiddenPools: {
+            basalSettings: params.showbasalsettings ? true : null
+          }
+        }
+      });
+    }
   },
 
   log: bows('PatientData'),


### PR DESCRIPTION
@nicolashery or @jh-bate have a look-see please :)

Naming of variables etc. by no means set in stone. Feel free to change.

Expected behavior: no tabular basal settings by default.
If `?showbasalsettings` or `?showbasalsettings=true`, you get the show/hide norgie (NB: before the hash like so http://localhost:3000/?showbasalsettings=true#/patients/11/data)
If `?showbasalsettings=false`, they are disabled again.
