### PR TITLE
lodash _.first doesn't return an array

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1496,7 +1496,7 @@ app.start = function() {
   var self = this;
 
   this.init(function() {
-    self.component = React.renderComponent(
+    self.component = React.render(
       /* jshint ignore:start */
       <AppComponent />,
       /* jshint ignore:end */

--- a/app/components/messages/__tests__/messages-test.js
+++ b/app/components/messages/__tests__/messages-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2015, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ */
+
+/*global describe, it, jest, expect */
+
+jest.dontMock('../messages');
+jest.dontMock('lodash');
+
+var _ = require('lodash');
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+var mockData = require('blip-mock-data');
+
+var Messages = require('../messages');
+
+var parentMessage = _.findWhere(mockData.messagenotes['11'], {id: '1141'});
+var mockMessages = mockData.messagethread['1141'].concat([parentMessage]);
+
+describe('Messages', function() {
+	it('sets messages to undefined if none provided in props', function() {
+		var renderedMessages = TestUtils.renderIntoDocument(
+			<Messages />
+		);
+		expect(renderedMessages.state).toEqual({messages: undefined});
+	});
+	it('receives messages from the server via props and puts them in state', function() {
+		var renderedMessages = TestUtils.renderIntoDocument(
+			<Messages user={mockData.users['11']} messages={mockMessages} />
+		);
+		expect(Array.isArray(renderedMessages.state.messages)).toBe(true);
+		expect(renderedMessages.state.messages.length).toEqual(mockMessages.length);
+	});
+	it('finds the correct parent for threaded comment', function() {
+		var renderedMessages = TestUtils.renderIntoDocument(
+			<Messages user={mockData.users['11']} messages={mockMessages} />
+		);
+		expect(renderedMessages.getParent()).toEqual(parentMessage);
+	});
+});

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -27,8 +27,10 @@ var sundial = require('sundial');
 
 var MessageForm = require('./messageform');
 
-var profileLargeSrc = require('./images/profile-100x100.png');
-var profileSmallSrc = require('./images/profile-64x64.png');
+if (!window.process) {
+  var profileLargeSrc = require('./images/profile-100x100.png');
+  var profileSmallSrc = require('./images/profile-64x64.png');
+}
 
 var Message = React.createClass({
 

--- a/app/components/messages/messages.js
+++ b/app/components/messages/messages.js
@@ -179,7 +179,7 @@ var Messages = React.createClass({
   },
   getParent : function(){
     if(this.isMessageThread()){
-      return _.first(this.state.messages, function(message){ return !(message.parentmessage); });
+      return _.find(this.state.messages, function(message){ return !(message.parentmessage); });
     }
     return;
   },

--- a/app/components/messages/messages.js
+++ b/app/components/messages/messages.js
@@ -179,7 +179,7 @@ var Messages = React.createClass({
   },
   getParent : function(){
     if(this.isMessageThread()){
-      return _.first(this.state.messages, function(message){ return !(message.parentmessage); })[0];
+      return _.first(this.state.messages, function(message){ return !(message.parentmessage); });
     }
     return;
   },

--- a/app/preprocessor.js
+++ b/app/preprocessor.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ */
+
+//This is used for our jest tests see https://facebook.github.io/jest/docs/tutorial-react.html
+var ReactTools = require('react-tools');
+module.exports = {
+  process: function(src) {
+    return ReactTools.transform(src);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "serve-static": "1.9.2",
     "shelljs": "0.4.0",
     "style-loader": "0.8.3",
-    "sundial": "1.1.7",
+    "sundial": "1.1.8",
     "tideline": "0.1.20",
     "tidepool-platform-client": "0.16.5",
     "url-loader": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.24",
   "private": true,
   "scripts": {
-    "test": "webpack-dev-server 'mocha!./test/entry.js' --output-file test.js --devtool eval-source-map --cache --colors --progress",
+    "test": "jest",
     "start": "webpack-dev-server --devtool eval-source-map --cache --colors --progress --port 3000",
     "build": "npm run build-app && npm run build-config",
     "build-app": "node buildapp",
@@ -46,15 +46,21 @@
     "gulp": "3.8.11",
     "gulp-jshint": "1.9.4",
     "gulp-react": "3.0.1",
+    "jest-cli": "0.4.0",
     "jshint-stylish": "1.0.1",
     "mocha": "2.2.1",
     "mocha-loader": "0.7.1",
     "moment": "2.9.0",
+    "react-tools": "0.13.2",
     "sinon": "1.14.1",
     "sinon-chai": "2.7.0",
     "webpack-dev-server": "1.7.0"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": "0.12.x"
+  },
+  "jest": {
+    "scriptPreprocessor": "app/preprocessor.js",
+    "unmockedModulePathPatterns": ["node_modules/react", "node_modules/blip-mock-data"]
   }
 }


### PR DESCRIPTION
I believe this addresses both bugs recently found on staging: https://trello.com/c/2I11ddBi and https://trello.com/c/0zfGV7oG.

The issue is that `_.first` does not return an array, and we were trying to extract from it at index 0. Possibly/probably(?) this is a change in lodash and came in with the dependency updates.

Ping @kentquirk 