### PR TITLE
Rename Notification; it seems React now has one

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -37,7 +37,7 @@ var usrMessages = require('./userMessages');
 var Navbar = require('./components/navbar');
 var LogoutOverlay = require('./components/logoutoverlay');
 var BrowserWarningOverlay = require('./components/browserwarningoverlay');
-var Notification = require('./components/notification');
+var TidepoolNotification = require('./components/notification');
 var TermsOverlay = require('./components/termsoverlay');
 var MailTo = require('./components/mailto');
 
@@ -318,11 +318,11 @@ var AppComponent = React.createClass({
 
       return (
         /* jshint ignore:start */
-        <Notification
+        <TidepoolNotification
           type={notification.type}
           onClose={handleClose}>
           {notification.body}
-        </Notification>
+        </TidepoolNotification>
         /* jshint ignore:end */
       );
     }

--- a/app/components/notification/notification.js
+++ b/app/components/notification/notification.js
@@ -16,7 +16,7 @@
 
 var React = require('react');
 
-var Notification = React.createClass({
+var TidepoolNotification = React.createClass({
   propTypes: {
     type: React.PropTypes.string,
     onClose: React.PropTypes.func
@@ -73,4 +73,4 @@ var Notification = React.createClass({
   }
 });
 
-module.exports = Notification;
+module.exports = TidepoolNotification;


### PR DESCRIPTION
Sarah's jshint mysteriously broke -- it seems React has now added an object called Notification, which conflicts with ours. So I've renamed it TidepoolNotification.

I didn't see this problem until I deleted my node_modules and reinstalled them. Then jshint started failing. 