### PR TITLE
Use hash query params for invites

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -319,17 +319,26 @@ var AppComponent = React.createClass({
   },
 
   renderLogin: function() {
-    var inviteEmail = utils.validateEmail(this.state.queryParams.inviteEmail) && this.state.queryParams.inviteEmail;
-
     return (
       /* jshint ignore:start */
       <Login
         onSubmit={this.login}
-        inviteEmail={inviteEmail}
+        inviteEmail={this.getInviteEmail()}
         onSubmitSuccess={this.handleLoginSuccess}
         trackMetric={trackMetric} />
       /* jshint ignore:end */
     );
+  },
+
+  getInviteEmail: function() {
+    var hashQueryParams = app.router.getQueryParams();
+    var inviteEmail = hashQueryParams.inviteEmail;
+    if (inviteEmail && utils.validateEmail(inviteEmail)) {
+      return inviteEmail;
+    }
+    else {
+      return null;
+    }
   },
 
   showSignup: function() {
@@ -338,13 +347,11 @@ var AppComponent = React.createClass({
   },
 
   renderSignup: function() {
-    var inviteEmail = utils.validateEmail(this.state.queryParams.inviteEmail) && this.state.queryParams.inviteEmail;
-
     return (
       /* jshint ignore:start */
       <Signup
         onSubmit={this.signup}
-        inviteEmail={inviteEmail}
+        inviteEmail={this.getInviteEmail()}
         onSubmitSuccess={this.handleSignupSuccess}
         trackMetric={trackMetric} />
       /* jshint ignore:end */

--- a/app/components/loginnav/loginnav.js
+++ b/app/components/loginnav/loginnav.js
@@ -63,7 +63,6 @@ var LoginNav = React.createClass({
   },
 
   renderLink: function() {
-    console.log('this.props.inviteEmail',this.props.inviteEmail);
     if (this.props.inviteEmail) {
       return null;
     }

--- a/app/router.js
+++ b/app/router.js
@@ -83,6 +83,17 @@ router.setup = function(routes, options) {
   return this;
 };
 
+router.getQueryParams = function() {
+  var routeFragments = router.getRoute();
+  var lastFragment = routeFragments[routeFragments.length - 1];
+  var queryStr = lastFragment.match(/\?(.+)/);
+  if (queryStr && queryStr.length > 1) {
+    queryStr = queryStr[1];
+    return queryString.parse(queryStr);
+  }
+  return {};
+};
+
 router._parseNoAuthRoutes = function(routes) {
   return _.map(routes, this._getRouteFirstFragment);
 };


### PR DESCRIPTION
@ianjorgensen This should fix your problem. There wasn't much to do once we're using the hash query params, so this single commit should make everything "work" like you wanted. Take a look and merge if you're good with it?

I've updated `hydrophone`'s config to `2014-10-16-v2` which reflects this new URL format (/cc @jh-bate), i.e.:

```
https://devel-blip.tidepool.io/#/login?inviteEmail=bob@example.com&inviteKey=abc123
```
