### PR TITLE
ignore error on logout and destroy the session

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -863,11 +863,8 @@ var AppComponent = React.createClass({
     // Need to track this before expiring auth token
     trackMetric('Logged Out');
 
-    app.api.user.logout(function(err) {
-      if (err) {
-        self.setState({loggingOut: false});
-        return self.handleApiError(err, usrMessages.ERR_ON_LOGOUT, buildExceptionDetails());
-      }
+    app.api.user.logout(function() {
+      //ignore the error - the session has already been destroyed
       self.refs.logoutOverlay.fadeOut(function() {
         self.setState({loggingOut: false});
       });

--- a/app/core/api.js
+++ b/app/core/api.js
@@ -114,7 +114,7 @@ api.user.logout = function(cb) {
   if (!api.user.isAuthenticated()) {
     api.log('not authenticated but still destroySession');
     tidepool.destroySession();
-    return;
+    return cb();
   }
 
   tidepool.logout(function(err) {
@@ -123,7 +123,7 @@ api.user.logout = function(cb) {
       api.log('error logging out but still destroySession');
       tidepool.destroySession();
     }
-    cb();
+    return cb();
   });
 };
 

--- a/app/core/api.js
+++ b/app/core/api.js
@@ -112,14 +112,17 @@ api.user.logout = function(cb) {
   api.log('POST /user/logout');
 
   if (!api.user.isAuthenticated()) {
+    api.log('not authenticated but still destroySession');
+    tidepool.destroySession();
     return;
   }
 
   tidepool.logout(function(err) {
+    //don't return the error, we just want to log out and be done with it
     if (err) {
-      return cb(err);
+      api.log('error logging out but still destroySession');
+      tidepool.destroySession();
     }
-
     cb();
   });
 };


### PR DESCRIPTION
this relates an error seen when a session times out, then the user clicks "log out", the app hangs. It should re-direct to the login page.

@jebeck if you could have a quick look?