### PR TITLE
Only show "Remove People" link when there's an account displayed that the user does not own.

### DIFF
--- a/app/components/peoplelist/peoplelist.js
+++ b/app/components/peoplelist/peoplelist.js
@@ -71,7 +71,7 @@ var PeopleList = React.createClass({
       'people-list-single': this.props.people.length === 1
     });
 
-    var editControls = this.editablePersonExists(this.props.people) ? this.renderEditControls() : null;
+    var removeControls = this.removeablePersonExists(this.props.people) ? this.renderRemoveControls() : null;
 
       /* jshint ignore:start */
     return (
@@ -80,17 +80,17 @@ var PeopleList = React.createClass({
           {peopleNodes}
           <div className="clear"></div>
         </ul>
-        {editControls}
+        {removeControls}
       </div>
     );
     /* jshint ignore:end */
   },
 
-  editablePersonExists: function(patients) {
-    return Boolean(_.find(patients, personUtils.hasEditPermissions));
+  removeablePersonExists: function(patients) {
+    return Boolean(_.find(patients, personUtils.isRemoveable));
   },
 
-  renderEditControls: function() {
+  renderRemoveControls: function() {
     var key = 'edit';
     var text = 'Remove People';
     if (this.state.editing) {

--- a/app/core/personutils.js
+++ b/app/core/personutils.js
@@ -69,4 +69,13 @@ personUtils.hasEditPermissions = function(person) {
   );
 };
 
+personUtils.isRemoveable = function(person) {
+  return (
+    person &&
+    !_.isEmpty(person.permissions) &&
+    !person.permissions.admin &&
+    !person.permissions.root
+  );
+};
+
 module.exports = personUtils;


### PR DESCRIPTION
@jh-bate 

This PR fixes functionality that determines whether the 'Remove people' link should be shown. The original code (editControls, editablePersonExists) was incorrectly always showing the link because it was looking for the existence of admin perms, which are always there - because the logged in user has admins perms for their own account. 

To get this working, I added an .isRemoveable function to core/personutils.js that, when passed a person, checks to ensure that the perms aren't empty and their they're not root and not admin. If that is true, then it's a person the user has view/upload/etc rights for. When that is the case, the remove button should be shown onscreen. 

Resolves: PR: https://trello.com/c/1YFnGntX