### PR TITLE
Adds ability to route an external request to different app location based on whether the user is logged in or out.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -76,6 +76,7 @@ var app = {
   router: router
 };
 
+// List of routes and associated handlers which display/render the routes
 var routes = {
   '/': 'redirectToDefaultRoute',
   '/login': 'showLogin',
@@ -87,14 +88,22 @@ var routes = {
   '/patients/:id/share': 'showPatientShare',
   '/patients/:id/data': 'showPatientData',
   '/request-password-reset': 'showRequestPasswordReset',
-  '/confirm-password-reset': 'showConfirmPasswordReset'
+  '/confirm-password-reset': 'showConfirmPasswordReset',
+  '/request-password-from-uploader': 'handleExternalPasswordUpdate'
 };
 
+// List of routes that are accessible to logged-out users
 var noAuthRoutes = [
   '/login',
   '/signup',
   '/request-password-reset',
   '/confirm-password-reset'
+];
+
+// List of routes that are requested from other apps
+// (like the Chrome Uploader, for example)
+var externalAppRoutes = [
+  '/request-password-from-uploader'
 ];
 
 var defaultNotAuthenticatedRoute = '/login';
@@ -202,6 +211,7 @@ var AppComponent = React.createClass({
     app.router.setup(routingTable, {
       isAuthenticated: isAuthenticated,
       noAuthRoutes: noAuthRoutes,
+      externalAppRoutes: externalAppRoutes,
       defaultNotAuthenticatedRoute: defaultNotAuthenticatedRoute,
       defaultAuthenticatedRoute: defaultAuthenticatedRoute,
       onRouteChange: onRouteChange
@@ -1345,6 +1355,18 @@ var AppComponent = React.createClass({
   getPasswordResetKey: function() {
     var hashQueryParams = app.router.getQueryParams();
     return hashQueryParams.resetKey;
+  },
+
+  handleExternalPasswordUpdate: function() {
+    // If the user is logged in, go to their profile to update password
+    if (this.state.authenticated) {
+      this.renderPage = this.renderProfile;
+      this.setState({page: 'profile'});
+    } else {
+      // If the user is not logged in, go to the forgot password page
+      this.renderPage = this.renderRequestPasswordReset;
+      this.setState({page: 'request-password-reset'});
+    }
   },
 
   hideNavbarDropdown: function() {

--- a/app/router.js
+++ b/app/router.js
@@ -32,6 +32,16 @@ var configuration = {
     routeBase = routeBase.replace(/(\?.*)/, '');
     var isNoAuthRoute = _.contains(router.noAuthRoutes, routeBase);
 
+    // Check to see if the route is an external request
+    var isExternalAppRoute = _.contains(router.externalAppRoutes, routeBase);
+
+    if (isExternalAppRoute) {
+      router.log('External app request');
+      redirectRoute = routeBase;
+      router.setRoute(redirectRoute);
+      return true;
+    }
+
     if (!isAuthenticated && !isNoAuthRoute) {
       router.log('Not logged in, redirecting');
       redirectRoute = router.defaultNotAuthenticatedRoute;
@@ -65,7 +75,10 @@ router.setup = function(routes, options) {
                          function() { return true; };
 
   this.noAuthRoutes = options.noAuthRoutes || [];
-  this.noAuthRoutes = this._parseNoAuthRoutes(this.noAuthRoutes);
+  this.noAuthRoutes = this._parseRouteLists(this.noAuthRoutes);
+
+  this.externalAppRoutes = options.externalAppRoutes || [];
+  this.externalAppRoutes = this._parseRouteLists(this.externalAppRoutes);
 
   this.defaultNotAuthenticatedRoute =
     options.defaultNotAuthenticatedRoute || '/';
@@ -94,7 +107,7 @@ router.getQueryParams = function() {
   return {};
 };
 
-router._parseNoAuthRoutes = function(routes) {
+router._parseRouteLists = function(routes) {
   return _.map(routes, this._getRouteFirstFragment);
 };
 


### PR DESCRIPTION
@jh-bate @kentquirk 

This PR is the first of a two parter to fix a bug that occurs when a user clicks the "reset password" link from the Chrome Uploader. Today, when a user clicks that 'reset password' link, they are taken from the uploader to Blip and if they're logged in, you are redirected to the /patients by default. 

To resolve this bug and make future external requests a bit easier to manage, I made some changes that allow us to support URLs that will route to different locations based on whether a user is logged in or out. 

For the Chrome Uploader, reset password link bug, the solution will be to change the reset password link to a new URL (request-password-from-uploader) rather than the default 'request-password-reset'. When the user clicks that link in the Uploader, if they are logged in to Blip, they will be sent to their Profile page where they can update their password. If the user is not logged into Blip, they will be sent to the Request Password Reset page. 

To test, change your path to something like localhost:3000/#/request-password-from-uploader from both logged in and out scenarios. 

Resolves the first task in: https://trello.com/c/ilkdLJKh
Once this PR is approved and all clear, I'll make the corresponding link change in the Uploader.