### PR TITLE
handle two crashing scenarios possible because of data + name mismatch fix

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -908,6 +908,7 @@ var AppComponent = React.createClass({
         bgPrefs={this.state.bgPrefs}
         timePrefs={this.state.timePrefs}
         patientData={this.state.patientData}
+        fetchingPatient={this.state.fetchingPatient}
         fetchingPatientData={this.state.fetchingPatientData}
         isUserPatient={this.isSamePersonUserAndPatient()}
         queryParams={this.state.queryParams}

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -39,7 +39,8 @@ var PatientData = React.createClass({
     timePrefs: React.PropTypes.object.isRequired,
     patientData: React.PropTypes.object,
     patient: React.PropTypes.object,
-    fetchingPatientData: React.PropTypes.bool,
+    fetchingPatient: React.PropTypes.bool.isRequired,
+    fetchingPatientData: React.PropTypes.bool.isRequired,
     isUserPatient: React.PropTypes.bool,
     queryParams: React.PropTypes.object.isRequired,
     uploadUrl: React.PropTypes.string,
@@ -116,7 +117,7 @@ var PatientData = React.createClass({
   },
 
   renderPatientData: function() {
-    if (this.props.fetchingPatientData) {
+    if (this.props.fetchingPatient || this.props.fetchingPatientData) {
       return this.renderLoading();
     }
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -206,7 +206,7 @@ var PatientData = React.createClass({
 
   isEmptyPatientData: function() {
     var patientDataLength =
-      utils.getIn(this.props.patientData[this.props.patient.userid], ['data', 'length'], 0);
+      utils.getIn(this.props.patientData, [this.props.patient.userid, 'data', 'length'], 0);
     return !Boolean(patientDataLength);
   },
 


### PR DESCRIPTION
In testing the fix originally implemented in #230 @NSRiggall was getting some crashes occasionally when fetching data (reported [here](https://trello.com/c/HUPEouyS)). After talking with him and also experiencing similar myself on devel yesterday when tide-whisperer was timing out completely on data requests, I think the change in this pull request handles the issue by more gracefully recognizing when the server doesn't respond with data.

Still going to try to have a look in the logs to see if I can tell that this is the same issue as @NSRiggall was experiencing, but it may be difficult because of the weird stringification of blip errors that we haven't fixed yet in the logs...