### PR TITLE
Determine whether to render the Patients or skip and go directly to Patient Data

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -427,10 +427,11 @@ var AppComponent = React.createClass({
   },
 
   redirectToDefaultRoute: function() {
-    this.showPatients();
+    this.showPatients(true);
   },
 
-  showPatients: function() {
+  showPatients: function(canSkipPatients) {
+    this.setState({canSkipPatients: canSkipPatients});
     this.renderPage = this.renderPatients;
     this.setState({page: 'patients'});
     this.fetchInvites();
@@ -439,8 +440,9 @@ var AppComponent = React.createClass({
   },
 
   renderPatients: function() {
+    var patients;
     /* jshint ignore:start */
-    return <Patients
+    patients = <Patients
         user={this.state.user}
         fetchingUser={this.state.fetchingUser}
         patients={this.state.patients}
@@ -456,6 +458,49 @@ var AppComponent = React.createClass({
         onDismissInvitation={this.handleDismissInvitation}
         onRemovePatient={this.handleRemovePatient}/>;
     /* jshint ignore:end */
+
+    // Determine whether to skip the Patients page & go directly to Patient data.
+    // If there is only one patient you can see data for, go to the patient's data.
+    // Otherwise, display the Patients page.
+    if (this.state.canSkipPatients) {
+
+      if (!this.state.fetchingUser && !this.state.fetchingPatients && !this.state.fetchingInvites) {
+
+        var viewerUserId = null;
+        var isPatient = personUtils.isPatient(this.state.user);
+        var numPatientsUserCanSee = (this.state.patients == null) ? 0 : this.state.patients.length;
+
+        // First check that the user has no pending invites
+        if (_.isEmpty(this.state.invites)) {
+
+          // Then determine how many people the user can view
+          if (isPatient) {
+            if (numPatientsUserCanSee === 0) {
+              viewerUserId = this.state.user.userid;
+            }
+          } else {
+            if (numPatientsUserCanSee === 1) {
+              viewerUserId = this.state.patients[0].userid;
+            }
+          }
+
+          // Last, set the appropriate route
+          if (viewerUserId === null) {
+            app.router.setRoute('/patients');
+            return;
+          } else {
+            app.router.setRoute('/patients/' + viewerUserId + '/data');
+            return;
+          }
+        }
+
+        app.router.setRoute('/patients');
+      }
+
+      return;
+    }
+
+    return (patients);
   },
 
   handleHideWelcomeSetup: function(options) {

--- a/app/app.js
+++ b/app/app.js
@@ -430,8 +430,8 @@ var AppComponent = React.createClass({
     this.showPatients(true);
   },
 
-  showPatients: function(canSkipPatients) {
-    this.setState({canSkipPatients: canSkipPatients});
+  showPatients: function(showPatientData) {
+    this.setState({showPatientData: showPatientData});
     this.renderPage = this.renderPatients;
     this.setState({page: 'patients'});
     this.fetchInvites();
@@ -462,7 +462,7 @@ var AppComponent = React.createClass({
     // Determine whether to skip the Patients page & go directly to Patient data.
     // If there is only one patient you can see data for, go to the patient's data.
     // Otherwise, display the Patients page.
-    if (this.state.canSkipPatients) {
+    if (this.state.showPatientData) {
 
       if (!this.state.fetchingUser && !this.state.fetchingPatients && !this.state.fetchingInvites) {
 


### PR DESCRIPTION
This change picks up on a stale PR (https://github.com/tidepool-org/blip/pull/164) which had some logic problems. 

The approach is pretty simple, whenever we call redirectToDefaultRoute, we call showPatients, which now sets a state called canSkipPatients as true.

In the renderPatients function, when we see that canSkipPatients flag, we do some checks to make sure data has loaded, then figure out how many people the user can view data for - then direct them to either the patients page or patient data page. After stepping carefully through all the cases (if you're a patient, caregiver, etc.) and the permissions you have for various other users, the logic I arrived at it pretty simple: 

Providing the user has no pending invites, if there is only patient (including the user themselves) the user can see data for, go directly to the Patient Data page, otherwise, go to the Patients page.

I've walked through this with @kentquirk, but @jebeck or @jh-bate, can you review? Thank you!

Resolves: https://trello.com/c/bmAQYqbu