### PR TITLE
add back `library` option that exposes the bundle on `window` (crucially)

### DIFF
--- a/config.webpack.js
+++ b/config.webpack.js
@@ -22,7 +22,8 @@ module.exports = {
   entry: './config.app.js',
   output: {
     path: path.join(__dirname, '/dist'),
-    filename: 'config.js'
+    filename: 'config.js',
+    library: 'config'
   },
   module: {
     loaders: [


### PR DESCRIPTION
Ping @jh-bate for review. Just an oversight after I ended up creating a new webpack config for just the config bundle with the updates work.