### PR TITLE
Skip basals with a "time" field

### DIFF
--- a/app/core/lib/devicedata/convertbasal.js
+++ b/app/core/lib/devicedata/convertbasal.js
@@ -84,6 +84,11 @@ if (Rx.Observable.prototype.tidepoolConvertBasal == null) {
           return null;
         }
 
+        // Skip over elements with a "time" field because they belong to the new data model
+        if (e.time != null) {
+          return null;
+        }
+
         return isScheduledBasal(e) ? makeNewBasalHandler() : null;
       }
     ).tidepoolSelfJoin(


### PR DESCRIPTION
@jebeck 

This PR is required to get basals in the new data format to successfully make it past the pre-processing stuff in blip.  It's backwards compatible with the current stuff, though, so it should be fine to merge.
