### PR TITLE
get rid of all screwing around with 'user-select' property

### DIFF
--- a/app/components/chart/settings.less
+++ b/app/components/chart/settings.less
@@ -1,3 +1,0 @@
-#tidelineSettings {
-  user-select: all;
-}

--- a/app/core/less/scaffolding.less
+++ b/app/core/less/scaffolding.less
@@ -39,7 +39,6 @@ body {
   line-height: @line-height-base;
   color: @text-color;
   background-color: @body-bg;
-  user-select: none;
 }
 
 // Make form elements use body font styles

--- a/app/pages/login/login.less
+++ b/app/pages/login/login.less
@@ -15,7 +15,6 @@
 
 .login-form {
   margin-bottom: @spacing-large;
-  user-select: all;
 
   .input-group-checkbox-label {
     font-size: 14px;

--- a/app/pages/patient/patient.less
+++ b/app/pages/patient/patient.less
@@ -103,7 +103,6 @@
 
 .PatientPage-teamSection {
   padding-top: 10px;
-  user-select: all;
 }
 
 // Patient delete

--- a/app/style.less
+++ b/app/style.less
@@ -30,7 +30,6 @@
 @import "components/modaloverlay/modaloverlay.less";
 @import "components/datepicker/datepicker.less";
 @import "components/waitlist/waitlist.less";
-@import "components/chart/settings.less";
 @import "components/chart/modalsubnav.less";
 @import "components/browserwarning/browserwarning.less";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "install-selenium": "./node_modules/selenium-standalone/bin/selenium-standalone install --version=2.53.0"
   },
   "dependencies": {
-    "@tidepool/viz": "0.2.14",
+    "@tidepool/viz": "0.2.15",
     "async": "1.5.2",
     "babel-core": "6.13.2",
     "babel-loader": "6.2.5",


### PR DESCRIPTION
What it says on the tin 😆

In response to a user support request, this restores the ability to select & copy text from device settings.

When [viz #27](https://github.com/tidepool-org/viz/pull/27) is approved and published to npm, this branch should get the updated version in the package.json.