### PR TITLE
eliminate React warnings re: api deprecation and increase test coverage

### DIFF
--- a/app/components/invitation/invitation.js
+++ b/app/components/invitation/invitation.js
@@ -22,7 +22,6 @@ var personUtils = require('../../core/personutils');
 var Invitation = React.createClass({
   propTypes: {
     invitation: React.PropTypes.object,
-    patientsComponent: React.PropTypes.component,
     onAcceptInvitation: React.PropTypes.func,
     onDismissInvitation: React.PropTypes.func,
     trackMetric: React.PropTypes.func.isRequired,

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -196,7 +196,7 @@ var Message = React.createClass({
       var image = this.renderImage();
       var title = this.renderTitle();
 
-      return this.transferPropsTo(
+      return (
         /* jshint ignore:start */
         <div>
           {image}

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -35,7 +35,7 @@ if (!window.process) {
 var Message = React.createClass({
 
   propTypes: {
-    theNote : React.PropTypes.object,
+    theNote : React.PropTypes.object.isRequired,
     imageSize: React.PropTypes.string,
     onSaveEdit : React.PropTypes.func
   },
@@ -46,13 +46,15 @@ var Message = React.createClass({
     };
   },
   componentDidMount: function () {
-    var offset = sundial.getOffsetFromTime(this.props.theNote.timestamp) || sundial.getOffset();
+    if (this.props.theNote) {
+      var offset = sundial.getOffsetFromTime(this.props.theNote.timestamp) || sundial.getOffset();
 
-    this.setState({
-      author :  this.getUserDisplayName(this.props.theNote.user),
-      note : this.props.theNote.messagetext,
-      when : sundial.formatFromOffset(this.props.theNote.timestamp, offset)
-    });
+      this.setState({
+        author : this.getUserDisplayName(this.props.theNote.user),
+        note : this.props.theNote.messagetext,
+        when : sundial.formatFromOffset(this.props.theNote.timestamp, offset)
+      });
+    }
   },
   getUserDisplayName: function(user) {
     var result = 'Anonymous user';

--- a/app/components/modaloverlay/modaloverlay.js
+++ b/app/components/modaloverlay/modaloverlay.js
@@ -20,7 +20,7 @@ var cx = require('react/lib/cx');
 var ModalOverlay = React.createClass({
   propTypes: {
     show: React.PropTypes.bool,
-    dialog: React.PropTypes.renderable,
+    dialog: React.PropTypes.node,
     overlayClickHandler: React.PropTypes.func
   },
   render: function() {

--- a/app/pages/patient/patient.js
+++ b/app/pages/patient/patient.js
@@ -161,15 +161,7 @@ var Patient = React.createClass({
 
   renderPatientTeam: function() {
     return (
-      <PatientTeam
-        user={this.props.user}
-        patient={this.props.patient}
-        pendingInvites={this.props.pendingInvites}
-        onChangeMemberPermissions={this.props.onChangeMemberPermissions}
-        onRemoveMember={this.props.onRemoveMember}
-        onInviteMember={this.props.onInviteMember}
-        onCancelInvite={this.props.onCancelInvite}
-        trackMetric={this.props.trackMetric}/>
+      <PatientTeam {...this.props} />
     );
   },
 });

--- a/app/pages/patient/patient.js
+++ b/app/pages/patient/patient.js
@@ -160,7 +160,17 @@ var Patient = React.createClass({
   },
 
   renderPatientTeam: function() {
-    return this.transferPropsTo(<PatientTeam />);
+    return (
+      <PatientTeam
+        user={this.props.user}
+        patient={this.props.patient}
+        pendingInvites={this.props.pendingInvites}
+        onChangeMemberPermissions={this.props.onChangeMemberPermissions}
+        onRemoveMember={this.props.onRemoveMember}
+        onInviteMember={this.props.onInviteMember}
+        onCancelInvite={this.props.onCancelInvite}
+        trackMetric={this.props.trackMetric}/>
+    );
   },
 });
 

--- a/app/pages/patient/patientteam.js
+++ b/app/pages/patient/patientteam.js
@@ -190,7 +190,7 @@ var MemberInviteForm = React.createClass({
 
 var ConfirmDialog = React.createClass({
   propTypes: {
-    message: React.PropTypes.renderable,
+    message: React.PropTypes.node,
     buttonText: React.PropTypes.string,
     dismissText: React.PropTypes.string,
     buttonTextWorking: React.PropTypes.string,

--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -118,7 +118,6 @@ var Patients = React.createClass({
       <Invitation
         key={invitation.key}
         invitation={invitation}
-        patientsComponent={this}
         onAcceptInvitation={this.props.onAcceptInvitation}
         onDismissInvitation={this.props.onDismissInvitation}
         trackMetric={this.props.trackMetric}

--- a/test/unit/components/messages/message.test.js
+++ b/test/unit/components/messages/message.test.js
@@ -10,8 +10,6 @@ describe('Message', function () {
   describe('getInitialState', function() {
     it('should return an object with editing set to false', function() {
       console.warn = sinon.spy();
-      // TODO: consider requiring Proptype: theNote (maybe define as a shape as well?)
-      //   -> Properties of theNote are accessed in componentDidMount()
       var note = {
         timestamp : new Date().toISOString(),
         messagetext : 'foo',
@@ -31,6 +29,14 @@ describe('Message', function () {
   });
 
   describe('render', function() {
+    it('should console.warn when theNote not set', function () {
+      console.warn = sinon.spy();
+      var elem = TestUtils.renderIntoDocument(<Message />);
+
+      expect(console.warn.calledWith('Warning: Required prop `theNote` was not specified in `Message`.')).to.equal(true);
+      expect(console.warn.callCount).to.equal(1);
+    });
+
     it('should render a populated message', function() {
       console.warn = sinon.spy();
       var note = {

--- a/test/unit/components/messages/message.test.js
+++ b/test/unit/components/messages/message.test.js
@@ -1,0 +1,61 @@
+/* global chai */
+
+var React = require('react');
+var TestUtils = require('react/lib/ReactTestUtils');
+var expect = chai.expect;
+
+var Message = require('../../../../app/components/messages/message');
+
+describe('Message', function () {
+  describe('getInitialState', function() {
+    it('should return an object with editing set to false', function() {
+      console.warn = sinon.spy();
+      // TODO: consider requiring Proptype: theNote (maybe define as a shape as well?)
+      //   -> Properties of theNote are accessed in componentDidMount()
+      var note = {
+        timestamp : new Date().toISOString(),
+        messagetext : 'foo',
+        user : {
+          fullName:'Test User'
+        }
+      };
+
+      var elem = TestUtils.renderIntoDocument(<Message theNote={note}/>);
+      expect(elem).to.be.ok;
+
+      var initialState = elem.getInitialState();
+      expect(Object.keys(initialState).length).to.equal(1);
+      expect(initialState.editing).to.equal(false);
+      expect(console.warn.callCount).to.equal(0);
+    });
+  });
+
+  describe('render', function() {
+    it('should render a populated message', function() {
+      console.warn = sinon.spy();
+      var note = {
+        timestamp : new Date().toISOString(),
+        messagetext : 'foo bar',
+        user : {
+          fullName:'Test User'
+        }
+      };
+
+      var elem = TestUtils.renderIntoDocument(<Message theNote={note}/>);
+      expect(elem).to.be.ok;
+
+      // actual rendered text is modified version of input 'note'
+      var headerElem = TestUtils.findRenderedDOMComponentWithClass(elem, 'message-header');
+      expect(headerElem).to.be.ok;
+
+      // actual rendered text is modified version of input 'note'
+      var timestampElem = TestUtils.findRenderedDOMComponentWithClass(elem, 'message-timestamp');
+      expect(timestampElem).to.be.ok;
+
+      var textElem = elem.refs.messageText;
+      expect(textElem).to.be.ok;
+      expect(textElem.getDOMNode().textContent).to.equal(note.messagetext);
+      expect(console.warn.callCount).to.equal(0);
+    });
+  });
+});

--- a/test/unit/pages/patient/patient.test.js
+++ b/test/unit/pages/patient/patient.test.js
@@ -1,0 +1,155 @@
+/* global chai */
+
+var React = require('react');
+var TestUtils = require('react/lib/ReactTestUtils');
+var expect = chai.expect;
+
+var Patient = require('../../../../app/pages/patient/patient');
+var PatientTeam = require('../../../../app/pages/patient/patientteam');
+
+describe('Patient', function () {
+  describe('getInitialState', function() {
+    it('should return an object when showModalOverlay is false', function() {
+      console.warn = sinon.spy();
+      var props = {
+        trackMetric: function() {}
+      };
+      var patientElem = React.createElement(Patient, props);
+      var elem = TestUtils.renderIntoDocument(patientElem);
+      var initialState = elem.getInitialState();
+
+      expect(Object.keys(initialState).length).to.equal(1);
+      expect(initialState.showModalOverlay).to.equal(false);
+      expect(console.warn.callCount).to.equal(0);
+    });
+  });
+
+  describe('render', function() {
+    it('should console.warn when trackMetric not set', function () {
+      console.warn = sinon.spy();
+      var elem = TestUtils.renderIntoDocument(<Patient/>);
+
+      expect(elem).to.be.ok;
+      expect(console.warn.calledWith('Warning: Required prop `trackMetric` was not specified in `Patient`.')).to.equal(true);
+    });
+
+    it('should not console.warn when trackMetric set', function() {
+      console.warn = sinon.spy();
+      var props = {
+        trackMetric: function() {}
+      };
+      var patientElem = React.createElement(Patient, props);
+      var elem = TestUtils.renderIntoDocument(patientElem);
+
+      expect(elem).to.be.ok;
+      expect(console.warn.callCount).to.equal(0);
+    });
+  });
+
+  describe('renderPatientTeam', function() {
+    it('should not render when user and patient ids are different', function() {
+      console.warn = sinon.spy();
+      var props = {
+        user: {
+          userid: 'foo'
+        },
+        patient: {
+          userid: 'bar',
+          team: []
+        },
+        shareOnly: true,
+        trackMetric: function() {}
+      };
+      var patientElem = React.createElement(Patient, props);
+      var elem = TestUtils.renderIntoDocument(patientElem);
+      var getShareSection = function() {
+        TestUtils.findRenderedDOMComponentWithClass(elem, 'PatientPage-teamSection');
+      }
+
+      expect(getShareSection).to.throw(Error);
+      expect(console.warn.callCount).to.equal(0);
+    });
+
+    it('should not render when shareOnly is false', function() {
+      console.warn = sinon.spy();
+      var props = {
+        user: {
+          userid: 'foo'
+        },
+        patient: {
+          userid: 'foo',
+          team: []
+        },
+        shareOnly: false,
+        trackMetric: function() {}
+      };
+      var patientElem = React.createElement(Patient, props);
+      var elem = TestUtils.renderIntoDocument(patientElem);
+      var getShareSection = function() {
+        TestUtils.findRenderedDOMComponentWithClass(elem, 'PatientPage-teamSection');
+      }
+
+      expect(getShareSection).to.throw(Error);
+      expect(console.warn.callCount).to.equal(0);
+    });
+
+    it('should render when shareOnly is true', function() {
+      console.warn = sinon.spy();
+      var props = {
+        user: {
+          userid: 'foo'
+        },
+        patient: {
+          userid: 'foo',
+          team: []
+        },
+        shareOnly: true,
+        trackMetric: function() {}
+      };
+      var patientElem = React.createElement(Patient, props);
+      var elem = TestUtils.renderIntoDocument(patientElem);
+      var share = TestUtils.findRenderedDOMComponentWithClass(elem, 'PatientPage-teamSection');
+
+      expect(share).to.be.ok;
+      expect(console.warn.callCount).to.equal(0);
+    });
+
+    it('should transfer all props to patient-team', function() {
+      console.warn = sinon.spy();
+      var props = {
+        onCancelInvite: function() {},
+        onChangeMemberPermissions: function() {},
+        onInviteMember: function() {},
+        onRemoveMember: function() {},
+        patient: {
+          userid: 'foo',
+          team: ['coffee', 'mug']
+        },
+        pendingInvites: [
+          { key: 'foo' },
+          { key: 'bar' },
+          { key: 'baz' }
+        ],
+        shareOnly: true,
+        trackMetric: function() {},
+        user: {
+          userid: 'foo'
+        }
+      };
+      var patientElem = React.createElement(Patient, props);
+      var elem = TestUtils.renderIntoDocument(patientElem);
+      var team = TestUtils.findRenderedComponentWithType(elem, PatientTeam);
+
+      expect(team.props.onCancelInvite).to.be.ok;
+      expect(team.props.onChangeMemberPermissions).to.be.ok;
+      expect(team.props.onInviteMember).to.be.ok;
+      expect(team.props.onRemoveMember).to.be.ok;
+      expect(team.props.patient.userid).to.equal('foo');
+      expect(team.props.patient.team.length).to.equal(2);
+      expect(team.props.pendingInvites.length).to.equal(3);
+      expect(team.props.user.userid).to.equal('foo');
+      expect(team.props.trackMetric).to.be.ok;
+      expect(console.warn.callCount).to.equal(0);
+    });
+  });
+});

--- a/test/unit/pages/patient/patient.test.js
+++ b/test/unit/pages/patient/patient.test.js
@@ -64,7 +64,7 @@ describe('Patient', function () {
       var elem = TestUtils.renderIntoDocument(patientElem);
       var getShareSection = function() {
         TestUtils.findRenderedDOMComponentWithClass(elem, 'PatientPage-teamSection');
-      }
+      };
 
       expect(getShareSection).to.throw(Error);
       expect(console.warn.callCount).to.equal(0);
@@ -87,7 +87,7 @@ describe('Patient', function () {
       var elem = TestUtils.renderIntoDocument(patientElem);
       var getShareSection = function() {
         TestUtils.findRenderedDOMComponentWithClass(elem, 'PatientPage-teamSection');
-      }
+      };
 
       expect(getShareSection).to.throw(Error);
       expect(console.warn.callCount).to.equal(0);


### PR DESCRIPTION
Hi,
When I was checking out your app I noticed some warnings in the console and here is a patch to fix them. Do let me know if there is a better option than targeting this branch - I don't know the codebase well so I wanted to include test coverage to validate that my changes weren't breaking anything, and the best place to accomplish that at the moment was in this branch (as I wasn't able to run tests effectively in master).

##### Commit Message
- removed usage of 'transferPropsTo'
- changed React.PropTypes.renderable -> React.PropTypes.node
- removed unused property 'patientsComponent'
- added test coverage for the changes

Issue: #228 