### PR TITLE
Sk/trends iterations

### DIFF
--- a/app/components/chart/footer.js
+++ b/app/components/chart/footer.js
@@ -46,8 +46,7 @@ var TidelineFooter = React.createClass({
       <label htmlFor="valuesCheckbox">
         <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox"
           checked={this.props.showingValues}
-          onChange={this.props.onClickValues}
-          onKeyDown={this.handleValuesKeyDown} /> Values
+          onChange={this.props.onClickValues} /> Values
       </label>
       );
     /* jshint ignore:end */
@@ -58,22 +57,19 @@ var TidelineFooter = React.createClass({
         <label htmlFor="linesCheckbox">
           <input type="checkbox" name="linesCheckbox" id="linesCheckbox"
             checked={this.props.showingLines}
-            onChange={this.props.onClickLines}
-            onKeyDown={this.handleLinesKeyDown} /> Lines
+            onChange={this.props.onClickLines} /> Lines
         </label>
 
         <label htmlFor="groupCheckbox">
           <input type="checkbox" name="groupCheckbox" id="groupCheckbox"
             checked={this.props.grouped}
-            onChange={this.props.onClickGroup}
-            onKeyDown={this.handleGroupKeyDown} /> Group
+            onChange={this.props.onClickGroup} /> Group
         </label>
 
         <label htmlFor="overlayCheckbox">
           <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox"
             checked={this.props.boxOverlay}
-            onChange={this.props.onClickBoxOverlay}
-            onKeyDown={this.handleOverlayKeyDown} /> Range &amp; Average
+            onChange={this.props.onClickBoxOverlay} /> Range &amp; Average
         </label>
       </div>
       );
@@ -100,20 +96,6 @@ var TidelineFooter = React.createClass({
       </div>
       );
     /* jshint ignore:end */
-  },
-
-  // The following handlers let the user select a checkbox by hitting enter
-  handleValuesKeyDown: function() {
-    return event.keyCode !== 13 || this.props.onClickValues();
-  },
-  handleLinesKeyDown: function() {
-    return event.keyCode !== 13 || this.props.onClickLines();
-  },
-  handleGroupKeyDown: function() {
-    return event.keyCode !== 13 || this.props.onClickGroup();
-  },
-  handleOverlayKeyDown: function() {
-    return event.keyCode !== 13 || this.props.onClickBoxOverlay();
   }
 });
 

--- a/app/components/chart/footer.js
+++ b/app/components/chart/footer.js
@@ -43,21 +43,23 @@ var TidelineFooter = React.createClass({
 
     /* jshint ignore:start */
     var showValues = (
-      <label htmlFor="valuesCheckbox">
-        <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox"
-          checked={this.props.showingValues}
-          onChange={this.props.onClickValues} /> Values
-      </label>
+      <div className="footer-right-options">
+        <label htmlFor="valuesCheckbox">
+          <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox"
+            checked={this.props.showingValues}
+            onChange={this.props.onClickValues} /> Values
+        </label>
+      </div>
       );
     /* jshint ignore:end */
 
     /* jshint ignore:start */
     var modalOpts = (
-      <div>
-        <label htmlFor="linesCheckbox">
-          <input type="checkbox" name="linesCheckbox" id="linesCheckbox"
-            checked={this.props.showingLines}
-            onChange={this.props.onClickLines} /> Lines
+      <div className="footer-right-options">
+        <label htmlFor="overlayCheckbox">
+          <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox"
+            checked={this.props.boxOverlay}
+            onChange={this.props.onClickBoxOverlay} /> Range &amp; Average
         </label>
 
         <label htmlFor="groupCheckbox">
@@ -66,10 +68,10 @@ var TidelineFooter = React.createClass({
             onChange={this.props.onClickGroup} /> Group
         </label>
 
-        <label htmlFor="overlayCheckbox">
-          <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox"
-            checked={this.props.boxOverlay}
-            onChange={this.props.onClickBoxOverlay} /> Range &amp; Average
+        <label htmlFor="linesCheckbox">
+          <input type="checkbox" name="linesCheckbox" id="linesCheckbox"
+            checked={this.props.showingLines}
+            onChange={this.props.onClickLines} /> Lines
         </label>
       </div>
       );
@@ -84,14 +86,12 @@ var TidelineFooter = React.createClass({
     return (
       <div className="container-box-outer patient-data-footer-outer">
         <div className="container-box-inner patient-data-footer-inner">
-          <div className="grid patient-data-footer">
-            <div className="grid-item one-whole medium-one-half patient-data-footer-left">
-              <button className="btn btn-chart"
-                onClick={this.props.onClickRefresh}>
-                Refresh</button>
-            </div>
-            <div className="grid-item one-whole medium-one-half patient-data-footer-right">{rightSide}</div>
+          <div className="patient-data-footer-left">
+            <button className="btn btn-chart"
+              onClick={this.props.onClickRefresh}>
+              Refresh</button>
           </div>
+          <div className="patient-data-footer-right">{rightSide}</div>
         </div>
       </div>
       );

--- a/app/components/chart/footer.js
+++ b/app/components/chart/footer.js
@@ -41,82 +41,49 @@ var TidelineFooter = React.createClass({
       'patient-data-subnav-hidden': this.props.chartType === 'no-data'
     });
 
-    function getValuesLinkText(props) {
-      if (props.chartType === 'weekly') {
-        if (props.showingValues) {
-          return 'Hide numbers';
-        }
-        else {
-          return 'Show numbers';
-        }
-      }
-      else {
-        return '';
-      }
+    function getValuesCheckboxValue(props) {
+      return props.showingValues;
     }
 
-    function getLinesLinkText(props) {
-      if (props.chartType === 'modal') {
-        if (props.showingLines) {
-          return 'Hide lines';
-        }
-        else {
-          return 'Show lines';
-        }
-      }
-      else {
-        return '';
-      }
+    function getLinesCheckboxValue(props) {
+      return props.showingLines;
     }
 
-    function getGroupLinkText(props) {
-      if (props.chartType === 'modal') {
-        if (props.grouped) {
-          return 'Ungroup';
-        }
-        else {
-          return 'Group';
-        }
-      }
-      else {
-        return '';
-      }
+    function getGroupCheckboxValue(props) {
+      return props.grouped;
     }
 
-    function getOverlayLinkText(props) {
-      if (props.chartType === 'modal') {
-        if (props.boxOverlay) {
-          return 'Hide range & average';
-        }
-        else {
-          return 'Show range & average';
-        }
-      }
-      else {
-        return '';
-      }
+    function getOverlayCheckboxValue(props) {
+      return props.boxOverlay;
     }
 
-    var valuesLinkText = getValuesLinkText(this.props);
-
-    var linesLinkText = getLinesLinkText(this.props);
-
-    var groupLinkText = getGroupLinkText(this.props);
-
-    var overlayLinkText = getOverlayLinkText(this.props);
+    var valuesCheck = getValuesCheckboxValue(this.props);
+    var linesCheck = getLinesCheckboxValue(this.props);
+    var groupCheck = getGroupCheckboxValue(this.props);
+    var overlayCheck = getOverlayCheckboxValue(this.props);
 
     /* jshint ignore:start */
     var showValues = (
-      <a href="" onClick={this.props.onClickValues}>{valuesLinkText}</a>
+      <label htmlFor="valuesCheckbox" ref="label">
+        <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox" checked={valuesCheck} onChange={this.props.onClickValues} ref="control" /> Values
+      </label>
       );
     /* jshint ignore:end */
 
     /* jshint ignore:start */
     var modalOpts = (
       <div>
-        <a href="" onClick={this.props.onClickLines}>{linesLinkText}</a>
-        <a href="" onClick={this.props.onClickGroup}>{groupLinkText}</a>
-        <a href="" onClick={this.props.onClickBoxOverlay}>{overlayLinkText}</a>
+        <label htmlFor="linesCheckbox" ref="label">
+          <input type="checkbox" name="linesCheckbox" id="linesCheckbox" checked={linesCheck} onChange={this.props.onClickLines} ref="control" /> Lines
+        </label>
+
+        <label htmlFor="groupCheckbox" ref="label">
+          <input type="checkbox" name="groupCheckbox" id="groupCheckbox" checked={groupCheck} onChange={this.props.onClickGroup} ref="control" /> Group
+        </label>
+
+        <label htmlFor="overlayCheckbox" ref="label">
+          <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox" checked={overlayCheck} onChange={this.props.onClickBoxOverlay} ref="control" /> Range &amp; Average
+        </label>
       </div>
       );
     /* jshint ignore:end */

--- a/app/components/chart/footer.js
+++ b/app/components/chart/footer.js
@@ -43,11 +43,11 @@ var TidelineFooter = React.createClass({
 
     /* jshint ignore:start */
     var showValues = (
-      <label htmlFor="valuesCheckbox" ref="label">
+      <label htmlFor="valuesCheckbox">
         <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox"
           checked={this.props.showingValues}
           onChange={this.props.onClickValues}
-          ref="control" /> Values
+          onKeyDown={this.handleValuesKeyDown} /> Values
       </label>
       );
     /* jshint ignore:end */
@@ -55,25 +55,25 @@ var TidelineFooter = React.createClass({
     /* jshint ignore:start */
     var modalOpts = (
       <div>
-        <label htmlFor="linesCheckbox" ref="label">
+        <label htmlFor="linesCheckbox">
           <input type="checkbox" name="linesCheckbox" id="linesCheckbox"
             checked={this.props.showingLines}
             onChange={this.props.onClickLines}
-            ref="control" /> Lines
+            onKeyDown={this.handleLinesKeyDown} /> Lines
         </label>
 
-        <label htmlFor="groupCheckbox" ref="label">
+        <label htmlFor="groupCheckbox">
           <input type="checkbox" name="groupCheckbox" id="groupCheckbox"
             checked={this.props.grouped}
             onChange={this.props.onClickGroup}
-            ref="control" /> Group
+            onKeyDown={this.handleGroupKeyDown} /> Group
         </label>
 
-        <label htmlFor="overlayCheckbox" ref="label">
+        <label htmlFor="overlayCheckbox">
           <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox"
             checked={this.props.boxOverlay}
             onChange={this.props.onClickBoxOverlay}
-            ref="control" /> Range &amp; Average
+            onKeyDown={this.handleOverlayKeyDown} /> Range &amp; Average
         </label>
       </div>
       );
@@ -100,6 +100,20 @@ var TidelineFooter = React.createClass({
       </div>
       );
     /* jshint ignore:end */
+  },
+
+  // The following handlers let the user select a checkbox by hitting enter
+  handleValuesKeyDown: function() {
+    return event.keyCode !== 13 || this.props.onClickValues();
+  },
+  handleLinesKeyDown: function() {
+    return event.keyCode !== 13 || this.props.onClickLines();
+  },
+  handleGroupKeyDown: function() {
+    return event.keyCode !== 13 || this.props.onClickGroup();
+  },
+  handleOverlayKeyDown: function() {
+    return event.keyCode !== 13 || this.props.onClickBoxOverlay();
   }
 });
 

--- a/app/components/chart/footer.js
+++ b/app/components/chart/footer.js
@@ -41,31 +41,13 @@ var TidelineFooter = React.createClass({
       'patient-data-subnav-hidden': this.props.chartType === 'no-data'
     });
 
-    function getValuesCheckboxValue(props) {
-      return props.showingValues;
-    }
-
-    function getLinesCheckboxValue(props) {
-      return props.showingLines;
-    }
-
-    function getGroupCheckboxValue(props) {
-      return props.grouped;
-    }
-
-    function getOverlayCheckboxValue(props) {
-      return props.boxOverlay;
-    }
-
-    var valuesCheck = getValuesCheckboxValue(this.props);
-    var linesCheck = getLinesCheckboxValue(this.props);
-    var groupCheck = getGroupCheckboxValue(this.props);
-    var overlayCheck = getOverlayCheckboxValue(this.props);
-
     /* jshint ignore:start */
     var showValues = (
       <label htmlFor="valuesCheckbox" ref="label">
-        <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox" checked={valuesCheck} onChange={this.props.onClickValues} ref="control" /> Values
+        <input type="checkbox" name="valuesCheckbox" id="valuesCheckbox"
+          checked={this.props.showingValues}
+          onChange={this.props.onClickValues}
+          ref="control" /> Values
       </label>
       );
     /* jshint ignore:end */
@@ -74,15 +56,24 @@ var TidelineFooter = React.createClass({
     var modalOpts = (
       <div>
         <label htmlFor="linesCheckbox" ref="label">
-          <input type="checkbox" name="linesCheckbox" id="linesCheckbox" checked={linesCheck} onChange={this.props.onClickLines} ref="control" /> Lines
+          <input type="checkbox" name="linesCheckbox" id="linesCheckbox"
+            checked={this.props.showingLines}
+            onChange={this.props.onClickLines}
+            ref="control" /> Lines
         </label>
 
         <label htmlFor="groupCheckbox" ref="label">
-          <input type="checkbox" name="groupCheckbox" id="groupCheckbox" checked={groupCheck} onChange={this.props.onClickGroup} ref="control" /> Group
+          <input type="checkbox" name="groupCheckbox" id="groupCheckbox"
+            checked={this.props.grouped}
+            onChange={this.props.onClickGroup}
+            ref="control" /> Group
         </label>
 
         <label htmlFor="overlayCheckbox" ref="label">
-          <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox" checked={overlayCheck} onChange={this.props.onClickBoxOverlay} ref="control" /> Range &amp; Average
+          <input type="checkbox" name="overlayCheckbox" id="overlayCheckbox"
+            checked={this.props.boxOverlay}
+            onChange={this.props.onClickBoxOverlay}
+            ref="control" /> Range &amp; Average
         </label>
       </div>
       );

--- a/app/components/chart/modal.js
+++ b/app/components/chart/modal.js
@@ -304,25 +304,16 @@ var Modal = React.createClass({
     };
   },
   toggleBoxOverlay: function(e) {
-    if (e) {
-      e.preventDefault();
-    }
     var prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.modal.boxOverlay = prefs.modal.boxOverlay ? false : true;
     this.props.updateChartPrefs(prefs);
   },
   toggleGroup: function(e) {
-    if (e) {
-      e.preventDefault();
-    }
     var prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.modal.grouped = prefs.modal.grouped ? false : true;
     this.props.updateChartPrefs(prefs);
   },
   toggleLines: function(e) {
-    if (e) {
-      e.preventDefault();
-    }
     var prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.modal.showingLines = prefs.modal.showingLines ? false : true;
     this.props.updateChartPrefs(prefs);

--- a/app/components/chart/modalsubnav.js
+++ b/app/components/chart/modalsubnav.js
@@ -38,6 +38,7 @@ var DaysGroup = React.createClass({
       <div>
         <input type="checkbox" className={groupClass}
         onChange={this.handleDaysGroupClick}
+        onKeyDown={this.handleDaysGroupKeyDown}
         checked={this.props.active} />
         {this.props.days}
       </div>
@@ -46,6 +47,9 @@ var DaysGroup = React.createClass({
   },
   handleDaysGroupClick: function() {
     this.props.onClickGroup(this.props.category);
+  },
+  handleDaysGroupKeyDown: function() {
+    return event.keyCode !== 13 || this.handleDaysGroupClick();
   }
 });
 
@@ -127,7 +131,8 @@ var ModalSubNav = React.createClass({
     });
     /* jshint ignore:start */
     return (
-      <button className={domainLinkClass} onClick={this.props.domainClickHandlers[domain]}>{domain}</button>
+      <button className={domainLinkClass} key={domain}
+        onClick={this.props.domainClickHandlers[domain]}>{domain}</button>
       );
     /* jshint ignore:end */
   },

--- a/app/components/chart/modalsubnav.js
+++ b/app/components/chart/modalsubnav.js
@@ -35,7 +35,12 @@ var DaysGroup = React.createClass({
     }) + ' ' + this.props.category;
     /* jshint ignore:start */
     return (
-      <div className={groupClass} onClick={this.handleDaysGroupClick}>{this.props.days}</div>
+      <div>
+        <input type="checkbox" className={groupClass}
+        onChange={this.handleDaysGroupClick}
+        checked={this.props.active} />
+        {this.props.days}
+      </div>
       );
     /* jshint ignore:end */
   },
@@ -109,7 +114,7 @@ var ModalSubNav = React.createClass({
     /* jshint ignore:start */
     return (
       <div>
-        <div>{domainLinks}</div>
+        <div className="domainContainer">{domainLinks}</div>
         <div className="visibleDays">{visibleDaysText}</div>
       </div>
       );
@@ -134,7 +139,7 @@ var ModalSubNav = React.createClass({
     }
     /* jshint ignore:start */
     return (
-      <div className="dayGroupsContainer">
+      <div className="daysGroupContainer">
         <DaysGroup
           active={this.state.weekdaysActive}
           category={'weekday'}

--- a/app/components/chart/modalsubnav.js
+++ b/app/components/chart/modalsubnav.js
@@ -38,7 +38,6 @@ var DaysGroup = React.createClass({
       <div>
         <input type="checkbox" className={groupClass}
         onChange={this.handleDaysGroupClick}
-        onKeyDown={this.handleDaysGroupKeyDown}
         checked={this.props.active} />
         {this.props.days}
       </div>
@@ -47,9 +46,6 @@ var DaysGroup = React.createClass({
   },
   handleDaysGroupClick: function() {
     this.props.onClickGroup(this.props.category);
-  },
-  handleDaysGroupKeyDown: function() {
-    return event.keyCode !== 13 || this.handleDaysGroupClick();
   }
 });
 

--- a/app/components/chart/modalsubnav.js
+++ b/app/components/chart/modalsubnav.js
@@ -117,12 +117,12 @@ var ModalSubNav = React.createClass({
   },
   renderDomainLink: function(domain) {
     var domainLinkClass = cx({
-      'active': domain === this.props.activeDomain,
-      'modalDomain': true
+      'btn btn-chart-control' : true,
+      'active': domain === this.props.activeDomain
     });
     /* jshint ignore:start */
     return (
-      <a href="" className={domainLinkClass} key={domain} onClick={this.props.domainClickHandlers[domain]}>{domain}</a>
+      <button className={domainLinkClass} onClick={this.props.domainClickHandlers[domain]}>{domain}</button>
       );
     /* jshint ignore:end */
   },

--- a/app/components/chart/modalsubnav.js
+++ b/app/components/chart/modalsubnav.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -109,8 +109,8 @@ var ModalSubNav = React.createClass({
     /* jshint ignore:start */
     return (
       <div>
-        <div className="visibleDays">{visibleDaysText}</div>
         <div>{domainLinks}</div>
+        <div className="visibleDays">{visibleDaysText}</div>
       </div>
       );
     /* jshint ignore:end */

--- a/app/components/chart/modalsubnav.less
+++ b/app/components/chart/modalsubnav.less
@@ -66,7 +66,7 @@
   a.dayFilter {
     cursor: pointer;
     display: inline-block;
-    line-height: 30px;
+    line-height: (1.5 * @spacing-base) - 4;
     width: 30px;
     margin: 0 3px;
 

--- a/app/components/chart/modalsubnav.less
+++ b/app/components/chart/modalsubnav.less
@@ -25,7 +25,7 @@
     justify-content: space-between;
 
     width: 910px;
-    
+
     margin: 0px 20px 0px 50px;
     padding-top: 10px;
     padding-bottom: 10px;
@@ -40,16 +40,6 @@
     color: @gray-darkest;
     margin: 0 auto;
     text-align: center;
-  }
-
-  a.modalDomain {
-    color: @gray-darkest;
-    line-height: 30px;
-    margin: 0 8px;
-    &.active {
-      font-weight: bold;
-      text-decoration: underline;
-    }
   }
 
   .dayGroupsContainer {

--- a/app/components/chart/modalsubnav.less
+++ b/app/components/chart/modalsubnav.less
@@ -20,6 +20,7 @@
   margin: 0 auto;
 
   background-color: white;
+
   .modalSubNavContainer {
     display: flex;
     justify-content: space-between;
@@ -32,7 +33,12 @@
 
     .flexed {
       flex-grow: 2;
+      max-height: 50px;
     }
+  }
+
+  .domainContainer {
+    margin-top: @spacing-base;
   }
 
   .visibleDays {
@@ -40,66 +46,60 @@
     color: @gray-darkest;
     margin: 0 auto;
     text-align: center;
+    padding-top: @spacing-tiny;
   }
 
-  .dayGroupsContainer {
+
+  .daysGroupContainer {
     display: flex;
     justify-content: space-between;
+
+    margin-top: @spacing-base;
   }
 
   .daysGroup {
-    border-radius: 5px;
-    border: @gray 1px solid;
-    cursor: pointer;
-
-    padding: 3px;
-    margin: 3px;
-    &.active {
-      background-color: @gray;
-      opacity: 0.8;
-    }
-    &.weekday {
-      padding-left: 13px;
-    }
-    &.weekend {
-      padding-right: 13px;
-    }
+    margin-left: @spacing-tiny;
+    margin-right: 2px;
+    vertical-align: bottom;
   }
 
   a.dayFilter {
+    cursor: pointer;
     display: inline-block;
     line-height: 30px;
     width: 30px;
     margin: 0 3px;
 
-    background-color: white;
-    border-radius: 5px;
-    border: @gray-dark 1px solid;
-    color: @purple-highcontrast;
     text-align: center;
+
+    &.monday,
+    &.tuesday,
+    &.wednesday,
+    &.thursday,
+    &.friday {
+      background-color: fade(@weekday, 25%);
+    }
+    &.saturday,
+    &.sunday {
+      background-color: fade(@weekend, 25%);
+    }
+
+    color: fade(@purple-highcontrast, 50%);
+
     &.active {
+      color: @purple-highcontrast;
       font-weight: bold;
       opacity: 1.0;
     }
 
-    &.monday.active {
-      background-color: @weekday;
-    }
-    &.tuesday.active {
-      background-color: @weekday;
-    }
-    &.wednesday.active {
-      background-color: @weekday;
-    }
-    &.thursday.active {
-      background-color: @weekday;
-    }
+    &.monday.active,
+    &.tuesday.active,
+    &.wednesday.active,
+    &.thursday.active,
     &.friday.active {
       background-color: @weekday;
     }
-    &.saturday.active {
-      background-color: @weekend;
-    }
+    &.saturday.active,
     &.sunday.active {
       background-color: @weekend;
     }

--- a/app/components/chart/weekly.js
+++ b/app/components/chart/weekly.js
@@ -240,9 +240,6 @@ var Weekly = React.createClass({
     this.props.onSwitchToDaily(datetime);
   },
   toggleValues: function(e) {
-    if (e) {
-      e.preventDefault();
-    }
     if (this.state.showingValues) {
       this.refs.chart.hideValues();
     }

--- a/app/core/less/buttons.less
+++ b/app/core/less/buttons.less
@@ -126,7 +126,7 @@ a.btn-chart-control {
   background-color: @light-blue;
   color: @gray-blue;
   border: none;
-  margin: @spacing-tiny;
+  margin: 0 @spacing-tiny;
 
   &:hover,
   &:focus,

--- a/app/core/less/buttons.less
+++ b/app/core/less/buttons.less
@@ -108,14 +108,34 @@ a.btn-tertiary {
 .btn-chart,
 a.btn-chart {
   font-weight: normal;
-  background-color: @light-blue;
+  background-color: #fff;
   border-color: fade(@gray-blue, 15%);
   color: @gray-blue;
 
   &:hover,
   &:focus,
   &:active {
-    background-color: lighten(@light-blue, 20%);
+    background-color: fade(@blue-green-light, 50%);
     border-color: fade(@gray-blue, 25%);
+  }
+}
+
+.btn-chart-control,
+a.btn-chart-control {
+  font-weight: normal;
+  background-color: @light-blue;
+  color: @gray-blue;
+  border: none;
+  margin: @spacing-tiny;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: fade(@blue-green-light, 50%);
+  }
+
+  &.active {
+    background-color: @gray-dark;
+    color: #fff;
   }
 }

--- a/app/core/less/forms.less
+++ b/app/core/less/forms.less
@@ -88,6 +88,11 @@ select.form-control {
   -webkit-appearance: menulist;
 }
 
+// Increased accessibility of checkboxes by emphasizing actionable items
+input[type="checkbox"] {
+  cursor: pointer;
+}
+
 // Form groups
 // ====================================
 // Designed to help with the organization and spacing of vertical forms.

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -219,7 +219,7 @@
 
   label {
     float: right;
-    padding: 15px 12px 0 0;
+    padding: 15px 12px 0 10px;
     cursor: pointer;
   }
 }

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -185,6 +185,7 @@
 .patient-data-footer-inner {
   padding-left: 0;
   padding-right: 0;
+  display: flex;
 
   min-height: (2*@spacing-small + @line-height-base);
 }
@@ -216,9 +217,14 @@
 
 .patient-data-footer-right {
   text-align: right;
+  flex-grow: 2;
+}
+
+.footer-right-options {
+  display: flex;
+  justify-content: flex-end;
 
   label {
-    float: right;
     padding: 15px 12px 0 10px;
     cursor: pointer;
   }

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -216,6 +216,12 @@
 
 .patient-data-footer-right {
   text-align: right;
+
+  label {
+    float: right;
+    padding: 15px 12px 0 0;
+    cursor: pointer;
+  }
 }
 
 @media print {


### PR DESCRIPTION
@jebeck 

This PR makes a number of updates to the patient data trends view. 

* Add checkboxes to the all week/all weekend selectors. 
* Adds checkboxes (instead of text links) to range and avg, group, and line selectors. 
* Add a checkbox (instead of text link) to the values selector on the weekly view of patient data. 
* Moves the "days in view" text below week selectors. 
* Uses button (instead of text links) for the 1 week, 2 week, 4 week selectors. 

The changes match the latest design revisions posted on Pixelapse, with one slight change. I put the checkboxes for the weekday/weekend selectors to the left of the data they affect (instead of having the weekday selector to the left and the weekend selector to the right). I think this approach is clearer. Let me know what you think. A screenshot of the changes is included below: 

![trends-iteration](https://cloud.githubusercontent.com/assets/1380417/5889628/150c6964-a3ff-11e4-8a8b-7cd0ec36c0f7.png)

This resolves the tasks from the card I have a good handle on from: https://trello.com/c/lOa72Cqa

Note: There are two outstanding tasks for which I need more clarification before I could approach: 
1. Tooltip for "Range and Average" (styling leveraging range box). <-- I'm not sure what this task means. 
2. Alternate time navigation / data paging. (I don't know what the design is for the alternate paging). 

I felt enough changes had been made to the charts that a pull request for the completed tasks was worth it. 

Tested on: Chrome, Firefox, Safari