### PR TITLE
update build-related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "autoprefixer-loader": "1.2.0",
+    "autoprefixer-loader": "2.0.0",
     "bows": "1.4.2",
     "connect": "3.3.5",
     "crossfilter": "1.3.11",
-    "css-loader": "0.9.1",
+    "css-loader": "0.15.1",
     "director": "1.2.8",
-    "file-loader": "0.8.1",
+    "file-loader": "0.8.4",
     "hakken": "0.1.7",
-    "json-loader": "0.5.1",
-    "jsx-loader": "0.12.2",
-    "less": "2.4.0",
-    "less-loader": "2.1.0",
+    "json-loader": "0.5.2",
+    "jsx-loader": "0.13.2",
+    "less": "2.5.1",
+    "less-loader": "2.2.0",
     "lodash": "3.5.0",
     "ms": "0.7.0",
     "qs": "2.4.1",
@@ -37,8 +37,8 @@
     "sundial": "1.1.8",
     "tideline": "0.1.25",
     "tidepool-platform-client": "0.18.0",
-    "url-loader": "0.5.5",
-    "webpack": "1.7.3"
+    "url-loader": "0.5.6",
+    "webpack": "1.10.0"
   },
   "devDependencies": {
     "blip-mock-data": "tidepool-org/blip-mock-data#v0.3.7",
@@ -54,7 +54,7 @@
     "react-tools": "0.13.2",
     "sinon": "1.14.1",
     "sinon-chai": "2.7.0",
-    "webpack-dev-server": "1.7.0"
+    "webpack-dev-server": "1.10.1"
   },
   "engines": {
     "node": "0.12.x"


### PR DESCRIPTION
Fun times. After I merged #240, I did a `git pull` on master to get the merged in update, then I cleaned out my node modules and did a fresh install just to do a final check before tagging. After the clean install, the `npm start` script was failing. The build (i.e., `npm run build`) was still working, but...not good to not be able to run locally.

We've been getting some autoprefixer warnings for a while, and I've been bitten before by the fact that even though *we* lock down our dependencies, if one of our deps doesn't lock down *its* dependencies, that can break things. (This happened to me once with Jest.)

So my theory is that's what happened. I went through and updated *all* of our webpack-related dependencies (with the help of [this tool](https://www.npmjs.com/package/npm-check-updates)), and now I can run both `npm start` and `npm run build` successfully locally.

@jh-bate if you could confirm on your local set up with a clean install of node modules and merge, that'd be great. Then I can tag & build the changes from #240 and get them back through devel and staging.