### PR TITLE
make sure edited note text is rendered right away

### DIFF
--- a/app/components/messages/__tests__/message-test.js
+++ b/app/components/messages/__tests__/message-test.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ */
+
+/*global describe, it, jest, expect */
+
+jest.dontMock('../message');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var Message = require('../message');
+var onSaveMock = jest.genMockFunction();
+var note = { timestamp : new Date().toISOString() , messagetext : 'foo', user : {fullName:'Test User'} };
+
+describe('Message', function() {
+  it('updates the text when an edit is made', function() {
+    var renderedMessage = TestUtils.renderIntoDocument(
+      <Message theNote={note} onSaveEdit={onSaveMock} />
+    );
+
+    expect(renderedMessage.state.note).toBe('foo');
+    var updates = {timestamp : new Date().toISOString(), text : 'bar'};
+    renderedMessage.handleEditSave(updates);
+
+    expect(renderedMessage.state.note).toBe('bar');
+  });
+});

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -72,17 +72,20 @@ var Message = React.createClass({
 
     if(saveEdit){
       var newNote = _.cloneDeep(this.props.theNote);
-      newNote.messagetext = edits.text;
-      if (edits.timestamp) {
-        newNote.timestamp = edits.timestamp;
+      if (this.props.theNote.messagetext !== edits.text ||
+        (edits.timestamp && this.props.theNote.timestamp !== edits.timestamp)) {
+        newNote.messagetext = edits.text;
+        if (edits.timestamp) {
+          newNote.timestamp = edits.timestamp;
+        }
+        saveEdit(newNote);
       }
-      saveEdit(newNote);
 
       var offset = sundial.getOffsetFromTime(edits.timestamp || this.props.theNote.timestamp) || sundial.getOffset();
 
       this.setState({
         editing : false,
-        note : this.props.theNote.messagetext,
+        note : edits.text,
         when : sundial.formatFromOffset(edits.timestamp || this.props.theNote.timestamp, offset)
       });
     }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "scriptPreprocessor": "app/preprocessor.js",
     "unmockedModulePathPatterns": [
       "node_modules/react",
+      "node_modules/sundial",
+      "node_modules/moment",
+      "node_modules/lodash",
       "node_modules/blip-mock-data"
     ]
   }


### PR DESCRIPTION
Nick found another regression - edited note text wasn't displaying until after closing and reopening the note. `git blame` showed yours truly to blame for the regression :/

Ping @jh-bate for a quick review.

No regression test at the moment, could add one since I've already got started on Jest stuff for this component. LMK what you'd prefer @jh-bate.