### PR TITLE
perf stuff

### DIFF
--- a/app/redux/containers/Root.dev.js
+++ b/app/redux/containers/Root.dev.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import Perf from 'react-addons-perf';
+window.Perf = Perf;
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "object-invariant-test-helper": "0.1.1",
     "phantomjs-prebuilt": "2.1.12",
     "react-addons-create-fragment": "15.2.1",
+    "react-addons-perf": "15.2.1",
     "react-addons-test-utils": "15.2.1",
     "redux-devtools": "3.3.1",
     "redux-devtools-dock-monitor": "1.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,9 @@ var isDev = (process.env.NODE_ENV === 'development');
 // process.env with webpack, we have to create these magic constants
 // individually.
 var defineEnvPlugin = new webpack.DefinePlugin({
+  'process.env': {
+    'NODE_ENV': isDev ? JSON.stringify('development') : JSON.stringify('production')
+  },
   __UPLOAD_API__: JSON.stringify(process.env.UPLOAD_API || null),
   __API_HOST__: JSON.stringify(process.env.API_HOST || null),
   __INVITE_KEY__: JSON.stringify(process.env.INVITE_KEY || null),


### PR DESCRIPTION
I did it @krystophv!!! 🎉 🎊 🎉

We just weren't using webpack right /o\

This PR also contains the addition of the React Perf addon in dev (attached to `window` so you can use in the console, as described e.g., here: http://benchling.engineering/performance-engineering-with-react/). Sticking it in the redux dev mode `<Root />` component seemed like the easiest way (to me) to keep it out of prod, but LMK if you can think of a cleaner way.

@hntrdglss for context: @krystophv noticed a while ago that we were clearly still using the dev build of React in production because propTypes validation shows up all over any perf profiles...