### PR TITLE
track the previous domain (for exit animations) when switching between 1, 2, & 4 weeks

### DIFF
--- a/app/components/chart/modal.js
+++ b/app/components/chart/modal.js
@@ -315,15 +315,16 @@ var Modal = React.createClass({
     }
     var prefs = _.cloneDeep(this.props.chartPrefs);
     // no change, return early
-    if (prefs.activeDomain === '1 week' && prefs.extentSize === 7) {
+    if (prefs.modal.activeDomain === '1 week' && prefs.modal.extentSize === 7) {
       return;
     }
+    var current = new Date(this.chart.getCurrentDay());
+    var oldDomain = this.getNewDomain(current, prefs.modal.extentSize);
     prefs.modal.activeDomain = '1 week';
     prefs.modal.extentSize = 7;
     this.props.updateChartPrefs(prefs);
-    var current = new Date(this.chart.getCurrentDay());
     var newDomain = this.getNewDomain(current, 7);
-    this.chart.setExtent(newDomain);
+    this.chart.setExtent(newDomain, oldDomain);
   },
   handleClickTwoWeeks: function(e) {
     if (e) {
@@ -331,15 +332,16 @@ var Modal = React.createClass({
     }
     var prefs = _.cloneDeep(this.props.chartPrefs);
     // no change, return early
-    if (prefs.activeDomain === '2 weeks' && prefs.extentSize === 14) {
+    if (prefs.modal.activeDomain === '2 weeks' && prefs.modal.extentSize === 14) {
       return;
     }
+    var current = new Date(this.chart.getCurrentDay());
+    var oldDomain = this.getNewDomain(current, prefs.modal.extentSize);
     prefs.modal.activeDomain = '2 weeks';
     prefs.modal.extentSize = 14;
     this.props.updateChartPrefs(prefs);
-    var current = new Date(this.chart.getCurrentDay());
     var newDomain = this.getNewDomain(current, 14);
-    this.chart.setExtent(newDomain);
+    this.chart.setExtent(newDomain, oldDomain);
   },
   handleClickFourWeeks: function(e) {
     if (e) {
@@ -347,15 +349,16 @@ var Modal = React.createClass({
     }
     var prefs = _.cloneDeep(this.props.chartPrefs);
     // no change, return early
-    if (prefs.activeDomain === '4 weeks' && prefs.extentSize === 28) {
+    if (prefs.modal.activeDomain === '4 weeks' && prefs.modal.extentSize === 28) {
       return;
     }
+    var current = new Date(this.chart.getCurrentDay());
+    var oldDomain = this.getNewDomain(current, prefs.modal.extentSize);
     prefs.modal.activeDomain = '4 weeks';
     prefs.modal.extentSize = 28;
     this.props.updateChartPrefs(prefs);
-    var current = new Date(this.chart.getCurrentDay());
     var newDomain = this.getNewDomain(current, 28);
-    this.chart.setExtent(newDomain);
+    this.chart.setExtent(newDomain, oldDomain);
   },
   handleClickWeekly: function(e) {
     if (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.14.43",
+  "version": "0.14.46-alpha",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.3.3",
+    "@tidepool/viz": "0.4.3-alpha",
     "async": "1.5.2",
     "babel-core": "6.13.2",
     "babel-loader": "6.2.5",


### PR DESCRIPTION
What it says on the tin - some documentation/further explanation forthcoming about need to track previous dates shown in order to get expected/desired animation behavior.

Goes with [viz #40](https://github.com/tidepool-org/viz/pull/40).