### PR TITLE
Fixes long name layout issues.

### DIFF
--- a/app/components/navbar/navbar.less
+++ b/app/components/navbar/navbar.less
@@ -32,7 +32,8 @@
   // Magic number width: should contain whole menu,
   // and put some space between menu an patient section
   width: 330px;
-
+  
+  padding: 0;
   // Align child items to the right (flex-end)
   // and to the top (default)
   display: flex;
@@ -222,7 +223,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 150px;
+  max-width: 140px;
 }
 
 .Navbar-menuItem {


### PR DESCRIPTION
@jebeck 

By making the navbar icons larger in an earlier change the other week, the spacing allotted for username length was reduced by several pixels causing wrapping of the menu section. 

To fix this, I removed extra padding created by the ul element automatically, which reduced the amount of space left for layout in the div. I also reduced the allotted space for a username by 10px. I've tested this change with extremely long and short names in Safari, Chrome, and Firefox to ensure our previous changes to align arrows and increase sizes were not effected. Everything checks out. 

Resolves:  https://trello.com/c/y9MIvhtH