### PR TITLE
default to mg/dL for display of BG values (but allow change to mmol/L through query param)

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -160,6 +160,15 @@ var AppComponent = React.createClass({
         console.log(new Error('Invalid timezone name in query parameter. (Try capitalizing properly.)'));
       }
     }
+    var bgPrefs = {
+      bgUnits: 'mg/dL'
+    };
+    if (!_.isEmpty(queryParams.units)) {
+      var queryUnits = queryParams.units.toLowerCase();
+      if (queryUnits === 'mmoll') {
+        bgPrefs.bgUnits = 'mmol/L';
+      }
+    }
     return {
       authenticated: app.api.user.isAuthenticated(),
       notification: null,
@@ -175,7 +184,7 @@ var AppComponent = React.createClass({
       fetchingInvites: true,
       pendingInvites:null,
       fetchingPendingInvites: true,
-      bgPrefs: null,
+      bgPrefs: bgPrefs,
       timePrefs: timePrefs,
       patientData: null,
       fetchingPatientData: true,

--- a/app/app.js
+++ b/app/app.js
@@ -1217,7 +1217,7 @@ var AppComponent = React.createClass({
       self.setState({
         bgPrefs: {
           bgClasses: patientData.bgClasses,
-          bgUnits: patientData.bgUnits
+          bgUnits: self.state.bgPrefs.bgUnits
         },
         patientData: allPatientsData,
         fetchingPatientData: false
@@ -1250,10 +1250,13 @@ var AppComponent = React.createClass({
     }
 
     console.time('Nurseshark Total');
-    var res = nurseShark.processData(data, this.state.timePrefs);
+    var res = nurseShark.processData(data, this.state.bgPrefs.bgUnits);
     console.timeEnd('Nurseshark Total');
     console.time('TidelineData Total');
-    var tidelineData = new TidelineData(res.processedData, {timePrefs: this.state.timePrefs});
+    var tidelineData = new TidelineData(res.processedData, {
+      timePrefs: this.state.timePrefs,
+      bgUnits: this.state.bgPrefs.bgUnits
+    });
     console.timeEnd('TidelineData Total');
 
     window.tidelineData = tidelineData;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "shelljs": "0.4.0",
     "style-loader": "0.8.3",
     "sundial": "1.1.8",
-    "tideline": "0.1.21",
+    "tideline": "0.1.22",
     "tidepool-platform-client": "0.18.0",
     "url-loader": "0.5.5",
     "webpack": "1.7.3"


### PR DESCRIPTION
Depends on [tideline 213](https://github.com/tidepool-org/tideline/pull/213). Once that's merged and tagged, will update tideline version in package.json here.

This makes the default BG display in mg/dL, with the option to switch to mmol/L by putting a query parameter `units=mmoll` before the hash (`#`).