### PR TITLE
timezone-aware bugfixes for notes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -932,7 +932,11 @@ var AppComponent = React.createClass({
     /* jshint ignore:end */
   },
   handleUpdatePatientData: function(userid, data) {
-    var patientData = _.cloneDeep(this.state.patientData);
+    // NOTE: intentional use of _.clone instead of _.cloneDeep
+    // we only need a shallow clone at the top level of the patientId keys
+    // and the _.cloneDeep I had originally would hang the browser for *seconds*
+    // when there was actually something in this.state.patientData
+    var patientData = _.clone(this.state.patientData);
     patientData[userid] = data;
     this.setState({
       patientData: patientData

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -25,6 +25,8 @@ var React = require('react');
 var _ = require('lodash');
 var sundial = require('sundial');
 
+var getIn = require('../../core/utils').getIn;
+
 var MessageForm = require('./messageform');
 
 if (!window.process) {
@@ -35,9 +37,10 @@ if (!window.process) {
 var Message = React.createClass({
 
   propTypes: {
-    theNote : React.PropTypes.object,
+    theNote: React.PropTypes.object,
     imageSize: React.PropTypes.string,
-    onSaveEdit : React.PropTypes.func
+    onSaveEdit: React.PropTypes.func,
+    timePrefs: React.PropTypes.object.isRequired
   },
 
   getInitialState: function() {
@@ -46,12 +49,20 @@ var Message = React.createClass({
     };
   },
   componentDidMount: function () {
-    var offset = sundial.getOffsetFromTime(this.props.theNote.timestamp) || sundial.getOffset();
+    var displayTimestamp;
+    if (getIn(this.props, ['timePrefs', 'timezoneAware'], false) &&
+      getIn(this.props, ['timePrefs', 'timezoneAware'], false)) {
+      displayTimestamp = sundial.formatInTimezone(this.props.theNote.timestamp, this.props.timePrefs.timezoneName);
+    }
+    else {
+      var offset = sundial.getOffsetFromTime(this.props.theNote.timestamp) || sundial.getOffset();
+      displayTimestamp = sundial.formatFromOffset(this.props.theNote.timestamp, offset);
+    }
 
     this.setState({
-      author :  this.getUserDisplayName(this.props.theNote.user),
-      note : this.props.theNote.messagetext,
-      when : sundial.formatFromOffset(this.props.theNote.timestamp, offset)
+      author: this.getUserDisplayName(this.props.theNote.user),
+      note: this.props.theNote.messagetext,
+      when: displayTimestamp
     });
   },
   getUserDisplayName: function(user) {

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -35,17 +35,15 @@ if (!window.process) {
 
 var Message = React.createClass({
   mixins: [MessageMixins],
-
   propTypes: {
     theNote: React.PropTypes.object,
     imageSize: React.PropTypes.string,
     onSaveEdit: React.PropTypes.func,
     timePrefs: React.PropTypes.object.isRequired
   },
-
   getInitialState: function() {
     return {
-      editing : false
+      editing: false
     };
   },
   componentDidMount: function () {
@@ -62,16 +60,13 @@ var Message = React.createClass({
     }
     return result;
   },
-
-  isComment : function(){
+  isComment: function(){
     return _.isEmpty(this.props.theNote.parentmessage) === false;
   },
-
-  handleEditSave:function(edits){
-
+  handleEditSave: function(edits) {
     var saveEdit = this.props.onSaveEdit;
 
-    if(saveEdit){
+    if (saveEdit) {
       var newNote = _.cloneDeep(this.props.theNote);
       if (this.props.theNote.messagetext !== edits.text ||
         (edits.timestamp && this.props.theNote.timestamp !== edits.timestamp)) {
@@ -81,33 +76,30 @@ var Message = React.createClass({
         }
         saveEdit(newNote);
       }
-
-      var offset = sundial.getOffsetFromTime(edits.timestamp || this.props.theNote.timestamp) || sundial.getOffset();
-
-      this.setState({
-        editing : false,
-        note : edits.text,
-        when : sundial.formatFromOffset(edits.timestamp || this.props.theNote.timestamp, offset)
-      });
+      var newState = {
+        editing: false,
+        note: edits.text,
+        when: this.getDisplayTimestamp(edits.timestamp || this.props.theNote.timestamp)
+      };
+      if (edits.timestamp) {
+        newState.timestamp = edits.timestamp;
+      }
+      this.setState(newState);
     }
-
   },
-
-  handleAllowEdit : function(e){
+  handleAllowEdit: function(e){
     if (e) {
       e.preventDefault();
     }
     this.setState({editing:true});
   },
-
-  handleCancelEdit : function(e){
+  handleCancelEdit: function(e){
     if (e) {
       e.preventDefault();
     }
     this.setState({editing:false});
   },
-
-  renderTitle : function(){
+  renderTitle: function() {
     var edit = this.renderEditLink();
     /* jshint ignore:start */
     return (
@@ -118,9 +110,8 @@ var Message = React.createClass({
     );
     /* jshint ignore:end */
   },
-
-  renderEditLink : function(){
-    if( this.state.editing === false && this.props.onSaveEdit){
+  renderEditLink: function(){
+    if (this.state.editing === false && this.props.onSaveEdit) {
       return (
         /* jshint ignore:start */
         <a
@@ -146,23 +137,24 @@ var Message = React.createClass({
 
     /* jshint ignore:start */
     return (
-      <img
-        className={'message-picture message-picture-' + imageSize}
+      <img className={'message-picture message-picture-' + imageSize}
         src={imageSource}
         alt='Profile picture'/>
     );
     /* jshint ignore:end */
   },
-  renderNoteEdit:function(){
-    if(this.state.editing){
+  renderNoteEdit: function() {
+    if (this.state.editing) {
       var editForm;
        /* jshint ignore:start */
-      if ( this.isComment() ){
-
+      if (this.isComment()) {
         //we only allow the editing of the text on a comment
         editForm = (
           <MessageForm
-            formFields={{editableText: this.props.theNote.messagetext, displayOnlyTimestamp : this.props.theNote.timestamp }}
+            formFields={{
+              editableText: this.state.note || this.props.theNote.messagetext,
+              displayOnlyTimestamp: this.state.timestamp || this.props.theNote.timestamp
+            }}
             onSubmit={this.handleEditSave}
             onCancel={this.handleCancelEdit}
             saveBtnText='Save' />
@@ -170,7 +162,10 @@ var Message = React.createClass({
       } else {
         editForm = (
           <MessageForm
-            formFields={{editableText: this.props.theNote.messagetext, editableTimestamp: this.props.theNote.timestamp}}
+            formFields={{
+              editableText: this.state.note || this.props.theNote.messagetext,
+              editableTimestamp: this.state.timestamp || this.props.theNote.timestamp
+            }}
             onSubmit={this.handleEditSave}
             onCancel={this.handleCancelEdit}
             saveBtnText='Save'
@@ -192,9 +187,7 @@ var Message = React.createClass({
     }
   },
   renderNoteContent: function() {
-
-    if(this.state.editing === false){
-
+    if (this.state.editing === false) {
       var image = this.renderImage();
       var title = this.renderTitle();
 
@@ -216,10 +209,9 @@ var Message = React.createClass({
   },
 
   render: function() {
-
     var noteClasses = 'message';
     var note = this.renderNoteContent() ? this.renderNoteContent() : this.renderNoteEdit();
-    if( this.state.editing ){
+    if (this.state.editing) {
       noteClasses = noteClasses + ' message-editing';
     }
 

--- a/app/components/messages/message.js
+++ b/app/components/messages/message.js
@@ -25,9 +25,8 @@ var React = require('react');
 var _ = require('lodash');
 var sundial = require('sundial');
 
-var getIn = require('../../core/utils').getIn;
-
 var MessageForm = require('./messageform');
+var MessageMixins = require('./messagemixins');
 
 if (!window.process) {
   var profileLargeSrc = require('./images/profile-100x100.png');
@@ -35,6 +34,7 @@ if (!window.process) {
 }
 
 var Message = React.createClass({
+  mixins: [MessageMixins],
 
   propTypes: {
     theNote: React.PropTypes.object,
@@ -49,20 +49,10 @@ var Message = React.createClass({
     };
   },
   componentDidMount: function () {
-    var displayTimestamp;
-    if (getIn(this.props, ['timePrefs', 'timezoneAware'], false) &&
-      getIn(this.props, ['timePrefs', 'timezoneAware'], false)) {
-      displayTimestamp = sundial.formatInTimezone(this.props.theNote.timestamp, this.props.timePrefs.timezoneName);
-    }
-    else {
-      var offset = sundial.getOffsetFromTime(this.props.theNote.timestamp) || sundial.getOffset();
-      displayTimestamp = sundial.formatFromOffset(this.props.theNote.timestamp, offset);
-    }
-
     this.setState({
       author: this.getUserDisplayName(this.props.theNote.user),
       note: this.props.theNote.messagetext,
-      when: displayTimestamp
+      when: this.getDisplayTimestamp(this.props.theNote.timestamp)
     });
   },
   getUserDisplayName: function(user) {
@@ -183,7 +173,8 @@ var Message = React.createClass({
             formFields={{editableText: this.props.theNote.messagetext, editableTimestamp: this.props.theNote.timestamp}}
             onSubmit={this.handleEditSave}
             onCancel={this.handleCancelEdit}
-            saveBtnText='Save' />
+            saveBtnText='Save'
+            timePrefs={this.props.timePrefs} />
         );
       }
       var title = this.renderTitle();

--- a/app/components/messages/messagemixins.js
+++ b/app/components/messages/messagemixins.js
@@ -1,0 +1,25 @@
+var sundial = require('sundial');
+var getIn = require('../../core/utils').getIn;
+
+var MessageMixins = {
+  isTimezoneAware: function() {
+    if (getIn(this.props, ['timePrefs', 'timezoneAware'], false) &&
+      getIn(this.props, ['timePrefs', 'timezoneAware'], false)) {
+      return true;
+    }
+    return false;
+  },
+  getDisplayTimestamp: function(ts) {
+    var displayTimestamp;
+    if (this.isTimezoneAware()) {
+      displayTimestamp = sundial.formatInTimezone(ts, this.props.timePrefs.timezoneName);
+    }
+    else {
+      var offset = sundial.getOffsetFromTime(ts) || sundial.getOffset();
+      displayTimestamp = sundial.formatFromOffset(ts, offset);
+    }
+    return displayTimestamp;
+  }
+};
+
+module.exports = MessageMixins;

--- a/app/components/messages/messages.js
+++ b/app/components/messages/messages.js
@@ -37,7 +37,8 @@ var Messages = React.createClass({
     onClose : React.PropTypes.func,
     onSave : React.PropTypes.func,
     onEdit : React.PropTypes.func,
-    onNewMessage : React.PropTypes.func
+    onNewMessage : React.PropTypes.func,
+    timePrefs: React.PropTypes.object.isRequired
   },
 
   getDefaultProps: function () {
@@ -71,7 +72,8 @@ var Messages = React.createClass({
         key={message.id}
         theNote={message}
         imageSize='large'
-        onSaveEdit={this.getSaveEdit(message.userid)}/>
+        onSaveEdit={this.getSaveEdit(message.userid)}
+        timePrefs={this.props.timePrefs} />
       );
     /* jshint ignore:end */
   },
@@ -82,7 +84,8 @@ var Messages = React.createClass({
         key={message.id}
         theNote={message}
         imageSize='small'
-        onSaveEdit={this.getSaveEdit(message.userid)}/>
+        onSaveEdit={this.getSaveEdit(message.userid)}
+        timePrefs={this.props.timePrefs} />
       );
     /* jshint ignore:end */
   },

--- a/app/components/messages/messages.js
+++ b/app/components/messages/messages.js
@@ -28,19 +28,17 @@ var Message = require('./message');
 var MessageForm = require('./messageform');
 
 var Messages = React.createClass({
-
   propTypes: {
-    messages : React.PropTypes.array,
-    createDatetime : React.PropTypes.string,
-    user : React.PropTypes.object,
-    patient : React.PropTypes.object,
-    onClose : React.PropTypes.func,
-    onSave : React.PropTypes.func,
-    onEdit : React.PropTypes.func,
-    onNewMessage : React.PropTypes.func,
+    messages: React.PropTypes.array,
+    createDatetime: React.PropTypes.string,
+    user: React.PropTypes.object,
+    patient: React.PropTypes.object,
+    onClose: React.PropTypes.func,
+    onSave: React.PropTypes.func,
+    onEdit: React.PropTypes.func,
+    onNewMessage: React.PropTypes.func,
     timePrefs: React.PropTypes.object.isRequired
   },
-
   getDefaultProps: function () {
     return {
       NOTE_PROMPT : 'Type a new note here ...',
@@ -56,16 +54,16 @@ var Messages = React.createClass({
     };
   },
   /*
-   * Should the use be able to edit this message?
+   * Should the user be able to edit this message?
    */
-  getSaveEdit:function(messageUserId){
+  getSaveEdit: function(messageUserId) {
     var saveEdit;
-    if(messageUserId === this.props.user.userid){
+    if (messageUserId === this.props.user.userid) {
       saveEdit = this.handleEditNote;
     }
     return saveEdit;
   },
-  renderNote: function(message){
+  renderNote: function(message) {
     /* jshint ignore:start */
     return (
       <Message
@@ -77,7 +75,7 @@ var Messages = React.createClass({
       );
     /* jshint ignore:end */
   },
-  renderComment:function(message){
+  renderComment: function(message) {
     /* jshint ignore:start */
     return (
       <Message
@@ -89,12 +87,10 @@ var Messages = React.createClass({
       );
     /* jshint ignore:end */
   },
-  renderThread:function(){
-
-    if(this.isMessageThread()){
-
+  renderThread: function() {
+    if (this.isMessageThread()) {
       var thread = _.map(this.state.messages, function(message) {
-        if(!message.parentmessage) {
+        if (!message.parentmessage) {
           return this.renderNote(message);
         } else if (message.parentmessage) {
           return this.renderComment(message);
@@ -110,11 +106,10 @@ var Messages = React.createClass({
 
     return;
   },
-  isMessageThread:function(){
-    return this.state.messages;
+  isMessageThread: function() {
+    return !_.isEmpty(this.state.messages);
   },
-  renderCommentOnThreadForm:function(){
-
+  renderCommentOnThreadForm: function() {
     var submitButtonText = 'Comment';
 
     /* jshint ignore:start */
@@ -128,40 +123,36 @@ var Messages = React.createClass({
       </div>
     );
     /* jshint ignore:end */
-
   },
-  renderNewThreadForm:function(){
-
+  renderNewThreadForm: function() {
     var submitButtonText = 'Post';
 
     /* jshint ignore:start */
     return (
       <div className='messages-form'>
         <MessageForm
-            formFields={{ editableTimestamp : this.props.createDatetime }}
-            messagePrompt={this.props.NOTE_PROMPT}
-            saveBtnText={submitButtonText}
-            onSubmit={this.handleCreateNote}
-            onCancel={this.handleClose}
+          formFields={{editableTimestamp: this.props.createDatetime}}
+          messagePrompt={this.props.NOTE_PROMPT}
+          saveBtnText={submitButtonText}
+          onSubmit={this.handleCreateNote}
+          onCancel={this.handleClose}
           timePrefs={this.props.timePrefs} />
       </div>
     );
-      /* jshint ignore:end */
-
+    /* jshint ignore:end */
   },
-  renderClose:function(){
+  renderClose: function() {
     /* jshint ignore:start */
     return (<a className='messages-close' onClick={this.handleClose}>Close</a>);
     /* jshint ignore:end */
   },
   render: function() {
-
     var thread = this.renderThread();
     var form = this.renderNewThreadForm() ;
     var close;
 
     //If we are closing an existing thread then have close and render the comment form
-    if(thread){
+    if (thread) {
       close = this.renderClose();
       form = this.renderCommentOnThreadForm();
     }
@@ -180,31 +171,31 @@ var Messages = React.createClass({
       </div>
      </div>
      /* jshint ignore:end */
-     );
+    );
   },
-  getParent : function(){
-    if(this.isMessageThread()){
-      return _.find(this.state.messages, function(message){ return !(message.parentmessage); });
+  getParent: function() {
+    if (this.isMessageThread()) {
+      return _.find(
+        this.state.messages,
+        function(message) { return !(message.parentmessage); }
+      );
     }
     return;
   },
-  handleAddComment : function (formValues,cb){
-
-    if(_.isEmpty(formValues) === false){
-
+  handleAddComment: function(formValues, cb) {
+    if (_.isEmpty(formValues) === false) {
       var addComment = this.props.onSave;
       var parent = this.getParent();
 
       var comment = {
-        parentmessage : parent.id,
-        userid : this.props.user.userid,
-        groupid : parent.groupid,
-        messagetext : formValues.text,
-        timestamp : formValues.timestamp
+        parentmessage: parent.id,
+        userid: this.props.user.userid,
+        groupid: parent.groupid,
+        messagetext: formValues.text,
+        timestamp: formValues.timestamp
       };
 
-      addComment(comment, function(error,commentId){
-
+      addComment(comment, function(error, commentId) {
         if (commentId) {
           if(cb){
             //let the form know all is good
@@ -222,21 +213,21 @@ var Messages = React.createClass({
       }.bind(this));
     }
   },
-  handleCreateNote: function (formValues,cb){
-
-    if(_.isEmpty(formValues) === false){
-
+  handleCreateNote: function(formValues,cb) {
+    if (_.isEmpty(formValues) === false) {
       var createNote = this.props.onSave;
 
       var message = {
         userid : this.props.user.userid,
         groupid : this.props.patient.userid,
         messagetext : formValues.text,
-        timestamp : sundial.formatForStorage(formValues.timestamp,sundial.getOffsetFromTime(formValues.timestamp))
+        timestamp : sundial.formatForStorage(
+          formValues.timestamp,
+          sundial.getOffsetFromTime(formValues.timestamp)
+        )
       };
 
-      createNote(message, function(error,messageId){
-
+      createNote(message, function(error, messageId) {
         if (messageId) {
           if(cb){
             //let the form know all is good
@@ -259,14 +250,12 @@ var Messages = React.createClass({
             });
           }
         }
-
       }.bind(this));
     }
   },
-  handleEditNote: function (updated){
+  handleEditNote: function(updated) {
     if(_.isEmpty(updated) === false){
-      this.props.onEdit(updated, function(error,details){
-      });
+      this.props.onEdit(updated, function(error, details){});
     }
   },
   handleClose: function(e) {

--- a/app/components/messages/messages.js
+++ b/app/components/messages/messages.js
@@ -123,7 +123,8 @@ var Messages = React.createClass({
         <MessageForm
           messagePrompt={this.props.COMMENT_PROMPT}
           saveBtnText={submitButtonText}
-          onSubmit={this.handleAddComment}/>
+          onSubmit={this.handleAddComment}
+          timePrefs={this.props.timePrefs} />
       </div>
     );
     /* jshint ignore:end */
@@ -141,7 +142,8 @@ var Messages = React.createClass({
             messagePrompt={this.props.NOTE_PROMPT}
             saveBtnText={submitButtonText}
             onSubmit={this.handleCreateNote}
-            onCancel={this.handleClose}/>
+            onCancel={this.handleClose}
+          timePrefs={this.props.timePrefs} />
       </div>
     );
       /* jshint ignore:end */

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -320,7 +320,8 @@ var PatientData = React.createClass({
           onClose={this.closeMessageCreation}
           onSave={this.props.onCreateMessage}
           onNewMessage={this.handleMessageCreation}
-          onEdit={this.handleEditMessage} />
+          onEdit={this.handleEditMessage}
+          timePrefs={this.props.timePrefs} />
       );
     } else if(this.state.messages) {
       return (
@@ -330,7 +331,8 @@ var PatientData = React.createClass({
           patient={this.props.patient}
           onClose={this.closeMessageThread}
           onSave={this.handleReplyToMessage}
-          onEdit={this.handleEditMessage} />
+          onEdit={this.handleEditMessage}
+          timePrefs={this.props.timePrefs} />
       );
     }
     /* jshint ignore:end */

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "shelljs": "0.4.0",
     "style-loader": "0.8.3",
     "sundial": "1.1.8",
-    "tideline": "0.1.24",
+    "tideline": "0.1.25",
     "tidepool-platform-client": "0.18.0",
     "url-loader": "0.5.5",
     "webpack": "1.7.3"


### PR DESCRIPTION
Fixes display and editing of timestamps on notes for new default to timezone-aware display.

Depends on [tideline #217](https://github.com/tidepool-org/tideline/pull/217).