### PR TITLE
Temp fix for Webpack image issue

### DIFF
--- a/app/components/uploaderbutton/uploaderbutton.js
+++ b/app/components/uploaderbutton/uploaderbutton.js
@@ -16,9 +16,16 @@
 
 import React, { Component } from 'react'
 
-import logoSrc from './images/T-logo-dark-512x512.png';
+import logoPath from './images/T-logo-dark-512x512.png';
 
 const UploaderButton = (props) => {
+  // fixes issue where local and remote server environments handle import differently,
+  // either including (for local) or excluding (for dev/staging/production) protocol and hostname in path
+  let logoSrc = logoPath;
+  if (logoSrc.slice(0,4) !== 'http') {
+    logoSrc = '/' + logoPath;
+  }
+
   return (
     <div>
       <a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.15",
+  "version": "0.14.17",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
Local environment looks like 
![image](https://cloud.githubusercontent.com/assets/434672/20199306/94a9ec3c-a777-11e6-9bb6-8110e5d75aa1.png)

Dev environment looks like 
![image](https://cloud.githubusercontent.com/assets/434672/20199310/9b32ee1e-a777-11e6-98a0-4ec8d4053fe5.png)

Problem is that locally it includes the protocol, hostname, and root path, but on dev it doesn't. So, the image path goes from http://localhost:3000/0f0318e861c4012eb735c227401ebad9.png to https://dev-blip.tidepool.org/patients/<PATIENT_HASH>/0f0318e861c4012eb735c227401ebad9.png