### PR TITLE
flag for turning off various dev tools even in development

### DIFF
--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -29,11 +29,13 @@ import personUtils from './core/personutils';
 import queryString from './core/querystring';
 import detectTouchScreen from './core/notouch';
 
+/* global __DEV_TOOLS__ */
+
 // For React developer tools
 window.React = React;
 
 var appContext = {
-  log: bows('App'),
+  log: __DEV_TOOLS__ ? bows('App') : _.noop,
   api: api,
   personUtils: personUtils,
   DEBUG: !!(window.localStorage && window.localStorage.debug),

--- a/app/redux/containers/DevTools.js
+++ b/app/redux/containers/DevTools.js
@@ -12,7 +12,8 @@ const DevTools = createDevTools(
   // Monitors are individually adjustable with props.
   // Consult their repositories to learn about those props.
   // Here, we put LogMonitor inside a DockMonitor.
-  <DockMonitor toggleVisibilityKey='ctrl-h'
+  <DockMonitor defaultIsVisible={false}
+               toggleVisibilityKey='ctrl-h'
                changePositionKey='ctrl-q'>
     <LogMonitor theme='tomorrow' />
   </DockMonitor>

--- a/app/redux/containers/Root.dev.js
+++ b/app/redux/containers/Root.dev.js
@@ -4,9 +4,20 @@ import { Router, browserHistory } from 'react-router';
 
 import DevTools from './DevTools';
 
+/* global __DEV_TOOLS__ */
+
 export default class Root extends Component {
   render() {
     const { store, routing } = this.props;
+    if (!__DEV_TOOLS__) {
+      return (
+        <Provider store={store}>
+          <Router history={browserHistory}>
+            {routing}
+          </Router>
+        </Provider>
+      );
+    }
     return (
       <Provider store={store}>
         <div>

--- a/app/redux/store/configureStore.dev.js
+++ b/app/redux/store/configureStore.dev.js
@@ -15,6 +15,8 @@
  * == BSD2 LICENSE ==
  */
 
+/* global __DEV_TOOLS__ */
+
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import { persistState } from 'redux-devtools';
 import thunkMiddleware from 'redux-thunk';
@@ -47,20 +49,34 @@ const loggerMiddleware = createLogger({
   collapsed: true,
 });
 
-
-const enhancer = (api) => {
-  return compose(
-    applyMiddleware(
-      thunkMiddleware,
-      loggerMiddleware,
-      reduxRouterMiddleware,
-      createErrorLogger(api),
-      trackingMiddleware(api)
-    ),
-    DevTools.instrument(),
-    // We can persist debug sessions this way
-    persistState(getDebugSessionKey())
-  );
+let enhancer;
+if (!__DEV_TOOLS__) {
+  enhancer = (api) => {
+    return compose(
+      applyMiddleware(
+        thunkMiddleware,
+        reduxRouterMiddleware,
+        createErrorLogger(api),
+        trackingMiddleware(api)
+      ),
+      persistState(getDebugSessionKey())
+    );
+  }
+} else {
+  enhancer = (api) => {
+    return compose(
+      applyMiddleware(
+        thunkMiddleware,
+        loggerMiddleware,
+        reduxRouterMiddleware,
+        createErrorLogger(api),
+        trackingMiddleware(api)
+      ),
+      DevTools.instrument(),
+      // We can persist debug sessions this way
+      persistState(getDebugSessionKey())
+    );
+  }
 }
 
 let initialState = { blip: blipState };

--- a/config.app.js
+++ b/config.app.js
@@ -44,5 +44,5 @@ module.exports = {
   UPLOAD_API: __UPLOAD_API__ || 'https://tidepool.org/uploader',
   API_HOST: __API_HOST__ || 'https://dev-api.tidepool.org',
   INVITE_KEY: __INVITE_KEY__ || '',
-  PASSWORD_MIN_LENGTH: integerFromText(__PASSWORD_MIN_LENGTH__, 8)
+  PASSWORD_MIN_LENGTH: integerFromText(__PASSWORD_MIN_LENGTH__, 8),
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ var defineEnvPlugin = new webpack.DefinePlugin({
   __INVITE_KEY__: JSON.stringify(process.env.INVITE_KEY || null),
   __PASSWORD_MIN_LENGTH__: JSON.stringify(process.env.PASSWORD_MIN_LENGTH || null),
   __DEV__: isDev,
-  __TEST__: false
+  __TEST__: false,
+  __DEV_TOOLS__: (process.env.DEV_TOOLS != null) ? process.env.DEV_TOOLS : (isDev ? true : false)
 });
 
 var plugins = [ defineEnvPlugin, new ExtractTextPlugin('style.[contenthash].css') ];


### PR DESCRIPTION
primary change = add DEV_TOOLS flag for:
- removing redux DevTools
- removing redux-logger
- removing most bows logging

(even when building with NODE_ENV=development)

plus:
+ hide DevTools by default even when on (this is already the default in the uploader, and I almost always dismiss the dev tools as the first thing I do when opening app locally, but if @krystophv you feel differently LMK)

FYI @krystophv and @jh-bate This is necessary in order for me to accurately profile visualization performance issues when working locally. The DevTools are quite expensive and screw with the results.

Haven't added another config shell script for conveniently setting this because it probably won't be a very common use case. For now, just `export DEV_TOOLS=false` if you want to turn _off_ the dev tools while working with a local dev config.