### PR TITLE
Removes white background and lines up buttons on welcome screen.

### DIFF
--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -63,14 +63,14 @@ var Patients = React.createClass({
     var noPatientsSetupStorage = this.renderNoPatientsSetupStorageLink();
     var patients = this.renderPatients();
 
-    var bgClasses = cx({
+    var backgroundClasses = cx({
       'patients js-patients-page': true,
       'patients-welcome js-patients-page': this.isShowingWelcomeTitle()
     });
 
     return (
       <div className="container-box-outer">
-        <div className={bgClasses}>
+        <div className={backgroundClasses}>
           {welcomeTitle}
           {welcomeSetup}
           {noPatientsOrInvites}

--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -16,6 +16,7 @@
 
 var React = require('react');
 var _ = require('lodash');
+var cx = require('react/lib/cx');
 
 var config = require('../../config');
 
@@ -62,9 +63,14 @@ var Patients = React.createClass({
     var noPatientsSetupStorage = this.renderNoPatientsSetupStorageLink();
     var patients = this.renderPatients();
 
+    var bgClasses = cx({
+      'patients js-patients-page': true,
+      'patients-welcome js-patients-page': this.isShowingWelcomeTitle()
+    });
+
     return (
       <div className="container-box-outer">
-        <div className="patients js-patients-page">
+        <div className={bgClasses}>
           {welcomeTitle}
           {welcomeSetup}
           {noPatientsOrInvites}
@@ -99,8 +105,8 @@ var Patients = React.createClass({
           {"Would you like to set up data storage for someone’s diabetes data?"}
         </div>
         <div className="patients-welcomesetup-actions">
-          <div><button className="btn btn-primary" onClick={handleClickYes}>{"Yes, let's set it up"}</button></div>
-          <div><button className="btn btn-tertiary" onClick={handleClickNo}>{"No, not now"}</button></div>
+          <button className="btn btn-tertiary" onClick={handleClickNo}>{"No, not now"}</button>
+          <button className="btn btn-primary" onClick={handleClickYes}>{"Yes, let's set it up"}</button>
           <div className="patients-welcomesetup-actions-help">{"(You can always create one later)"}</div>
         </div>
       </div>

--- a/app/pages/patients/patients.less
+++ b/app/pages/patients/patients.less
@@ -15,12 +15,18 @@
 
 @patients-box-max-width: 680px;
 
-.patients {
+.patients,
+.patients-welcome {
   margin-right: auto;
   margin-left: auto;
   margin-bottom: @spacing-large;
   background: white;
   border: 1px solid @gray-light;
+}
+
+.patients-welcome {
+  background: none;
+  border: 0;
 }
 
 .patients-section {
@@ -113,7 +119,7 @@
 // ====================================
 
 .patients-message {
-  color: @gray-dark;
+  color: @gray-text;
   font-weight: 300;
   text-align: center;
 
@@ -151,7 +157,11 @@
 
   button {
     min-width: 180px;
-    margin-top: 10px;
+    margin: 10px 10px;
+
+    .btn .btn-primary {
+      float: left;
+    }
   }
 }
 


### PR DESCRIPTION
@skrugman @jebeck 

This PR removes the white box background from the welcome screen and aligns the two buttons on the screen (instead of stacking them). 

One other change I made was to use the 'gray-text' style instead of 'gray-dark'. The contrast between the gray background and gray text was too hard to read. The 'gray-text' style uses a slightly darker gray that's much easier to read. I hope this is okay. 

Resolves: https://trello.com/c/DVAEVnEC