### PR TITLE
rev tideline version to v0.4.10 for active basal sched display

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "shelljs": "0.6.0",
     "style-loader": "0.13.0",
     "sundial": "1.5.1",
-    "tideline": "0.4.8",
+    "tideline": "0.4.10",
     "tidepool-platform-client": "0.23.0",
     "url-loader": "0.5.7",
     "webpack": "1.12.13"


### PR DESCRIPTION
What it says on the tin. Sign-off @jh-bate?