### PR TITLE
Fixes webpack configuration for favicon.ico

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
       {test: /\.jpg$/, loader: 'url-loader?limit=10000&mimetype=image/jpg'},
       {test: /\.png$/, loader: 'url-loader?limit=10000&mimetype=image/png'},
       {test: /\.svg$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml'},
-      {test: /\.ico$/, loader: 'url-loader?limit=10000&mimetype=image/x-icon'},
+      {test: /favicon\.ico$/, loader: 'file-loader?name=favicon.ico&limit=100000&mimetype=image/x-icon'},
       {test: /\.eot$/, loader: 'url-loader?limit=10000&mimetype=application/vnd.ms-fontobject'},
       {test: /\.woff$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff'},
       {test: /\.ttf$/, loader: 'url-loader?limit=10000&mimetype=application/x-font-ttf'},


### PR DESCRIPTION
@kentquirk @jebeck 

Updates the webpack config to use the file loader which allows you to specify a name for a file in a build so that it's not hashed like most other assets.  

Resolves: https://trello.com/c/iQwJAoxZ