### PR TITLE
grab last settings instead of first

### DIFF
--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -95,13 +95,13 @@ var Settings = React.createClass({
     const settings = this.props.patientData.grouped.pumpSettings;
 
     const SettingsChart = ChartFactory.getChart(
-      _.get(settings, ['0','source']),
+      _.get(_.last(settings), 'source'),
     );
 
     if (SettingsChart){
       return (
         <SettingsChart
-          pumpSettings={_.get(settings, ['0'])}
+          pumpSettings={_.last(settings)}
           bgUnits={this.props.bgPrefs.bgUnits}
           timePrefs={this.props.timePrefs}
         />


### PR DESCRIPTION
The grouped patientData is sorted by date ascending, so the first index will be the earliest available. We want the latest available instead.