### PR TITLE
store patient data in hash under userid to prevent name + data mismatch

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -922,9 +922,11 @@ var AppComponent = React.createClass({
     );
     /* jshint ignore:end */
   },
-  handleUpdatePatientData: function(data) {
+  handleUpdatePatientData: function(userid, data) {
+    var patientData = _.cloneDeep(this.state.patientData);
+    patientData[userid] = data;
     this.setState({
-      patientData: data
+      patientData: patientData
     });
   },
   login: function(formValues, cb) {
@@ -1196,13 +1198,15 @@ var AppComponent = React.createClass({
         console.save(combinedData, 'blip-input.json');
       };
       patientData = self.processPatientData(combinedData);
+      var allPatientsData = _.cloneDeep(self.state.patientData) || {};
+      allPatientsData[patientId] = patientData;
 
       self.setState({
         bgPrefs: {
           bgClasses: patientData.bgClasses,
           bgUnits: patientData.bgUnits
         },
-        patientData: patientData,
+        patientData: allPatientsData,
         fetchingPatientData: false
       });
     });

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -206,12 +206,12 @@ var PatientData = React.createClass({
 
   isEmptyPatientData: function() {
     var patientDataLength =
-      utils.getIn(this.props.patientData, ['data', 'length'], 0);
+      utils.getIn(this.props.patientData[this.props.patient.userid], ['data', 'length'], 0);
     return !Boolean(patientDataLength);
   },
 
   isInsufficientPatientData: function() {
-    var data = this.props.patientData.data;
+    var data = this.props.patientData[this.props.patient.userid].data;
     // add additional checks against data and return false iff:
     // only messages data
     if (_.reject(data, function(d) { return d.type === 'message'; }).length === 0) {
@@ -231,7 +231,7 @@ var PatientData = React.createClass({
             chartPrefs={this.state.chartPrefs}
             imagesBaseUrl={config.IMAGES_ENDPOINT + '/tideline'}
             initialDatetimeLocation={this.state.initialDatetimeLocation}
-            patientData={this.props.patientData}
+            patientData={this.props.patientData[this.props.patient.userid]}
             onClickRefresh={this.handleClickRefresh}
             onCreateMessage={this.handleShowMessageCreation}
             onShowMessageThread={this.handleShowMessageThread}
@@ -251,7 +251,7 @@ var PatientData = React.createClass({
             bgPrefs={this.props.bgPrefs}
             chartPrefs={this.state.chartPrefs}
             initialDatetimeLocation={this.state.initialDatetimeLocation}
-            patientData={this.props.patientData}
+            patientData={this.props.patientData[this.props.patient.userid]}
             onClickRefresh={this.handleClickRefresh}
             onSwitchToDaily={this.handleSwitchToDaily}
             onSwitchToModal={this.handleSwitchToModal}
@@ -272,7 +272,7 @@ var PatientData = React.createClass({
             chartPrefs={this.state.chartPrefs}
             imagesBaseUrl={config.IMAGES_ENDPOINT + '/tideline'}
             initialDatetimeLocation={this.state.initialDatetimeLocation}
-            patientData={this.props.patientData}
+            patientData={this.props.patientData[this.props.patient.userid]}
             onClickRefresh={this.handleClickRefresh}
             onSwitchToDaily={this.handleSwitchToDaily}
             onSwitchToModal={this.handleSwitchToModal}
@@ -291,7 +291,7 @@ var PatientData = React.createClass({
           <Settings
             bgPrefs={this.props.bgPrefs}
             chartPrefs={this.state.chartPrefs}
-            patientData={this.props.patientData}
+            patientData={this.props.patientData[this.props.patient.userid]}
             onClickRefresh={this.handleClickRefresh}
             onSwitchToDaily={this.handleSwitchToDaily}
             onSwitchToModal={this.handleSwitchToModal}
@@ -346,7 +346,7 @@ var PatientData = React.createClass({
 
   handleMessageCreation: function(message){
     var data = this.refs.tideline.createMessageThread(nurseShark.reshapeMessage(message));
-    this.props.onUpdatePatientData(data);
+    this.props.onUpdatePatientData(this.props.patient.userid, data);
     this.props.trackMetric('Created New Message');
   },
 
@@ -364,7 +364,7 @@ var PatientData = React.createClass({
       edit(message, cb);
     }
     var data = this.refs.tideline.editMessageThread(nurseShark.reshapeMessage(message));
-    this.props.onUpdatePatientData(data);
+    this.props.onUpdatePatientData(this.props.patient.userid, data);
     this.props.trackMetric('Edit To Message');
   },
 


### PR DESCRIPTION
@jh-bate I believe this fixes the issue, and I hope I found all the uses of patient data so I'm not creating new bugs by changing what the prop looks like. I'd definitely appreciate another pair of eyes taking a close look to trace through uses of `patientData` as a prop to make sure nothing's been left out.

My plan is to try to get this fix in ASAP. On a separate branch I am pulling in @GordyD's work so far and there I will try to start working on (a) a regression test and (b) the clean up on `app/components/peoplelist.js` that we discussed (i.e., getting rid of the attempt to mutate props).

P.S. A side benefit of this change is it paves the way quite nicely for caching data that's already been fetched so we don't refetch every time you navigate between people :)