### PR TITLE
Fix loading indicator on dashboard with invites

### DIFF
--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -64,6 +64,7 @@ var Patients = React.createClass({
     /* jshint ignore:start */
     return (
       <Invitation
+        key={invitation.from.userid}
         invitation={invitation}
         patientsComponent={this}
         onAcceptInvitation={this.props.onAcceptInvitation}


### PR DESCRIPTION
@ianjorgensen This is just as an FYI. I noticed a small flash of empty UI on the dashboard when some things finish loading but it can't render yet. I fixed that here.

I don't expect you to catch it as I haven't documented how you can use the mock API to test this. But for info, if you save your session (`localStorage.mockAuthToken = 'token11'`), and then reload with the URL:

```
http://localhost:3000/?api.patient.getall.delay=2000&api.invitation.getReceived.delay=1000#/patients
```

You can see the app in "loading" states, which mimics a bit better what the user would see in the real world.

Merging this now, as only a cosmetic change. Just wanted to put it up here for you to see.
