### PR TITLE
Fix tidepool uploader URL

### DIFF
--- a/config.app.js
+++ b/config.app.js
@@ -41,7 +41,7 @@ module.exports = {
   VERSION: pkg.version,
   MOCK: booleanFromText(__MOCK__, false),
   MOCK_PARAMS: __MOCK_PARAMS__ || '',
-  UPLOAD_API: __UPLOAD_API__ || 'https://tidepool.org/uploader',
+  UPLOAD_API: __UPLOAD_API__ || 'https://tidepool.org/products/tidepool-uploader',
   API_HOST: __API_HOST__ || 'https://dev-api.tidepool.org',
   SHOW_ACCEPT_TERMS: booleanFromText(__SHOW_ACCEPT_TERMS__, true),
   PASSWORD_MIN_LENGTH: integerFromText(__PASSWORD_MIN_LENGTH__, 8),


### PR DESCRIPTION
When first signing up for blip you're most likely presented with the following screen - 

![](http://cl.ly/07183C310A2R/Screen%20Shot%202016-01-27%20at%202.02.00%20AM.png)

Sadly the giant "Upload Data" link doesn't work. It takes you to http://tidepool.org/uploader?token=REDACTED. If you remove the token from this URL (doesn't appear to be needed anymore anyways) the above url will redirect to the correct destination - http://tidepool.org/products/tidepool-uploader/. If you don't you're stuck on the blog's 404 page which is not where you want to be. 

Three possible fixes
1. Update the redirector to support the old style links even if they have query params. This should probably happen but after a quick look at your github I can't find the code that powers the marketing website. 
2. Don't include the token and allow the redirector to do it's job - This seems like a hack
3. Correct the original url. That is what this PR does, although it appears as though you may need to update some env vars which aren't stored in Github if they're overwriting these values. 

Let me know if there's anything I can add to this PR, and also let me know if I just missed the marketing website code, I'd happily update that as well. 