### PR TITLE
get Object.assign through babel-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "async": "1.5.2",
     "babel-core": "5.8.38",
     "babel-loader": "5.4.0",
+    "babel-runtime": "5.8.38",
     "bows": "1.5.0",
     "classnames": "2.2.3",
     "crossfilter": "1.3.12",
@@ -59,7 +60,6 @@
   "devDependencies": {
     "babel-eslint": "5.0.4",
     "babel-plugin-rewire": "0.1.12",
-    "babel-runtime": "5.8.38",
     "chai": "3.5.0",
     "chromedriver": "2.21.2",
     "eslint": "2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ if (isDev) {
   loaders.push({test: /\.less$/, loaders: ['style-loader', 'css-loader' , 'postcss-loader', 'less-loader']})
 } else {
   loaders.push({test: /\.less$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!less-loader')});
-  loaders.push({test: /\.js$/, exclude: /(node_modules)/, loaders: ['babel-loader']});
+  loaders.push({test: /\.js$/, exclude: /(node_modules)/, loaders: ['babel-loader?optional=runtime']});
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes the issue with the app crashing on IE post-redux migration.

@krystophv have a brief look-see?