### PR TITLE
we require the permissions

### DIFF
--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -150,10 +150,9 @@ export const allUsersMap = (state = initialState.allUsersMap, action) => {
         });
       } else {
         newState = update(state, {
-          [patient.userid]: { $set: _.omit(patient, ['permissions', 'team'])}
+          [patient.userid]: { $set: _.omit(patient, ['team'])}
         });
       }
-
       const { team } = patient;
       if (team) {
         let others = {};


### PR DESCRIPTION
@hntrdglss here is what I was seeing and this update now works for me. Below is what I was seeing in the console which lead me to see in both cases we were getting all the data (even though order was different). Then I noticed on the subsequent load the `patient.permissions` were being overridden.

### On initial load of data

```
action @ 10:02:03.536 @@router/UPDATE_LOCATION 
action @ 10:02:03.558 FETCH_USER_REQUEST 
action @ 10:02:03.600 FETCH_PATIENT_REQUEST 
action @ 10:02:03.612 FETCH_PATIENT_DATA_REQUEST 
action @ 10:02:07.657 FETCH_USER_SUCCESS 
action @ 10:02:07.905 FETCH_PATIENT_DATA_SUCCESS 
action @ 10:02:12.766 FETCH_PATIENT_SUCCESS 
```


### On subsequent load of data when you refresh the page

```
action @ 10:03:22.178 FETCH_USER_REQUEST 
action @ 10:03:22.213 FETCH_PATIENT_REQUEST 
action @ 10:03:22.226 FETCH_PATIENT_DATA_REQUEST 
action @ 10:03:28.331 FETCH_USER_SUCCESS 
action @ 10:03:32.398 FETCH_PATIENT_SUCCESS 
action @ 10:03:32.492 FETCH_PATIENT_DATA_SUCCESS 
```