### PR TITLE
Patient card interactions

### DIFF
--- a/app/components/patientcard/patientcard.js
+++ b/app/components/patientcard/patientcard.js
@@ -58,13 +58,12 @@ var PatientCard = React.createClass({
 
     return (
       <div>
-        <div onMouseEnter={this.setHighlight('view')} onMouseLeave={this.setHighlight('')} className={classes}
-          onClick={this.onClick}>
-          <Link className="patientcard-icon" to={this.props.href} onClick={self.handleViewClick}>
+        <div className={classes} onClick={this.onClick}>
+          <Link className="patientcard-icon" to={this.props.href} onMouseEnter={this.setHighlight('view')} onMouseLeave={this.setHighlight('')} onClick={self.handleViewClick}>
             <i className="Navbar-icon icon-face-standin"></i>
           </Link>
           <div className="patientcard-info">
-            <Link className="patientcard-fullname-link" to={this.props.href} onClick={self.handleViewClick}>
+            <Link className="patientcard-fullname-link" to={this.props.href} onMouseEnter={this.setHighlight('view')} onMouseLeave={this.setHighlight('')} onClick={self.handleViewClick}>
               <div className="patientcard-fullname" title={this.getFullName()}>{this.getFullName()} {profile}</div>
             </Link>
             <div className="patientcard-actions">

--- a/app/components/patientcard/patientcard.js
+++ b/app/components/patientcard/patientcard.js
@@ -287,7 +287,6 @@ var PatientCard = React.createClass({
 
   handleViewClick: function() {
     this.props.trackMetric('Clicked VDF View Data');
-    this.props.onClick();
   },
 });
 

--- a/app/components/patientcard/patientcard.js
+++ b/app/components/patientcard/patientcard.js
@@ -56,14 +56,17 @@ var PatientCard = React.createClass({
     var share = this.renderShare(patient);
     var profile = this.renderProfile(patient);
 
-    
     return (
       <div>
         <div onMouseEnter={this.setHighlight('view')} onMouseLeave={this.setHighlight('')} className={classes}
           onClick={this.onClick}>
-          <i className="Navbar-icon icon-face-standin"></i>
+          <Link className="patientcard-icon" to={this.props.href} onClick={self.handleViewClick}>
+            <i className="Navbar-icon icon-face-standin"></i>
+          </Link>
           <div className="patientcard-info">
-            <div className="patientcard-fullname" title={this.getFullName()}>{this.getFullName()} {profile}</div>
+            <Link className="patientcard-fullname-link" to={this.props.href} onClick={self.handleViewClick}>
+              <div className="patientcard-fullname" title={this.getFullName()}>{this.getFullName()} {profile}</div>
+            </Link>
             <div className="patientcard-actions">
               {view}
               {share}
@@ -88,14 +91,10 @@ var PatientCard = React.createClass({
     });
 
     var self = this;
-    var handleClick = function(e) {
-      self.props.trackMetric('Clicked VDF View Data');
-      self.props.onClick();
-    };
 
     return (
       
-      <Link className={classes} to={this.props.href} onClick={handleClick}>View</Link>
+      <Link className={classes} to={this.props.href} onClick={self.handleViewClick}>View</Link>
       
     );
   },
@@ -284,7 +283,12 @@ var PatientCard = React.createClass({
 
   onClick: function() {
     this.props.onClick();
-  }
+  },
+
+  handleViewClick: function() {
+    this.props.trackMetric('Clicked VDF View Data');
+    this.props.onClick();
+  },
 });
 
 module.exports = PatientCard;

--- a/app/components/patientcard/patientcard.js
+++ b/app/components/patientcard/patientcard.js
@@ -131,6 +131,7 @@ var PatientCard = React.createClass({
 
   renderRemove: function(patient) {
     var classes = cx({
+      'patientcard-actions-remove': true,
       'patientcard-actions--highlight': this.state.highlight === 'remove'
     });
 

--- a/app/components/patientcard/patientcard.less
+++ b/app/components/patientcard/patientcard.less
@@ -69,6 +69,11 @@
     height: 33px;
   }
 
+  > a.patientcard-icon {
+    width: auto;
+    height: auto;
+  }
+
   .icon-face-standin {
     font-size: 45px;
     width: 65px;
@@ -87,6 +92,10 @@
   max-width: 210px;
   color: @gray-dark;
   font-style: normal;
+}
+
+.patientcard-fullname-link:hover {
+  text-decoration: none;
 }
 
 .patientcard-leave {

--- a/app/components/patientcard/patientcard.less
+++ b/app/components/patientcard/patientcard.less
@@ -18,8 +18,6 @@
 }
 
 .patient-list-item {
-  cursor: pointer;
-
   .no-touch &:hover,
   &:focus,
   &:active {
@@ -180,7 +178,6 @@ a.patientcard {
 
 .patientcard-actions--highlight {
   color: @blue-green !important;
-  text-decoration: none;
 
   .patientcard-fullname {
     color: @blue-green;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/components/patientcard.test.js
+++ b/test/unit/components/patientcard.test.js
@@ -51,16 +51,16 @@ describe('PatientCard', function () {
 
     it('should render a patientcard-leave with delete icon and title text', function() {
       var patientCardLeave = renderedDOMElem.querySelectorAll('.patientcard-leave');
-      var leaveLink = renderedDOMElem.querySelectorAll('a');
+      var leaveLink = renderedDOMElem.querySelector('a.patientcard-actions-remove');
       var deleteIcon = renderedDOMElem.querySelectorAll('.icon-delete');
       expect(patientCardLeave.length).to.equal(1);
       expect(deleteIcon.length).to.equal(1);
-      expect(leaveLink[1].title).to.equal('Remove yourself from Jane Doe\'s care team.');
+      expect(leaveLink.title).to.equal('Remove yourself from Jane Doe\'s care team.');
     });
 
     it('should render a confirmation overlay when you click to remove yourself from a care team', function() {
-      var leaveLink = renderedDOMElem.querySelectorAll('a');
-      TestUtils.Simulate.click(leaveLink[1]);
+      var leaveLink = renderedDOMElem.querySelector('a.patientcard-actions-remove');
+      TestUtils.Simulate.click(leaveLink);
       var overlay = renderedDOMElem.querySelectorAll('.ModalOverlay-content');
       expect(overlay.length).to.equal(1);
     });


### PR DESCRIPTION
Updates the `Patient Card` component to better align visual affordances (i.e., "View" link appearance changes when entire card was hovered hovered over, but wasn't clickable) with real interactions:
 - Patient avatar icon now clicks to "View" page
 - Patient full name also clicks to "View" page
 - Hovering over either of these highlights/activates "View" link hover state
 - Pointer cursor removed from `.patient-list-item`, since the entire area is not interactive

Also updated CSS and unit test to support these changes. See [Trello card](https://trello.com/c/LNsakXUO) for more info.

/cc: @krystophv @jebeck @jh-bate