### PR TITLE
persist state of open/collapsed basal schedules (or settings profiles, for Tandem devices)

### DIFF
--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -99,8 +99,9 @@ var Settings = React.createClass({
     if (SettingsChart){
       return (
         <SettingsChart
-          pumpSettings={_.last(settings)}
+          currentPatientInViewId={this.props.currentPatientInViewId}
           bgUnits={this.props.bgPrefs.bgUnits}
+          pumpSettings={_.last(settings)}
           timePrefs={this.props.timePrefs}
         />
       );

--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -90,9 +90,7 @@ var Settings = React.createClass({
       );
   },
   renderChart: function() {
-
-    const allSettings = this.props.patientData.grouped.pumpSettings;
-    const mostRecentSettings = _.last(allSettings);
+    const mostRecentSettings = _.last(this.props.patientData.grouped.pumpSettings);
 
     return (
       <PumpSettingsContainer
@@ -103,7 +101,6 @@ var Settings = React.createClass({
         timePrefs={this.props.timePrefs}
       />
     );
-
   },
   renderMissingSettingsMessage: function() {
     var self = this;

--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -22,7 +22,8 @@ import ReactDOM from 'react-dom';
 
 import utils from '../../core/utils';
 
-import { getSettingsComponent } from '@tidepool/viz';
+import * as viz from '@tidepool/viz';
+const PumpSettingsContainer = viz.containers.PumpSettingsContainer;
 
 import Header from './header';
 import Footer from './footer';
@@ -90,22 +91,18 @@ var Settings = React.createClass({
   },
   renderChart: function() {
 
-    const settings = this.props.patientData.grouped.pumpSettings;
+    const allSettings = this.props.patientData.grouped.pumpSettings;
+    const mostRecentSettings = _.last(allSettings);
 
-    const SettingsChart = getSettingsComponent(
-      _.get(_.last(settings), 'source'),
+    return (
+      <PumpSettingsContainer
+        currentPatientInViewId={this.props.currentPatientInViewId}
+        bgUnits={this.props.bgPrefs.bgUnits}
+        manufacturerKey={_.get(mostRecentSettings, 'source').toLowerCase()}
+        pumpSettings={mostRecentSettings}
+        timePrefs={this.props.timePrefs}
+      />
     );
-
-    if (SettingsChart){
-      return (
-        <SettingsChart
-          currentPatientInViewId={this.props.currentPatientInViewId}
-          bgUnits={this.props.bgPrefs.bgUnits}
-          pumpSettings={_.last(settings)}
-          timePrefs={this.props.timePrefs}
-        />
-      );
-    }
 
   },
   renderMissingSettingsMessage: function() {

--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -22,10 +22,7 @@ import ReactDOM from 'react-dom';
 
 import utils from '../../core/utils';
 
-import * as viz from '@tidepool/viz';
-
-const ChartFactory = viz.components.SettingsFactory;
-
+import { getSettingsComponent } from '@tidepool/viz';
 
 import Header from './header';
 import Footer from './footer';
@@ -95,7 +92,7 @@ var Settings = React.createClass({
 
     const settings = this.props.patientData.grouped.pumpSettings;
 
-    const SettingsChart = ChartFactory.getChart(
+    const SettingsChart = getSettingsComponent(
       _.get(_.last(settings), 'source'),
     );
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -321,6 +321,7 @@ export let PatientData = React.createClass({
           <Settings
             bgPrefs={this.state.bgPrefs}
             chartPrefs={this.state.chartPrefs}
+            currentPatientInViewId={this.props.currentPatientInViewId}
             timePrefs={this.state.timePrefs}
             patientData={this.state.processedPatientData}
             onClickRefresh={this.handleClickRefresh}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "install-selenium": "./node_modules/selenium-standalone/bin/selenium-standalone install --version=2.53.0"
   },
   "dependencies": {
-    "@tidepool/viz": "0.2.18-alpha",
+    "@tidepool/viz": "0.2.20",
     "async": "1.5.2",
     "babel-core": "6.13.2",
     "babel-loader": "6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.13",
+  "version": "0.14.14",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "install-selenium": "./node_modules/selenium-standalone/bin/selenium-standalone install --version=2.53.0"
   },
   "dependencies": {
-    "@tidepool/viz": "0.2.17",
+    "@tidepool/viz": "0.2.18-alpha",
     "async": "1.5.2",
     "babel-core": "6.13.2",
     "babel-loader": "6.2.5",

--- a/test/unit/components/chart/settings.test.js
+++ b/test/unit/components/chart/settings.test.js
@@ -10,20 +10,11 @@ var TestUtils = require('react-addons-test-utils');
 var _ = require('lodash');
 var expect = chai.expect;
 
+const renderer = TestUtils.createRenderer();
+
 import Settings from '../../../../app/components/chart/settings';
 
 describe('Settings', function () {
-  before(() => {
-    Settings.__Rewire__('SettingsChart', React.createClass({
-      render: function() {
-        return (<div className='fake-settings-view'></div>);
-      }
-    }));
-  });
-
-  after(() => {
-    Settings.__ResetDependency__('SettingsChart');
-  });
 
   describe('render', function() {
     it('should render without problems', function () {
@@ -45,8 +36,9 @@ describe('Settings', function () {
         uploadUrl: ''
       };
       var settingsElem = React.createElement(Settings, props);
-      var elem = TestUtils.renderIntoDocument(settingsElem);
-      expect(elem).to.be.ok;
+      var elem = renderer.render(settingsElem);
+      var result = renderer.getRenderOutput();
+      expect(result).to.be.ok;
     });
 
     it('should render with missing data message when no pumpSettings data supplied', function () {


### PR DESCRIPTION
Companion branch to [viz #31](https://github.com/tidepool-org/viz/pull/31), nothing huge to comment on here, should be fairly self-explanatory I think.
