### PR TITLE
Gordyd/people list sorting

### DIFF
--- a/app/components/peoplelist/peoplelist.js
+++ b/app/components/peoplelist/peoplelist.js
@@ -46,8 +46,6 @@ var PeopleList = React.createClass({
     var peopleNodes = [];
     if (!_.isEmpty(this.props.people)) {
 
-      console.log(this.props.people);
-
       // first sort by fullName
       var sortedPeople = _.sortBy(this.props.people, function(person) {
         var patient = person.profile.patient;

--- a/app/components/peoplelist/peoplelist.js
+++ b/app/components/peoplelist/peoplelist.js
@@ -46,9 +46,12 @@ var PeopleList = React.createClass({
     var peopleNodes = [];
     if (!_.isEmpty(this.props.people)) {
 
+      console.log(this.props.people);
+
       // first sort by fullName
       var sortedPeople = _.sortBy(this.props.people, function(person) {
-        return person.profile.fullName;
+        var patient = person.profile.patient;
+        return (patient && patient.isOtherPerson && patient.fullName) ? person.profile.patient.fullName : person.profile.fullName;
       });
 
       // then pop the logged-in user to the top if has data

--- a/test/unit/components/peoplelist.test.js
+++ b/test/unit/components/peoplelist.test.js
@@ -87,6 +87,53 @@ describe('PeopleList', function () {
       expect(fullNames[3].title).to.equal('Tucker Doe');
     });
 
+    it('should use a patients fullName to sort if present and isOtherPerson', function() {
+      var props = {
+        people: [{
+          profile: {
+            fullName: 'Zoe Doe',
+          },
+          permissions: {
+            root: {}
+          }
+        }, {
+          profile: {
+            fullName: 'Professor Snape',
+            patient: {
+              fullName: 'Alan Rickman',
+              isOtherPerson: true
+            }
+          }
+        }, {
+          profile: {
+            fullName: 'John Doe'
+          }
+        }, {
+          profile: {
+            fullName: 'Anna Zork'
+          }
+        }
+        {
+          profile: {
+            fullName: 'Bruce Wayne',
+            patient: {
+              fullName: 'Christian Bale',
+              isOtherPerson: true
+            }
+          }
+        }]
+      };
+      var listElem = React.createElement(PeopleList, props);
+      var elem = TestUtils.renderIntoDocument(listElem);
+      var renderedDOM = ReactDOM.findDOMNode(elem);
+      var fullNames = renderedDOM.querySelectorAll('.patientcard-fullname');
+      expect(fullNames.length).to.equal(4);
+      expect(fullNames[0].title).to.equal('Zoe Doe');
+      expect(fullNames[1].title).to.equal('Alan Rickman');
+      expect(fullNames[2].title).to.equal('Anna Zork');
+      expect(fullNames[3].title).to.equal('Christian Bale');
+      expect(fullNames[4].title).to.equal('John Doe');
+    });
 
 
     it('should be sorted by fullName, no logged-in user present (b/c not data storage acct)', function() {


### PR DESCRIPTION
When displaying a list of patients whose data you are able to view we need to ensure the list is sorted by the patient's name rather than the name associated with the profile that manages the patient. This commit updates the sorting rules and adds a new test condition to ensure that this property is used when the patient isOtherPerson flag is set to true