### PR TITLE
pass joinKey through even after joining normal and square components of extended boluses

### DIFF
--- a/app/core/lib/devicedata/convertbolus.js
+++ b/app/core/lib/devicedata/convertbolus.js
@@ -87,6 +87,7 @@ function dualNormalBuilder() {
       return [
         {
           id: normal.id,
+          joinKey: normal.joinKey,
           deviceId: normal.deviceId,
           initialDelivery: normal.value,
           extendedDelivery: square.value,


### PR DESCRIPTION
Just looked at this with some real data, looks like it's the same `joinKey` for joining both the normal and square components of an extended bolus as for combining bolus records with wizard records, so all we should need for the new lollipops visualization is this simple change - making sure we continue to pass that `joinKey` through.

CC @cheddar @ianjorgensen 
