### PR TITLE
Light gray outline added to the navbar dropdown menu.

### DIFF
--- a/app/components/navbar/navbar.less
+++ b/app/components/navbar/navbar.less
@@ -321,13 +321,13 @@
 }
 
 .Navbar-menuDropdown {
+  border: 1px solid @gray-light;
   cursor: default;
   position: absolute;
   background: white;
   right: 0px;
   z-index: 100;
   width: 200px;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
   top: 25px;
 
   > ul {
@@ -345,16 +345,28 @@
   }
 }
 
+.Navbar-menuDropdown:after,
 .Navbar-menuDropdown:before {
 	position: absolute;
-  top: -7px;
+  top: -8px;
   right: 14px;
   display: inline-block;
+  border: solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #eee;
   border-left: 7px solid transparent;
   border-bottom-color: white;
   content: '';
+  height: 0;
+  width: 0;
+}
+
+.Navbar-menuDropdown:before {
+  top: -14px;
+  border-color: rgba(230, 230, 229, 0);
+  border-bottom-color: @gray-light;
+  border-width: 7px;
+  margin-left: -7px;
 }
 
 .Navbar-dropdownIcon {


### PR DESCRIPTION
@skrugman @jebeck 

This PR removes the shadow from the dropdown menu and adds a light gray border around it. The change took a bit more time than I thought since you have to do some CSS magic to get an outline around that triangle in the menu. I've tested my change in Chrome, Safari, and Firefox to make sure it's working cross-browser and it looks good.

Resolves: https://trello.com/c/Y5eXAWyQ