### PR TITLE
add local node_modules as root resolve path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,8 +65,14 @@ module.exports = {
   // tideline DEV env variable only needs to be true in tideline local dev
   plugins: plugins,
   // resolves tideline's embedded React dependencies
-  resolve: { fallback: path.join(__dirname, 'node_modules') },
-  resolveLoader: { fallback: path.join(__dirname, 'node_modules') },
+  resolve: {
+    root: path.resolve('./node_modules'),
+    fallback: path.join(__dirname, 'node_modules'),
+  },
+  resolveLoader: {
+    root: path.resolve('./node_modules'),
+    fallback: path.join(__dirname, 'node_modules'),
+  },
   devServer: {
     publicPath: output.publicPath,
     hot: true,


### PR DESCRIPTION
So the problem that we were having was that dependencies in the resolve tree were defaulting to their own local node_modules directory first (since that's the way that the resolver generally works). By setting the reaolver.root property, we tell webpack that it should check blip's node_modules before anything else, so if a dependency can be resolved locally, it is. We can also use resolver.alias in order to do one-by-one resolutions, but unless I'm mistaken, we'd prefer to have any dependency that's available in blip to be the one that's used.