### PR TITLE
get rid of long browser hang

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -119,9 +119,9 @@ function objectDifference(destination, source) {
   var result = {};
 
   _.forEach(source, function(sourceValue, key) {
-    var destinactionValue = destination[key];
-    if (!_.isEqual(sourceValue, destinactionValue)) {
-      result[key] = destinactionValue;
+    var destinationValue = destination[key];
+    if (!_.isEqual(sourceValue, destinationValue)) {
+      result[key] = destinationValue;
     }
   });
 

--- a/app/app.js
+++ b/app/app.js
@@ -1198,7 +1198,11 @@ var AppComponent = React.createClass({
         console.save(combinedData, 'blip-input.json');
       };
       patientData = self.processPatientData(combinedData);
-      var allPatientsData = _.cloneDeep(self.state.patientData) || {};
+      // NOTE: intentional use of _.clone instead of _.cloneDeep
+      // we only need a shallow clone at the top level of the patientId keys
+      // and the _.cloneDeep I had originally would hang the browser for *seconds*
+      // when there was actually something in this.state.patientData
+      var allPatientsData = _.clone(self.state.patientData) || {};
       allPatientsData[patientId] = patientData;
 
       self.setState({


### PR DESCRIPTION
This fixes the issue I found on staging after deploying #230 yesterday. It turned out the `_.cloneDeep` I'd added was hanging the browser for *seconds* when there was actually something already in `this.state.patientData` (understandably, because it was deep-cloning all of the device data). The deep clone isn't actually necessary here, so I changed it to `_.clone`, and that works.

As a reminder, the issue on staging was this: log into an account, go to view data, navigate away (first data fetch still happening in background), navigate to view away (second data fetch starts), and then navigate away again, to the edit profile page. I noticed I couldn't keep editing my profile after a bit - app was frozen. In the console it was apparent this was happening after both the first and second data fetches (and tideline data preprocessing) concluded - turns out that's because it was stuck trying to deep clone all the device data before updating the app state. (It would finish eventually, so it turned out to not be a complete app freeze, just looked like it because it took *forever*.)

Ping @jh-bate for review.