### PR TITLE
Link cleanup for the patientcard component

### DIFF
--- a/app/components/patientcard/patientcard.less
+++ b/app/components/patientcard/patientcard.less
@@ -76,6 +76,7 @@
     margin-top: 5px;
   }
 }
+
 .patientcard-fullname {
   padding-top: 5px;
   padding-left: 5px;
@@ -158,11 +159,12 @@ a.patientcard {
     text-decoration: none;
 
     .patientcard-fullname {
-      color: @gray-darker;
+      color: @blue-green-light;
+      text-decoration: underline;
     }
 
     i {
-      color: @gray-darker;
+      color: @blue-green-light;
     }
   }
 }
@@ -170,7 +172,6 @@ a.patientcard {
 .patientcard-actions--highlight {
   color: @blue-green !important;
   text-decoration: none;
-  font-weight: 400;
 
   .patientcard-fullname {
     color: @blue-green;


### PR DESCRIPTION
@skrugman @jebeck 

This PR updates the patient card component in two places: 
1) On the patients page, the bold hover effect has been removed from the View|Share|Upload links to make navigation less jumpy. 
2) On the patient data page, the patient name and icon (in the patient card component in the navbar) now has a light blue green hover effect with an underline for the patient name for consistency with other text links in the site. 

Per @skrugman, in the future, we'll look for better affordances for indicating hover than the outline, but this will be good for accessibility for the time being. 

Resolves: https://trello.com/c/W6OCIaCY 