### PR TITLE
remove a metric that will never actually get recorded

### DIFF
--- a/app/redux/utils/trackingMiddleware.js
+++ b/app/redux/utils/trackingMiddleware.js
@@ -23,7 +23,6 @@ const trackMetricMap = {
   SIGNUP_SUCCESS: 'Signed Up',
   LOGIN_SUCCESS: 'Logged In',
   SETUP_DATA_STORAGE_SUCCESS: 'Created Profile',
-  CONFIRM_SIGNUP_SUCCESS: 'Finalized Signup',
   UPDATE_PATIENT_SUCCESS: 'Updated Profile',
   UPDATE_USER_SUCCESS: 'Updated Account',
   LOGOUT_REQUEST: 'Logged Out'


### PR DESCRIPTION
This metric will also be fire before login, but we can't push metrics until after login. This PR therefore removes the metric for greatest code readability.