### PR TITLE
Add helper and tests for tracking mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "mocha": "2.4.5",
     "mocha-loader": "0.7.1",
     "moment": "2.11.2",
+    "object-invariant-test-helper": "0.1.1",
     "phantomjs": "2.1.3",
     "react-addons-test-utils": "0.14.7",
     "react-hot-loader": "1.3.0",

--- a/test/unit/redux/reducers/allUserMap.test.js
+++ b/test/unit/redux/reducers/allUserMap.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { allUsersMap as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -144,6 +146,8 @@ describe('allUsersMap', () => {
         500: { userid: 500, name: 'Xavier' }
       };
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let acceptedDate = new Date();
 
       let action = actions.sync.acceptTermsSuccess(500, acceptedDate)
@@ -153,6 +157,7 @@ describe('allUsersMap', () => {
       expect(Object.keys(state).length).to.equal(Object.keys(initialStateForTest).length);
 
       expect(state[500].termsAccepted).to.equal(acceptedDate);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -162,6 +167,8 @@ describe('allUsersMap', () => {
         500:  {userid: 500 }
       };
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let patient = { userid: 500, name: 'Xavier', profile: { foo: 'bar' } };
 
       let action = actions.sync.createPatientSuccess(500, patient)
@@ -169,8 +176,8 @@ describe('allUsersMap', () => {
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(1);
-
       expect(state[patient.userid].profile).to.equal(patient.profile);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -180,6 +187,8 @@ describe('allUsersMap', () => {
         505:  {userid: 505 }
       };
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let patient = { userid: 505, name: 'Xavier', profile: { foo: 'sweet' }, permissions: { foo: 'bar'} };
 
       let action = actions.sync.updateUserRequest(505, patient)
@@ -187,9 +196,9 @@ describe('allUsersMap', () => {
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(1);
-
       expect(state[patient.userid].profile).to.equal(patient.profile);
       expect(state[patient.userid].permissions).to.be.undefined;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -198,6 +207,8 @@ describe('allUsersMap', () => {
       let initialStateForTest = {
         500:  {userid: 500 }
       };
+      
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let patient = { userid: 500, name: 'Xavier', profile: { foo: 'bar' }, permissions: { foo: 'bar'} };
 
@@ -209,6 +220,7 @@ describe('allUsersMap', () => {
 
       expect(state[patient.userid].profile).to.equal(patient.profile);
       expect(state[patient.userid].permissions).to.be.undefined;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -217,6 +229,8 @@ describe('allUsersMap', () => {
       let initialStateForTest = {
         500:  {userid: 500 }
       };
+
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let patient = { userid: 500, name: 'Xavier', profile: { foo: 'bar' }, permissions: { foo: 'bar'} };
 
@@ -228,6 +242,7 @@ describe('allUsersMap', () => {
 
       expect(state[patient.userid].profile).to.equal(patient.profile);
       expect(state[patient.userid].permissions).to.be.undefined;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -237,11 +252,14 @@ describe('allUsersMap', () => {
         500:  {userid: 500 }
       };
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/membersOfTargetCareTeam.test.js
+++ b/test/unit/redux/reducers/membersOfTargetCareTeam.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { membersOfTargetCareTeam as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -59,12 +61,15 @@ describe('membersOfTargetCareTeam', () => {
   describe('logoutSuccess', () => {
     it('should set state to null', () => {
       let initialStateForTest = [1, 2 ,3];
+
+      let tracked = mutationTracker.trackObj(initialStateForTest);
       
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(state.length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/membershipPermissionsInOtherCareTeams.test.js
+++ b/test/unit/redux/reducers/membershipPermissionsInOtherCareTeams.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { membershipPermissionsInOtherCareTeams as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -59,12 +61,15 @@ describe('membershipPermissionsInOtherCareTeams', () => {
         3434: { view: {}, notes: {} },
         250: { view: {}, notes: {} }
       };
+
+      let tracked = mutationTracker.trackObj(initialStateForTest);
       
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/messageThread.test.js
+++ b/test/unit/redux/reducers/messageThread.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { messageThread as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -67,11 +69,14 @@ describe('messageThread', () => {
         ]
       };
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let action = actions.sync.closeMessageThread()
 
       let state = reducer(initialStateForTest, action);
 
       expect(state).to.be.null;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -86,11 +91,14 @@ describe('messageThread', () => {
         ]
       };
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(state).to.be.null;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/notification.test.js
+++ b/test/unit/redux/reducers/notification.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { notification as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -38,6 +40,7 @@ describe('notification', () => {
     it('should clear notification state when no acknowledgeNotificationKey specified in payload', () => {
       let notification = 'Some notification'
       let initialStateForTest = notification;
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let action = actions.sync.acknowledgeNotification()
 
@@ -45,11 +48,13 @@ describe('notification', () => {
 
       let state = reducer(initialStateForTest, action);
       expect(state).to.be.null;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
 
     it('should not clear notification state when a acknowledgeNotificationKey is specified in payload', () => {
       let notification = 'Some notification'
       let initialStateForTest = notification;
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let action = actions.sync.acknowledgeNotification('someAcknowledgementKey')
 
@@ -57,6 +62,7 @@ describe('notification', () => {
 
       let state = reducer(initialStateForTest, action);
       expect(state).to.equal(notification);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/patientDataMap.test.js
+++ b/test/unit/redux/reducers/patientDataMap.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { patientDataMap as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -65,6 +67,7 @@ describe('patientDataMap', () => {
           { value: 34 }
         ]
       };
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let patientId = 100;
 
@@ -76,6 +79,7 @@ describe('patientDataMap', () => {
 
       expect(Object.keys(state).length).to.equal(2);
       expect(state[patientId]).to.be.null;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -90,11 +94,13 @@ describe('patientDataMap', () => {
           { value: 34 }
         ]
       };
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let action = actions.sync.logoutSuccess()
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/patientNotesMap.test.js
+++ b/test/unit/redux/reducers/patientNotesMap.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { patientNotesMap as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -65,6 +67,7 @@ describe('patientNotesMap', () => {
           { message: 'Awesome sauce!' }
         ]
       };
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let patientId = 100;
 
@@ -76,6 +79,7 @@ describe('patientNotesMap', () => {
 
       expect(Object.keys(state).length).to.equal(2);
       expect(state[patientId]).to.be.null;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -90,11 +94,13 @@ describe('patientNotesMap', () => {
           { message: 'Awesome sauce!' }
         ]
       };
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let action = actions.sync.logoutSuccess()
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/pendingReceivedInvites.test.js
+++ b/test/unit/redux/reducers/pendingReceivedInvites.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { pendingReceivedInvites as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -58,6 +60,8 @@ describe('pendingReceivedInvites', () => {
         { key: 50 }
       ];
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let membership = { key: 50 };
 
       let action = actions.sync.acceptReceivedInviteSuccess(membership)
@@ -65,6 +69,7 @@ describe('pendingReceivedInvites', () => {
       let state = reducer(initialStateForTest, action);
 
       expect(state.length).to.equal(initialStateForTest.length - 1);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -75,6 +80,8 @@ describe('pendingReceivedInvites', () => {
         { key: 50, email: 'a@a.com' }
       ];
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let membership = { key: 30 };
 
       let action = actions.sync.rejectReceivedInviteSuccess(membership)
@@ -82,6 +89,7 @@ describe('pendingReceivedInvites', () => {
       let state = reducer(initialStateForTest, action);
 
       expect(state.length).to.equal(initialStateForTest.length - 1);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -92,11 +100,14 @@ describe('pendingReceivedInvites', () => {
         { key: 50 }
       ];
 
+      let tracked = mutationTracker.trackObj(initialStateForTest);
+
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(state.length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/pendingSentInvites.test.js
+++ b/test/unit/redux/reducers/pendingSentInvites.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { pendingSentInvites as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -57,6 +59,7 @@ describe('pendingSentInvites', () => {
         { inviteid: 30 },
         { inviteid: 50 }
       ];
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let invitation = { inviteid: 500 };
 
@@ -65,6 +68,7 @@ describe('pendingSentInvites', () => {
       let state = reducer(initialStateForTest, action);
 
       expect(state.length).to.equal(initialStateForTest.length + 1);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -74,6 +78,7 @@ describe('pendingSentInvites', () => {
         { inviteid: 30, email: 'g@g.com' },
         { inviteid: 50, email: 'a@a.com' }
       ];
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let removedEmail = 'g@g.com';
 
@@ -83,6 +88,7 @@ describe('pendingSentInvites', () => {
 
       expect(state.length).to.equal(initialStateForTest.length - 1);
       expect(state[0].email).to.equal('a@a.com');
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 
@@ -92,12 +98,14 @@ describe('pendingSentInvites', () => {
         { inviteid: 30, email: 'g@g.com' },
         { inviteid: 50, email: 'a@a.com' }
       ];
+      let tracked = mutationTracker.trackObj(initialStateForTest);
 
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(state.length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });

--- a/test/unit/redux/reducers/permissionsOfMembersInTargetCareTeam.test.js
+++ b/test/unit/redux/reducers/permissionsOfMembersInTargetCareTeam.test.js
@@ -23,6 +23,8 @@
 
 import _ from 'lodash';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { permissionsOfMembersInTargetCareTeam as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
@@ -61,12 +63,13 @@ describe('permissionsOfMembersInTargetCareTeam', () => {
         3434: { view: {}, notes: {} },
         250: { view: {}, notes: {} }
       };
-      
+      let tracked = mutationTracker.trackObj(initialStateForTest);
       let action = actions.sync.logoutSuccess()
 
       let state = reducer(initialStateForTest, action);
 
       expect(Object.keys(state).length).to.equal(0);
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
 - Add object-invarient-test-helper to package.json
 - Use object-invariant-test-helper in all reducer tests to ensure state is not mutated