### PR TITLE
Moves the white dropdown menu up arrow so it aligns with the blue arrow in the navbar

### DIFF
--- a/app/components/navbar/navbar.less
+++ b/app/components/navbar/navbar.less
@@ -348,7 +348,7 @@
 .Navbar-menuDropdown:before {
 	position: absolute;
   top: -7px;
-  right: 7px;
+  right: 14px;
   display: inline-block;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #eee;

--- a/app/components/navbar/navbar.less
+++ b/app/components/navbar/navbar.less
@@ -347,7 +347,7 @@
 .Navbar-menuDropdown:before {
 	position: absolute;
   top: -7px;
-  left: 98px;
+  right: 7px;
   display: inline-block;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #eee;


### PR DESCRIPTION
@jebeck @skrugman 
Quick change to move the white arrow in the dropdown menu of the navbar to line up under the blue down arrow. 

![blip](https://cloud.githubusercontent.com/assets/1380417/5724562/844b7812-9b1a-11e4-946b-4b522f07147d.png)

Resolves: https://trello.com/c/z7iYok6F