### PR TITLE
two-tone color scheme for trends view days of the week

### DIFF
--- a/app/components/chart/modalsubnav.less
+++ b/app/components/chart/modalsubnav.less
@@ -85,7 +85,7 @@
     background-color: white;
     border-radius: 5px;
     border: @gray-dark 1px solid;
-    color: @gray-superdark;
+    color: @purple-highcontrast;
     text-align: center;
     &.active {
       font-weight: bold;

--- a/app/components/chart/modalsubnav.less
+++ b/app/components/chart/modalsubnav.less
@@ -85,7 +85,7 @@
     background-color: white;
     border-radius: 5px;
     border: @gray-dark 1px solid;
-    color: @gray-darkest;
+    color: @gray-superdark;
     text-align: center;
     &.active {
       font-weight: bold;

--- a/app/components/chart/modalsubnav.less
+++ b/app/components/chart/modalsubnav.less
@@ -93,25 +93,25 @@
     }
 
     &.monday.active {
-      background-color: @monday;
+      background-color: @weekday;
     }
     &.tuesday.active {
-      background-color: @tuesday;
+      background-color: @weekday;
     }
     &.wednesday.active {
-      background-color: @wednesday;
+      background-color: @weekday;
     }
     &.thursday.active {
-      background-color: @thursday;
+      background-color: @weekday;
     }
     &.friday.active {
-      background-color: @friday;
+      background-color: @weekday;
     }
     &.saturday.active {
-      background-color: @saturday;
+      background-color: @weekend;
     }
     &.sunday.active {
-      background-color: @sunday;
+      background-color: @weekend;
     }
   }
 }

--- a/app/core/less/variables.less
+++ b/app/core/less/variables.less
@@ -39,13 +39,16 @@
 @gray-title:             #808080;
 
 // Modal Day
-@monday: #B7E66E;
-@tuesday: #5ACA64;
-@wednesday: #37BFB9;
-@thursday: #1EA2DC;
-@friday: #4E8ADB;
-@saturday: #E5E200;
-@sunday: #E5B20C;
+@weekday: #3D9998;
+@weekend: #5DE8DE;
+
+@monday: @weekday;
+@tuesday: @weekday;
+@wednesday: @weekday;
+@thursday: @weekday;
+@friday: @weekday;
+@saturday: @weekend;
+@sunday: @weekend;
 
 // Scaffolding
 // ====================================

--- a/app/core/less/variables.less
+++ b/app/core/less/variables.less
@@ -16,7 +16,6 @@
 // Colors
 // ====================================
 
-@gray-superdark:         #353535; // Trends view subnav
 @gray-darkest:           #636363; // Hover state for links, buttons
 @gray-darker:            #727375; // Text on white background
 @gray-dark:              #989897; // Nav links, buttons, tabs
@@ -24,6 +23,7 @@
 @gray-light:             #e6e6e5; // Container on white background
 @gray-lighter:           #f7f7f8; // Background
 
+@purple-highcontrast:    #281946; // Trends view day subnav text
 @purple-success:         #7950ea;
 @purple-blip:            #4E4490;
 @orange-alert:           #ffa70b;

--- a/app/core/less/variables.less
+++ b/app/core/less/variables.less
@@ -16,6 +16,7 @@
 // Colors
 // ====================================
 
+@gray-superdark:         #353535; // Trends view subnav
 @gray-darkest:           #636363; // Hover state for links, buttons
 @gray-darker:            #727375; // Text on white background
 @gray-dark:              #989897; // Nav links, buttons, tabs

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "shelljs": "0.3.0",
     "style-loader": "0.6.4",
     "sundial": "1.0.1",
-    "tideline": "0.1.9",
+    "tideline": "0.1.11",
     "tidepool-platform-client": "0.11.0",
     "url-loader": "0.5.5",
     "webpack": "1.4.9"


### PR DESCRIPTION
In conjunction with [tideline PR #197](https://github.com/tidepool-org/tideline/pull/197). That should be merged and tagged first, then this PR updated.

At present, the sub-navigation for selecting and deselecting days of the week - in particular, the dark text for weekday abbrevs on the darker turquoise - does not meet our accessibility requirements for text contrast:
![screenshot 2015-01-12 15 33 50](https://cloud.githubusercontent.com/assets/1588547/5713543/3f3767b6-9a72-11e4-9a57-2dbc38f7f6d6.png)

I attempted a quick solution (make the day of week text white for weekdays), but I don't think it works very well:
![screenshot 2015-01-12 15 38 20](https://cloud.githubusercontent.com/assets/1588547/5713547/4ba041ee-9a72-11e4-8d88-6f27136ee216.png)
(White text on the weekend color also fails our accessibility requirements.)

Further input required to move forward... Ping @skrugman @brandonarbiter 
