### PR TITLE
Remove waterfall logic for welcome screen and reinstate redirect when…

### DIFF
--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -36,6 +36,7 @@ export let Patients = React.createClass({
     user: React.PropTypes.object,
     patients: React.PropTypes.array,
     invites: React.PropTypes.array,
+    loading: React.PropTypes.bool,
     showingWelcomeMessage: React.PropTypes.bool,
     onHideWelcomeSetup: React.PropTypes.func,
     trackMetric: React.PropTypes.func.isRequired,

--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -50,7 +50,7 @@ export let Patients = React.createClass({
   render: function() {
     var welcomeTitle = this.renderWelcomeTitle();
 
-    if (this.isLoading() && !(this.props.showingWelcomeMessage)) {
+    if (this.isLoading()) {
       return (
         <div className="container-box-outer">
           <div className="patients js-patients-page">

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -84,12 +84,12 @@ export function login(api, credentials, options) {
                 } else {
                   user = update(user, { $merge: patient });
                   dispatch(sync.loginSuccess(user));
-                  dispatch(routeActions.push('/patients'));
+                  dispatch(routeActions.push('/patients?justLoggedIn=true'));
                 }
               });
             } else {
               dispatch(sync.loginSuccess(user));
-              dispatch(routeActions.push('/patients'));
+              dispatch(routeActions.push('/patients?justLoggedIn=true'));
             }
           }
         });

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -197,7 +197,7 @@ export function acceptTerms(api, acceptedDate) {
         dispatch(sync.acceptTermsFailure(ErrorMessages.STANDARD));
       } else {
         dispatch(sync.acceptTermsSuccess(loggedInUserId, acceptedDate));
-        dispatch(routeActions.push(`/patients`));
+        dispatch(routeActions.push(`/patients?justLoggedIn=true`));
       }
     })
   };

--- a/app/redux/reducers/index.js
+++ b/app/redux/reducers/index.js
@@ -38,7 +38,7 @@ import {
   pendingReceivedInvites,
   resentEmailVerification,
   sentEmailVerification,
-  signupConfirmed,
+  showingWelcomeMessage,
   timePrefs
 } from './misc';
 
@@ -62,7 +62,7 @@ export default combineReducers({
   pendingReceivedInvites,
   resentEmailVerification,
   sentEmailVerification,
-  signupConfirmed,
+  showingWelcomeMessage,
   timePrefs,
   working
 });

--- a/app/redux/reducers/initialState.js
+++ b/app/redux/reducers/initialState.js
@@ -24,7 +24,7 @@ const working = {
 
 export default { 
   passwordResetConfirmed: false,
-  signupConfirmed: false,
+  showingWelcomeMessage: null,
   isLoggedIn: false,
   sentEmailVerification: false,
   resentEmailVerification: false,

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -40,9 +40,9 @@ export const passwordResetConfirmed = (state = initialState.passwordResetConfirm
   }
 };
 
-export const signupConfirmed = (state = initialState.signupConfirmed, action) => {
+export const showingWelcomeMessage = (state = initialState.showingWelcomeMessage, action) => {
   switch(action.type) {
-    case types.CONFIRM_SIGNUP_SUCCESS:
+    case types.SHOW_WELCOME_MESSAGE:
       return update(state, { $set: true });
     case types.HIDE_WELCOME_MESSAGE:
       return update(state, { $set: false });

--- a/test/unit/redux/reducers/showingWelcomeMessage.test.js
+++ b/test/unit/redux/reducers/showingWelcomeMessage.test.js
@@ -23,7 +23,7 @@
 
 import _ from 'lodash';
 
-import { signupConfirmed as reducer } from '../../../../app/redux/reducers/misc';
+import { showingWelcomeMessage as reducer } from '../../../../app/redux/reducers/misc';
 
 import actions from '../../../../app/redux/actions/index';
 
@@ -33,16 +33,28 @@ import { notification as initialState } from '../../../../app/redux/reducers/ini
 
 var expect = chai.expect;
 
-describe('signupConfirmed', () => {
-  describe('confirmSignupSuccess', () => {
-    it('should set state to true', () => {
+describe('showingWelcomeMessage', () => {
+  describe('showWelcomeMessage', () => {
+    it('should set state to false', () => {
       let initialStateForTest = false;
 
-      let action = actions.sync.confirmSignupSuccess()
+      let action = actions.sync.showWelcomeMessage()
 
       let state = reducer(initialStateForTest, action);
 
       expect(state).to.be.true;
+    });
+  });
+
+  describe('hideWelcomeMessage', () => {
+    it('should set state to false', () => {
+      let initialStateForTest = true;
+
+      let action = actions.sync.hideWelcomeMessage()
+
+      let state = reducer(initialStateForTest, action);
+
+      expect(state).to.be.false;
     });
   });
 });


### PR DESCRIPTION
… logging in with one patient

The state logic for showing the welcome screen to users was confusing, and only triggered when a user had just signed up (confirmed signup), this has now been simplified to just be triggered any time they log in if they have no data and no access to patients and no pending invites.

The reinstated redirect for accounts with access to exactly one patient has been put back in to improve the UX