### PR TITLE
Add metric tracking to Blip Notes link

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -177,6 +177,9 @@ export let PatientData = React.createClass({
     var handleClickUpload = function() {
       self.props.trackMetric('Clicked No Data Upload');
     };
+    var handleClickBlipNotes = function() {
+      self.props.trackMetric('Clicked No Data Get Blip Notes');
+    };
 
     if (this.props.isUserPatient) {
       content = (
@@ -186,7 +189,7 @@ export let PatientData = React.createClass({
             buttonUrl={URL_UPLOADER_CHROME_STORE}
             onClick={handleClickUpload}
             buttonText='Get the Tidepool Uploader' />
-          <p>To upload Dexcom with iPhone get <a href={URL_BLIP_NOTES_APP_STORE} className="uploader-color-override" target="_blank">Blip Notes</a></p>
+          <p>To upload Dexcom with iPhone get <a href={URL_BLIP_NOTES_APP_STORE} className="uploader-color-override" target="_blank" onClick={handleClickBlipNotes}>Blip Notes</a></p>
           <p className="patient-no-data-help">
             Already uploaded? <a href="" className="uploader-color-override" onClick={this.handleClickNoDataRefresh}>Click to reload.</a><br />
             <b>Need help?</b> Email us at <a className="uploader-color-override" href="mailto:support@tidepool.org">support@tidepool.org</a> or visit our <a className="uploader-color-override" href="http://support.tidepool.org/">help page</a>.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.18",
+  "version": "0.14.20",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -6,6 +6,7 @@
 /* global after */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
 
@@ -302,6 +303,88 @@ describe('PatientData', function () {
 
           var x = TestUtils.findRenderedDOMComponentWithClass(elem, 'patient-data-uploader-message');
           expect(x).to.be.ok;
+        });
+
+        it('should track click on main upload button', function() {
+          var props = {
+            currentPatientInViewId: 40,
+            isUserPatient: true,
+            patient: {
+              userid: 40,
+              profile: {
+                fullName: 'Fooey McBar'
+              }
+            },
+            fetchingPatient: false,
+            fetchingPatientData: false,
+            trackMetric: sinon.stub()
+          };
+
+          var elem = TestUtils.renderIntoDocument(<PatientData {...props}/>);
+          // bypass the actual processing function since that's not what we're testing here!
+          elem.doProcessing = () => {
+            elem.setState({
+              processedPatientData: {data: []},
+              processingData: false
+            });
+          }
+          elem.componentWillReceiveProps({
+            patientDataMap: {
+              40: []
+            },
+            patientNotesMap: {
+              40: []
+            }
+          });
+
+          var renderedDOMElem = ReactDOM.findDOMNode(elem);
+          var links = renderedDOMElem.querySelectorAll('.patient-data-uploader-message a');
+
+          var callCount = props.trackMetric.callCount;
+          TestUtils.Simulate.click(links[0]);
+          expect(props.trackMetric.callCount).to.equal(callCount + 1);
+          expect(props.trackMetric.calledWith('Clicked No Data Upload')).to.be.true;
+        });
+
+        it('should track click on Blip Notes link', function() {
+          var props = {
+            currentPatientInViewId: 40,
+            isUserPatient: true,
+            patient: {
+              userid: 40,
+              profile: {
+                fullName: 'Fooey McBar'
+              }
+            },
+            fetchingPatient: false,
+            fetchingPatientData: false,
+            trackMetric: sinon.stub()
+          };
+
+          var elem = TestUtils.renderIntoDocument(<PatientData {...props}/>);
+          // bypass the actual processing function since that's not what we're testing here!
+          elem.doProcessing = () => {
+            elem.setState({
+              processedPatientData: {data: []},
+              processingData: false
+            });
+          }
+          elem.componentWillReceiveProps({
+            patientDataMap: {
+              40: []
+            },
+            patientNotesMap: {
+              40: []
+            }
+          });
+
+          var renderedDOMElem = ReactDOM.findDOMNode(elem);
+          var links = renderedDOMElem.querySelectorAll('.patient-data-uploader-message a');
+
+          var callCount = props.trackMetric.callCount;
+          TestUtils.Simulate.click(links[1]);
+          expect(props.trackMetric.callCount).to.equal(callCount + 1);
+          expect(props.trackMetric.calledWith('Clicked No Data Get Blip Notes')).to.be.true;
         });
       });
     });


### PR DESCRIPTION
We neglected to add metric tracking to a new Blip Notes link on the improved main upload button (PR #345), so here it is! See [Trello card](https://trello.com/c/cb5ujwjI/) for more info.

/cc: @krystophv @jebeck @jh-bate