### PR TITLE
Fix navbar arrows for Safari

### DIFF
--- a/app/components/navbar/navbar.js
+++ b/app/components/navbar/navbar.js
@@ -93,10 +93,9 @@ var Navbar = React.createClass({
 
     return (
       <div className="Navbar-patientSection" ref="patient">
-        <a href={patientUrl} onClick={handleClick} className="Navbar-button Navbar-button--leftLabel">
-          <div className="Navbar-label">
-            <span className="Navbar-labelContent Navbar-patientName">{displayName}</span>
-            <span className="Navbar-labelContent Navbar-leftLabelArrow"></span>
+        <a href={patientUrl} onClick={handleClick} className="Navbar-button Navbar-button--withLeftLabelAndArrow">
+          <div className="Navbar-label Navbar-label--left Navbar-label--withArrow">
+            <span className="Navbar-patientName">{displayName}</span>
           </div>
         </a>
         <div className="Navbar-patientPicture"></div>
@@ -154,11 +153,10 @@ var Navbar = React.createClass({
     return (
       <ul className="Navbar-menuSection" ref="user">
         <li className="Navbar-menuItem">
-          <a href="#/profile" title="Account" onClick={handleClickUser} className="Navbar-button Navbar-button--leftLabel">
-            <div className="Navbar-label">
-              <span className="Navbar-labelContent Navbar-loggedInAs">Logged in as</span>
-              <span className="Navbar-labelContent Navbar-userName" ref="userFullName">{displayName}</span>
-              <span className="Navbar-labelContent Navbar-leftLabelArrow"></span>
+          <a href="#/profile" title="Account" onClick={handleClickUser} className="Navbar-button Navbar-button--withLeftLabelAndArrow">
+            <div className="Navbar-label Navbar-label--left Navbar-label--withArrow">
+              <span className="Navbar-loggedInAs">{'Logged in as '}</span>
+              <span className="Navbar-userName" ref="userFullName">{displayName}</span>
             </div>
             <i className="Navbar-icon icon-profile"></i>
           </a>

--- a/app/components/navbar/navbar.less
+++ b/app/components/navbar/navbar.less
@@ -92,63 +92,59 @@
   text-decoration: none;
 
   &:hover,
-  &:focus {
+  &:focus,
+  &:active {
     color: @gray-darkest;
     text-decoration: none;
   }
-
-  &:active {
-    color: @gray;
-  }
 }
 
-.Navbar-button--leftLabel {
+.Navbar-button--withLeftLabelAndArrow {
+  // No idea why, but this makes the button keep correct height
   display: flex;
 
-  // Hack to give room to things on the right
   margin-right: 8px;
 }
 
-.Navbar-labelContent {
-  // All label content blocks need to have this so they align vertically
-  // Note: "text-overflow: ellipsis" will only trigger if you set a "max-width"
-  display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  // Necessary when using text-overflow, according to SO
-  white-space: nowrap;
-
+.Navbar-label {
   color: #fff;
   background-color: @gray-dark;
 
   .Navbar-button:hover &,
-  .Navbar-button:focus & {
-    background-color: @gray-darkest;
-  }
-
+  .Navbar-button:focus &,
   .Navbar-button:active & {
-    background-color: @gray;
+    background-color: @gray-darkest;
   }
 }
 
-.Navbar-leftLabelArrow {
-  width: 0;
-  height: 0;
-  border-top: (@Navbar-buttonHeight/2) solid transparent;
-  border-bottom: (@Navbar-buttonHeight/2) solid transparent;
+.Navbar-label--left {
+  padding-left: 20px;
+  padding-right: 5px;
+}
 
-  border-left: 10px solid @gray-dark;
-  background: none;
+// http://cssarrowplease.com/
+.Navbar-label--left.Navbar-label--withArrow {
+  position: relative;
+  margin-right: @Navbar-buttonHeight/2;
 
-  .Navbar-button:hover &,
-  .Navbar-button:focus & {
-    border-left-color: @gray-darkest;
-    background: none;
+  &:after {
+  	left: 100%;
+  	top: 50%;
+  	border: solid transparent;
+  	content: " ";
+  	height: 0;
+  	width: 0;
+  	position: absolute;
+  	pointer-events: none;
+	  border-left-color: @gray-dark;
+  	border-width: @Navbar-buttonHeight/2;
+  	margin-top: -@Navbar-buttonHeight/2;
   }
 
-  .Navbar-button:active & {
-    border-left-color: @gray;
-    background: none;
+  .Navbar-button:hover &:after,
+  .Navbar-button:focus &:after,
+  .Navbar-button:active &:after {
+    border-left-color: @gray-darkest;
   }
 }
 
@@ -173,17 +169,26 @@
   list-style: none;
 }
 
+
 .Navbar-loggedInAs {
-  padding-left: 20px;
-  padding-right: 5px;
+  // Everything inside the label needs to have
+  // so it aligns correctly with the text that has "overflow ellipsis"
+  // Note: setting "max-width" triggers the ellipsis
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  margin-right: 5px;
 }
 
 .Navbar-userName {
-  padding-right: 5px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
-  // Set width to trigger "text-overflow: ellipsis"
-  // Make sure to take into account padding
-  max-width: (180px + 5px);
+  max-width: 180px;
 }
 
 .Navbar-menuItem .Navbar-icon {
@@ -194,12 +199,12 @@
 // ====================================
 
 .Navbar-patientName {
-  padding-left: 20px;
-  padding-right: 5px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
-  // Set width to trigger "text-overflow: ellipsis"
-  // Make sure to take into account padding
-  max-width: (180px + 20px + 5px);
+  max-width: 180px;
 }
 
 @Navbar-patientPictureSize: 60px;


### PR DESCRIPTION
This fixes a bug with the "arrows" in the navbar under Safari (thanks @jebeck for pointing it out).

Man.. these arrows are the worse :p Tried to keep the CSS as clean as possible, but it's still a bit of a hack and magic numbers. @skrugman Just pointing it out for the future, some things are easier to build & maintain than others in HTML & CSS :)

BEFORE:

![screen shot 2014-09-16 at 9 35 14 am](https://cloud.githubusercontent.com/assets/1306536/4288713/43c1e2be-3dae-11e4-8090-24b823c39d45.png)

AFTER:

![screen shot 2014-09-16 at 10 28 03 am](https://cloud.githubusercontent.com/assets/1306536/4288719/4ccc246e-3dae-11e4-8b77-db07f496a38b.png)
