### PR TITLE
bump to latest platform-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "style-loader": "0.8.3",
     "sundial": "1.1.8",
     "tideline": "0.2.4",
-    "tidepool-platform-client": "0.18.0",
+    "tidepool-platform-client": "0.19.0",
     "url-loader": "0.5.6",
     "webpack": "1.10.0"
   },


### PR DESCRIPTION
@darinkrauss @jebeck  a bit of nothing PR that just bumps the platform-client to version 19. Have been running locally today just to ensure all is good - and it is :)

FYI this is the same version of platform-client the s3 upload version of the uploader is using - see https://github.com/tidepool-org/chrome-uploader/pull/147 