### PR TITLE
require the babel-core polyfill(s) for behind-the-times browsers

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -16,6 +16,8 @@
 window.onerror = require('./onerror');
 window.config = require('../config.app.js');
 
+require('babel-core/polyfill');
+
 var app = window.app = require('./bootstrap');
 
 app.start();


### PR DESCRIPTION
What it says on the tin. You only get one guess as to which browser (primarily) is behind the times...