### PR TITLE
Account for patient being other person

### DIFF
--- a/app/components/peoplelist/peoplelist.js
+++ b/app/components/peoplelist/peoplelist.js
@@ -48,7 +48,8 @@ var PeopleList = React.createClass({
 
       // first sort by fullName
       var sortedPeople = _.sortBy(this.props.people, function(person) {
-        return person.profile.fullName;
+        var patient = person.profile.patient;
+        return (patient && patient.isOtherPerson && patient.fullName) ? person.profile.patient.fullName : person.profile.fullName;
       });
 
       // then pop the logged-in user to the top if has data

--- a/app/components/peoplelist/peoplelist.js
+++ b/app/components/peoplelist/peoplelist.js
@@ -49,7 +49,8 @@ var PeopleList = React.createClass({
       // first sort by fullName
       var sortedPeople = _.sortBy(this.props.people, function(person) {
         var patient = _.get(person, 'profile.patient', null);
-        return (patient && patient.isOtherPerson && patient.fullName) ? person.profile.patient.fullName : person.profile.fullName;
+        return (patient && patient.isOtherPerson && patient.fullName) ? 
+          patient.fullName : person.profile.fullName;
       });
 
       // then pop the logged-in user to the top if has data

--- a/app/components/peoplelist/peoplelist.js
+++ b/app/components/peoplelist/peoplelist.js
@@ -48,7 +48,7 @@ var PeopleList = React.createClass({
 
       // first sort by fullName
       var sortedPeople = _.sortBy(this.props.people, function(person) {
-        var patient = person.profile.patient;
+        var patient = _.get(person, 'profile.patient', null);
         return (patient && patient.isOtherPerson && patient.fullName) ? person.profile.patient.fullName : person.profile.fullName;
       });
 

--- a/test/unit/components/peoplelist.test.js
+++ b/test/unit/components/peoplelist.test.js
@@ -87,6 +87,53 @@ describe('PeopleList', function () {
       expect(fullNames[3].title).to.equal('Tucker Doe');
     });
 
+    it('should use a patients fullName to sort if present and isOtherPerson', function() {
+      var props = {
+        people: [{
+          profile: {
+            fullName: 'Zoe Doe',
+          },
+          permissions: {
+            root: {}
+          }
+        }, {
+          profile: {
+            fullName: 'Professor Snape',
+            patient: {
+              fullName: 'Alan Rickman',
+              isOtherPerson: true
+            }
+          }
+        }, {
+          profile: {
+            fullName: 'John Doe'
+          }
+        }, {
+          profile: {
+            fullName: 'Anna Zork'
+          }
+        },
+        {
+          profile: {
+            fullName: 'Bruce Wayne',
+            patient: {
+              fullName: 'Christian Bale',
+              isOtherPerson: true
+            }
+          }
+        }]
+      };
+      var listElem = React.createElement(PeopleList, props);
+      var elem = TestUtils.renderIntoDocument(listElem);
+      var renderedDOM = ReactDOM.findDOMNode(elem);
+      var fullNames = renderedDOM.querySelectorAll('.patientcard-fullname');
+      expect(fullNames.length).to.equal(5);
+      expect(fullNames[0].title).to.equal('Zoe Doe');
+      expect(fullNames[1].title).to.equal('Alan Rickman');
+      expect(fullNames[2].title).to.equal('Anna Zork');
+      expect(fullNames[3].title).to.equal('Christian Bale');
+      expect(fullNames[4].title).to.equal('John Doe');
+    });
 
 
     it('should be sorted by fullName, no logged-in user present (b/c not data storage acct)', function() {


### PR DESCRIPTION
When displaying a list of patients whose data you are able to view we need to ensure the list is sorted by the patient's name rather than the name associated with the profile that manages the patient. This commit updates the sorting rules and adds a new test condition to ensure that this property is used when the patient isOtherPerson flag is set to true.