### PR TITLE
fix grammar in new authorization error message

### DIFF
--- a/app/core/actionhandlers.js
+++ b/app/core/actionhandlers.js
@@ -89,7 +89,7 @@ export default class ActionHandlers {
 
     if (error.status === 401) {
       body = (
-        // something is up with the users authorization ...
+        // something is up with the user's authorization...
         <div>
           <p> {usrMessages.ERR_AUTHORIZATION} </p>
           <p> {utcTime} </p>

--- a/app/userMessages.js
+++ b/app/userMessages.js
@@ -16,7 +16,7 @@ not, you can obtain one from Tidepool Project at tidepool.org.
 */
 
 module.exports = {
-  ERR_AUTHORIZATION : 'Something went wrong with your account authorization. Maybe try logging out and then logging back in? If your still having issues then please contact support.',
+  ERR_AUTHORIZATION : 'Something went wrong with your account authorization. Maybe try logging out and then logging back in? If you\'re still having issues then please contact support.',
   ERR_ACCEPTING_TERMS : 'Something went wrong while accepting the terms and conditions',
   ERR_DISMISSING_INVITE : 'Something went wrong while dismissing the invitation.',
   ERR_ACCEPTING_INVITE : 'Something went wrong while accepting the invitation.',


### PR DESCRIPTION
I managed to produce this error from the uploader (by clicking Go to Blip for a user that the user I had logged into blip w/Remember Me did not have access to). I noticed a grammatical mistake in the error message ('your' instead of 'you're') and fixed it here.

CC @darinkrauss @jh-bate 