### PR TITLE
Tideline v0.5.14 - calendar hovers and metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.38",
+  "version": "0.14.39",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.5.13",
+    "tideline": "0.5.14",
     "tidepool-platform-client": "0.27.0",
     "url-loader": "0.5.7",
     "webpack": "1.13.2"


### PR DESCRIPTION
Updates Tideline to v0.5.14, which includes calendar hovers and metrics. See [Trello card](https://trello.com/c/a9tHEqoK/) for more info.