### PR TITLE
Abbreviates dates in the patient data charts and brings arrows in closer.

### DIFF
--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -117,7 +117,7 @@ var Daily = React.createClass({
     else {
       timezone = timePrefs.timezoneName || 'UTC';
     }
-    return sundial.formatInTimezone(datetime, timezone, 'ddd, MMM Do');
+    return sundial.formatInTimezone(datetime, timezone, 'ddd, MMM D, YYYY');
   },
   // handlers
   handleClickModal: function(e) {

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -117,7 +117,7 @@ var Daily = React.createClass({
     else {
       timezone = timePrefs.timezoneName || 'UTC';
     }
-    return sundial.formatInTimezone(datetime, timezone, 'dddd, MMMM Do');
+    return sundial.formatInTimezone(datetime, timezone, 'ddd, MMM Do');
   },
   // handlers
   handleClickModal: function(e) {

--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -53,6 +53,13 @@ var TidelineHeader = React.createClass({
       'patient-data-subnav-hidden': this.props.chartType === 'no-data'
     });
 
+    var dateLinkClass = cx({
+      'patient-data-subnav-text' : this.props.chartType === 'daily' || this.props.chartType === 'weekly' || this.props.chartType === 'modal',
+      'patient-data-subnav-dates-daily': this.props.chartType === 'daily',
+      'patient-data-subnav-dates-weekly': this.props.chartType === 'weekly',
+      'patient-data-subnav-dates-modal': this.props.chartType === 'modal'
+    });
+
     var mostRecentLinkClass = cx({
       'patient-data-subnav-active': !this.props.atMostRecent && !this.props.inTransition,
       'patient-data-subnav-disabled': this.props.atMostRecent || this.props.inTransition,
@@ -93,7 +100,7 @@ var TidelineHeader = React.createClass({
             </div>
             <div className="grid-item one-whole large-one-half patient-data-subnav-center" id="tidelineLabel">
               <a href="" className={backClass} onClick={this.props.onClickBack}><i className={this.props.iconBack}/></a>
-              <div className="patient-data-subnav-text patient-data-subnav-text-dates">
+              <div className={dateLinkClass}>
                 {this.props.title}
               </div>
               <a href="" className={nextClass} onClick={this.props.onClickNext}><i className={this.props.iconNext}/></a>

--- a/app/components/chart/modal.js
+++ b/app/components/chart/modal.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -186,7 +186,7 @@ var Modal = React.createClass({
     else {
       timezone = timePrefs.timezoneName || 'UTC';
     }
-    return sundial.formatInTimezone(datetime, timezone, 'MMMM Do');
+    return sundial.formatInTimezone(datetime, timezone, 'MMM Do');
   },
   getTitle: function(datetimeLocationEndpoints) {
     // endpoint is exclusive, so need to subtract a day

--- a/app/components/chart/modal.js
+++ b/app/components/chart/modal.js
@@ -186,7 +186,7 @@ var Modal = React.createClass({
     else {
       timezone = timePrefs.timezoneName || 'UTC';
     }
-    return sundial.formatInTimezone(datetime, timezone, 'MMM Do');
+    return sundial.formatInTimezone(datetime, timezone, 'MMM D, YYYY');
   },
   getTitle: function(datetimeLocationEndpoints) {
     // endpoint is exclusive, so need to subtract a day

--- a/app/components/chart/weekly.js
+++ b/app/components/chart/weekly.js
@@ -161,7 +161,7 @@ var Weekly = React.createClass({
   },
   formatDate: function(datetime) {
     // even when timezoneAware, labels should be generated as if UTC; just trust me (JEB)
-    return sundial.formatInTimezone(datetime, 'UTC', 'MMM Do');
+    return sundial.formatInTimezone(datetime, 'UTC', 'MMM D, YYYY');
   },
   getTitle: function(datetimeLocationEndpoints) {
     return this.formatDate(datetimeLocationEndpoints[0]) + ' - ' + this.formatDate(datetimeLocationEndpoints[1]);

--- a/app/components/chart/weekly.js
+++ b/app/components/chart/weekly.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -161,7 +161,7 @@ var Weekly = React.createClass({
   },
   formatDate: function(datetime) {
     // even when timezoneAware, labels should be generated as if UTC; just trust me (JEB)
-    return sundial.formatInTimezone(datetime, 'UTC', 'MMMM Do');
+    return sundial.formatInTimezone(datetime, 'UTC', 'MMM Do');
   },
   getTitle: function(datetimeLocationEndpoints) {
     return this.formatDate(datetimeLocationEndpoints[0]) + ' - ' + this.formatDate(datetimeLocationEndpoints[1]);

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -27,13 +27,14 @@
   color: #fff;
   background-color: @gray-dark;
 
-  padding-left: 0;
-  padding-right: 0;
+  // padding-left: 0;
+  // padding-right: 0;
+  padding: @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding 0;
 }
 
 .patient-data-subnav-text {
   display: inline-block;
-  padding: @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding 0;
+  //  padding: @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding 0;
 
   text-align: center;
 }
@@ -52,7 +53,7 @@
 
 .patient-data-subnav a {
   display: inline-block;
-  padding: @patient-data-subnav-vertical-padding @patient-data-subnav-horizontal-padding;
+  padding: 0 @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding;
 
   color: #fff;
   text-decoration: none;

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -27,14 +27,11 @@
   color: #fff;
   background-color: @gray-dark;
 
-  // padding-left: 0;
-  // padding-right: 0;
   padding: @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding 0;
 }
 
 .patient-data-subnav-text {
   display: inline-block;
-  //  padding: @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding 0;
 
   text-align: center;
 }

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -33,14 +33,21 @@
 
 .patient-data-subnav-text {
   display: inline-block;
-  padding: @patient-data-subnav-vertical-padding @patient-data-subnav-horizontal-padding;
+  padding: @patient-data-subnav-vertical-padding 0 @patient-data-subnav-horizontal-padding 0;
 
   text-align: center;
 }
 
-.patient-data-subnav-text-dates {
-  padding-left: 0;
-  padding-right: 0;
+.patient-data-subnav-dates-daily {
+  width: 150px;
+}
+
+.patient-data-subnav-dates-weekly {
+  width: 220px;
+}
+
+.patient-data-subnav-dates-modal {
+  width: 275px;
 }
 
 .patient-data-subnav a {

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -39,8 +39,6 @@
 }
 
 .patient-data-subnav-text-dates {
-  width: 275px;
-
   padding-left: 0;
   padding-right: 0;
 }


### PR DESCRIPTION
This PR abbreviates the dates shown in daily, weekly, and trend views of patient data. 
@jebeck @skrugman 

To tighten the position of the arrows, I removed a large block element that surrounded the dates in each view. When you test this, you'll notice that this causes the arrows to bounce slightly as the width of the date string changes. In my testing, I found that you can still click the arrows repeatedly to move forward or backward in time without losing focus. 

If the slight jump/bounce of the arrows is undesirable, I can create CSS rules for each view that will reintroduce the block around the date, just a bit tighter than before when there was one block for all views. 

Let me know how you'd like me to proceed!

Resolves: https://trello.com/c/RELPBpRy

I agree to the terms of Tidepool Project’s Volunteer/Contributor License Agreement v1.0
as it exists at http://tidepool-org.github.io/TidepoolVCLA.pdf on Monday, January 12, 2015.
cc/ @kentquirk 