### PR TITLE
remove require of config so it doesn't get bundled twice

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -14,7 +14,6 @@
  */
 
 window.onerror = require('./onerror');
-window.config = require('../config.app.js');
 
 var app = window.app = require('./app');
 


### PR DESCRIPTION
OK, I played around, and here's what I found that seems to be the root of our problem. The require of `config.app.js` in `main.js` meant that the config was getting bundled twice, both in the app bundle and the config bundle.

Here's how I figured this out:
- no env variables set, `npm run build-app`
- set env variables UPLOAD_API to foo-uploads and API_HOST to foo-api
- now `npm run build-config`
- serve static `dist/` to myself, and lo and behold! the app points to devel anyway

But remove the require of the config in `main.js` and go through the same procedure again, and now the app points to the foo endpoints.

Perhaps it's just a matter not of removing the require (although bundling the config twice seems a little blech to me, but removing the require also will break the running locally dev experience), but changing the order of the bundle links in index.html? The config bundle link comes first, which I expect means the config getting bundled into the app bundle, which comes second, overrides the actual config.
