### PR TITLE
default to the timezone from the most recent upload metadata for display

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1236,7 +1236,7 @@ var AppComponent = React.createClass({
       return Date.parse(d.time);
     }).reverse()[0];
     var timePrefsForTideline;
-    if (!_.isEmpty(mostRecentUpload.timezone)) {
+    if (!_.isEmpty(mostRecentUpload) && !_.isEmpty(mostRecentUpload.timezone)) {
       try {
         sundial.checkTimezoneName(mostRecentUpload.timezone);
         timePrefsForTideline = {

--- a/app/app.js
+++ b/app/app.js
@@ -1235,14 +1235,24 @@ var AppComponent = React.createClass({
     var mostRecentUpload = _.sortBy(_.where(data, {type: 'upload'}), function(d) {
       return Date.parse(d.time);
     }).reverse()[0];
-    var timePrefsForTideline = {
-      timezoneAware: true,
-      timezoneName: mostRecentUpload.timezone
-    };
+    var timePrefsForTideline;
+    if (!_.isEmpty(mostRecentUpload.timezone)) {
+      try {
+        sundial.checkTimezoneName(mostRecentUpload.timezone);
+        timePrefsForTideline = {
+          timezoneAware: true,
+          timezoneName: mostRecentUpload.timezone
+        };
+      }
+      catch(err) {
+        app.log(err);
+        app.log('Upload metadata lacking a valid timezone!', mostRecentUpload);
+      }
+    }
     var queryParams = this.state.queryParams;
     // if the user has put a timezone in the query params
     // it'll be stored already in the state, and we just keep using it
-    if (!_.isEmpty(queryParams.timezone)) {
+    if (!_.isEmpty(queryParams.timezone) || _.isEmpty(timePrefsForTideline)) {
       timePrefsForTideline = this.state.timePrefs;
     }
     // but otherwise we use the timezone from the most recent upload metadata obj

--- a/app/app.js
+++ b/app/app.js
@@ -145,8 +145,7 @@ var AppComponent = React.createClass({
     var queryParams = queryString.parseTypes(window.location.search);
     var timePrefs = {
       timezoneAware: false,
-      // TODO: remove hardcoding of this in future once we actually introduce arbitrary timezone support
-      timezoneName: 'US/Pacific'
+      timezoneName: null
     };
     if (!_.isEmpty(queryParams.timezone)) {
       var queryTimezone = queryParams.timezone.replace('-', '/');

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -33,6 +33,7 @@ var Daily = React.createClass({
   propTypes: {
     bgPrefs: React.PropTypes.object.isRequired,
     chartPrefs: React.PropTypes.object.isRequired,
+    timePrefs: React.PropTypes.object.isRequired,
     imagesBaseUrl: React.PropTypes.string.isRequired,
     initialDatetimeLocation: React.PropTypes.string,
     patientData: React.PropTypes.object.isRequired,
@@ -87,7 +88,7 @@ var Daily = React.createClass({
                 imagesBaseUrl={this.props.imagesBaseUrl}
                 initialDatetimeLocation={this.props.initialDatetimeLocation}
                 patientData={this.props.patientData}
-                timePrefs={this.props.chartPrefs.timePrefs}
+                timePrefs={this.props.timePrefs}
                 // message handlers
                 onCreateMessage={this.props.onCreateMessage}
                 onShowMessageThread={this.props.onShowMessageThread}
@@ -110,7 +111,7 @@ var Daily = React.createClass({
     /* jshint ignore:end */
   },
   getTitle: function(datetime) {
-    var timePrefs = this.props.chartPrefs.timePrefs, timezone;
+    var timePrefs = this.props.timePrefs, timezone;
     if (!timePrefs.timezoneAware) {
       timezone = 'UTC';
     }

--- a/app/components/chart/modal.js
+++ b/app/components/chart/modal.js
@@ -37,6 +37,7 @@ var Modal = React.createClass({
   propTypes: {
     bgPrefs: React.PropTypes.object.isRequired,
     chartPrefs: React.PropTypes.object.isRequired,
+    timePrefs: React.PropTypes.object.isRequired,
     initialDatetimeLocation: React.PropTypes.string,
     patientData: React.PropTypes.object.isRequired,
     // refresh handler
@@ -132,7 +133,7 @@ var Modal = React.createClass({
         boxOverlay={this.props.chartPrefs.modal.boxOverlay}
         grouped={this.props.chartPrefs.modal.grouped}
         showingLines={this.props.chartPrefs.modal.showingLines}
-        timePrefs={this.props.chartPrefs.timePrefs}
+        timePrefs={this.props.timePrefs}
         // handlers
         onDatetimeLocationChange={this.handleDatetimeLocationChange}
         onSelectDay={this.handleSelectDay}
@@ -179,7 +180,7 @@ var Modal = React.createClass({
     /* jshint ignore:end */
   },
   formatDate: function(datetime) {
-    var timePrefs = this.props.chartPrefs.timePrefs, timezone;
+    var timePrefs = this.props.timePrefs, timezone;
     if (!timePrefs.timezoneAware) {
       timezone = 'UTC';
     }
@@ -194,7 +195,7 @@ var Modal = React.createClass({
     return this.formatDate(datetimeLocationEndpoints[0]) + ' - ' + this.formatDate(end);
   },
   getNewDomain: function(current, extent) {
-    var timePrefs = this.props.chartPrefs.timePrefs, timezone;
+    var timePrefs = this.props.timePrefs, timezone;
     if (!timePrefs.timezoneAware) {
       timezone = 'UTC';
     }

--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -36,6 +36,7 @@ var Settings = React.createClass({
   propTypes: {
     bgPrefs: React.PropTypes.object.isRequired,
     chartPrefs: React.PropTypes.object.isRequired,
+    timePrefs: React.PropTypes.object.isRequired,
     patientData: React.PropTypes.object.isRequired,
     onClickRefresh: React.PropTypes.func.isRequired,
     onSwitchToDaily: React.PropTypes.func.isRequired,

--- a/app/components/chart/weekly.js
+++ b/app/components/chart/weekly.js
@@ -37,6 +37,7 @@ var Weekly = React.createClass({
   propTypes: {
     bgPrefs: React.PropTypes.object.isRequired,
     chartPrefs: React.PropTypes.object.isRequired,
+    timePrefs: React.PropTypes.object.isRequired,
     imagesBaseUrl: React.PropTypes.string.isRequired,
     initialDatetimeLocation: React.PropTypes.string.isRequired,
     patientData: React.PropTypes.object.isRequired,
@@ -87,7 +88,7 @@ var Weekly = React.createClass({
         bgUnits={this.props.bgPrefs.bgUnits}
         initialDatetimeLocation={this.props.initialDatetimeLocation}
         patientData={this.props.patientData}
-        timePrefs={this.props.chartPrefs.timePrefs}
+        timePrefs={this.props.timePrefs}
         // handlers
         onDatetimeLocationChange={this.handleDatetimeLocationChange}
         onMostRecent={this.handleMostRecent}
@@ -180,7 +181,7 @@ var Weekly = React.createClass({
     }
     var datetime;
     if (this.refs.chart) {
-      datetime = this.refs.chart.getCurrentDay(this.props.chartPrefs.timePrefs);
+      datetime = this.refs.chart.getCurrentDay(this.props.timePrefs);
     }
     this.props.onSwitchToModal(datetime);
   },
@@ -197,7 +198,7 @@ var Weekly = React.createClass({
     }
     var datetime;
     if (this.refs.chart) {
-      datetime = this.refs.chart.getCurrentDay(this.props.chartPrefs.timePrefs);
+      datetime = this.refs.chart.getCurrentDay(this.props.timePrefs);
     }
     this.props.onSwitchToDaily(datetime);
   },

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -72,8 +72,7 @@ var PatientData = React.createClass({
           boxOverlay: true,
           grouped: true,
           showingLines: false
-        },
-        timePrefs: this.props.timePrefs
+        }
       },
       chartType: 'modal',
       createMessage: null,
@@ -229,6 +228,7 @@ var PatientData = React.createClass({
           <Daily
             bgPrefs={this.props.bgPrefs}
             chartPrefs={this.state.chartPrefs}
+            timePrefs={this.props.timePrefs}
             imagesBaseUrl={config.IMAGES_ENDPOINT + '/tideline'}
             initialDatetimeLocation={this.state.initialDatetimeLocation}
             patientData={this.props.patientData}
@@ -250,6 +250,7 @@ var PatientData = React.createClass({
           <Modal
             bgPrefs={this.props.bgPrefs}
             chartPrefs={this.state.chartPrefs}
+            timePrefs={this.props.timePrefs}
             initialDatetimeLocation={this.state.initialDatetimeLocation}
             patientData={this.props.patientData}
             onClickRefresh={this.handleClickRefresh}
@@ -270,6 +271,7 @@ var PatientData = React.createClass({
           <Weekly
             bgPrefs={this.props.bgPrefs}
             chartPrefs={this.state.chartPrefs}
+            timePrefs={this.props.timePrefs}
             imagesBaseUrl={config.IMAGES_ENDPOINT + '/tideline'}
             initialDatetimeLocation={this.state.initialDatetimeLocation}
             patientData={this.props.patientData}
@@ -291,6 +293,7 @@ var PatientData = React.createClass({
           <Settings
             bgPrefs={this.props.bgPrefs}
             chartPrefs={this.state.chartPrefs}
+            timePrefs={this.props.timePrefs}
             patientData={this.props.patientData}
             onClickRefresh={this.handleClickRefresh}
             onSwitchToDaily={this.handleSwitchToDaily}


### PR DESCRIPTION
This isn't as sophisticated as I'd hoped. It's a chicken-and-egg problem to add the timezone to the data-viewing URL when we don't know what timezone to display in until *after* we've loaded the data and found the most recent metadata object with a timezone.

So:
- if a timezone is in the query params before the hash (e.g., `?timezone=US-Pacific#/`), that timezone takes precedence
- otherwise, blip defaults to the timezone from the most recent upload metadata for display, but this timezone will *not* be displayed in the URL (the only way to do that requires either a full page refresh and re-fetch of data (if in query params) or setting a new route and thus re-fetching data) :(

We could just take the setting of the timezone via query params away now, **but**:
- most people won't know it's there
- it's invaluable for testing - in particular misspelling a timezone in the query params will become our only way to turn *off* timezone-aware display if we need to