### PR TITLE
point to the correct of app/main.(prod.)js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,8 +19,7 @@ var defineEnvPlugin = new webpack.DefinePlugin({
 });
 
 var plugins = [ defineEnvPlugin, new ExtractTextPlugin('style.[contenthash].css') ];
-var appEntry = './app/main.js';
-var entryScripts = ['babel-polyfill', appEntry];
+var entryScripts = ['babel-polyfill', './app/main.prod.js'];
 var loaders = [
   // the JSX in tideline needs transpiling
   {test: /node_modules\/tideline\/.*\.js$/, exclude: /tideline\/node_modules/, loader: 'babel-loader'},
@@ -47,7 +46,7 @@ if (isDev) {
     'babel-polyfill',
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',
-    appEntry
+    './app/main.js'
   ];
 
   loaders.push({test: /\.less$/, loaders: ['style-loader', 'css-loader', 'less-loader']});


### PR DESCRIPTION
Looks like 'app.js' was being used for both dev and prod for a while, and it was only when I separated out the config bundling that it surfaced as a problem...somehow.

As discussed with @darinkrauss, in the near future (possibly on the 🛩 tomorrow) I'll try to do the hour or so work it would take to cleanly separate the dev and prod webpack configs (as I've seen in quite a few React app boilerplates) so that it's easier to read and something like this doesn't happen again.

Ping @darinkrauss for review?