### PR TITLE
bugfix race condition state tree

### DIFF
--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -283,6 +283,7 @@ let getFetchers = (dispatchProps, ownProps, api) => {
 export function mapStateToProps(state) {
   let user = null;
   let patient = null;
+  let permissions = null;
 
   if (state.blip.allUsersMap) {
     if (state.blip.loggedInUserId) {
@@ -290,17 +291,16 @@ export function mapStateToProps(state) {
     }
 
     if (state.blip.currentPatientInViewId) {
-      patient = state.blip.allUsersMap[state.blip.currentPatientInViewId];
-      if (state.blip.targetUserId && state.blip.currentPatientInViewId === state.blip.targetUserId) {
-        const permsOfTargetOnTarget = _.get(
-          state.blip.permissionsOfMembersInTargetCareTeam,
-          state.blip.currentPatientInViewId,
-          null
-        );
-        if (permsOfTargetOnTarget) {
-          patient.permissions = permsOfTargetOnTarget;
-        }
-      }
+      patient = _.get(
+        state.blip.allUsersMap,
+        state.blip.currentPatientInViewId,
+        null
+      );
+      permissions = _.get(
+        state.blip.permissionsOfMembersInTargetCareTeam,
+        state.blip.currentPatientInViewId,
+        {}
+      );
     }
   }
 
@@ -353,7 +353,7 @@ export function mapStateToProps(state) {
     notification: displayNotification,
     termsAccepted: _.get(user, 'termsAccepted', null),
     user: user,
-    patient: patient
+    patient: { permissions, ...patient }
   };
 
 };

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -353,7 +353,7 @@ export function mapStateToProps(state) {
     notification: displayNotification,
     termsAccepted: _.get(user, 'termsAccepted', null),
     user: user,
-    patient: { permissions, ...patient }
+    patient: patient ? { permissions, ...patient } : null,
   };
 
 };

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -49,6 +49,7 @@ export let PatientData = React.createClass({
     fetchers: React.PropTypes.array.isRequired,
     fetchingPatient: React.PropTypes.bool.isRequired,
     fetchingPatientData: React.PropTypes.bool.isRequired,
+    fetchingUser: React.PropTypes.bool.isRequired,
     isUserPatient: React.PropTypes.bool.isRequired,
     messageThread: React.PropTypes.array,
     onCloseMessageThread: React.PropTypes.func.isRequired,
@@ -122,7 +123,7 @@ export let PatientData = React.createClass({
   },
 
   renderPatientData: function() {
-    if (this.props.fetchingPatient || this.props.fetchingPatientData || this.state.processingData) {
+    if (this.props.fetchingUser || this.props.fetchingPatient || this.props.fetchingPatientData || this.state.processingData) {
       return this.renderLoading();
     }
 
@@ -636,6 +637,7 @@ export function mapStateToProps(state) {
     messageThread: state.blip.messageThread,
     fetchingPatient: state.blip.working.fetchingPatient.inProgress,
     fetchingPatientData: state.blip.working.fetchingPatientData.inProgress,
+    fetchingUser: state.blip.working.fetchingUser.inProgress,
     viz: state.viz,
   };
 }

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -616,22 +616,33 @@ let getFetchers = (dispatchProps, ownProps, api) => {
 };
 
 export function mapStateToProps(state) {
-  var user = null;
-  var patient = null;
+  let user = null;
+  let patient = null;
+  let permissions = {};
+
   if (state.blip.allUsersMap){
     if (state.blip.loggedInUserId) {
       user = state.blip.allUsersMap[state.blip.loggedInUserId];
     }
 
     if (state.blip.currentPatientInViewId){
-      patient = state.blip.allUsersMap[state.blip.currentPatientInViewId];
+      patient = _.get(
+        state.blip.allUsersMap,
+        state.blip.currentPatientInViewId,
+        null
+      );
+      permissions = _.get(
+        state.blip.permissionsOfMembersInTargetCareTeam,
+        state.blip.currentPatientInViewId,
+        {}
+      );
     }
   }
 
   return {
     user: user,
     isUserPatient: personUtils.isSame(user, patient),
-    patient: patient,
+    patient: { permissions, ...patient },
     patientDataMap: state.blip.patientDataMap,
     patientNotesMap: state.blip.patientNotesMap,
     messageThread: state.blip.messageThread,

--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -17,6 +17,7 @@ import React from 'react';
 import { browserHistory, Link } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import update from 'react-addons-update';
 
 import * as actions from '../../redux/actions';
 import utils from '../../core/utils';
@@ -372,7 +373,9 @@ export function mapStateToProps(state) {
       patientMap[state.blip.targetUserId] = state.blip.allUsersMap[state.blip.targetUserId];
       // to pass through the permissions of the logged-in user on the target (usually self)
       if (state.blip.permissionsOfMembersInTargetCareTeam[state.blip.targetUserId]) {
-        patientMap[state.blip.targetUserId].permissions = state.blip.permissionsOfMembersInTargetCareTeam[state.blip.targetUserId];
+        patientMap = update(patientMap, {
+          [state.blip.targetUserId]: { $merge: { permissions: state.blip.permissionsOfMembersInTargetCareTeam[state.blip.targetUserId] } }
+        });
       }
     }
 
@@ -383,13 +386,15 @@ export function mapStateToProps(state) {
     }
 
     if (state.blip.membershipPermissionsInOtherCareTeams) {
-      var permissions = state.blip.membershipPermissionsInOtherCareTeams;
-      var keys = Object.keys(state.blip.membershipPermissionsInOtherCareTeams);
+      const permissions = state.blip.membershipPermissionsInOtherCareTeams;
+      const keys = Object.keys(state.blip.membershipPermissionsInOtherCareTeams);
       keys.forEach((key) => {
         if (!patientMap[key]) {
           patientMap[key] = state.blip.allUsersMap[key];
         }
-        patientMap[key].permissions = permissions[key];
+        patientMap = update(patientMap, {
+          [key]: { $merge: { permissions: permissions[key] } }
+        });
       });
     }
   }

--- a/app/pages/share/share.js
+++ b/app/pages/share/share.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import update from 'react-addons-update';
 
 import * as actions from '../../redux/actions';
 
@@ -40,10 +41,12 @@ export function mapStateToProps(state) {
       patient = allUsersMap[currentPatientInViewId];
 
       if (currentPatientInViewId === targetUserId && membersOfTargetCareTeam) {
-        patient.team = [];
+        patient = update(patient, { team: { $set: [] } });
         membersOfTargetCareTeam.forEach((memberId) => {
           let member = allUsersMap[memberId];
-          member.permissions = permissionsOfMembersInTargetCareTeam[memberId];
+          member = update(member, {
+            permissions: { $set: permissionsOfMembersInTargetCareTeam[memberId] },
+          });
           patient.team.push(member);
         });
       }

--- a/app/redux/store/configureStore.dev.js
+++ b/app/redux/store/configureStore.dev.js
@@ -23,6 +23,7 @@ import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
 import { browserHistory } from 'react-router';
 import { syncHistory, routeReducer } from 'react-router-redux';
+import mutationTracker from 'redux-immutable-state-invariant';
 
 import { vizReducer } from '@tidepool/viz';
 
@@ -73,7 +74,8 @@ if (!__DEV_TOOLS__) {
         loggerMiddleware,
         reduxRouterMiddleware,
         createErrorLogger(api),
-        trackingMiddleware(api)
+        trackingMiddleware(api),
+        mutationTracker()
       ),
       DevTools.instrument(),
       // We can persist debug sessions this way

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "redux-devtools": "3.3.1",
     "redux-devtools-dock-monitor": "1.1.1",
     "redux-devtools-log-monitor": "1.0.11",
+    "redux-immutable-state-invariant": "1.2.4",
     "redux-mock-store": "1.1.4",
     "salinity": "0.0.8",
     "selenium-standalone": "5.5.0",

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -2,11 +2,14 @@
 /* global sinon */
 /* global describe */
 /* global it */
+/* global beforeEach */
 
 var React = require('react');
 var createFragment = require('react-addons-create-fragment');
 var _ = require('lodash');
 var TestUtils = require('react-addons-test-utils');
+
+import mutationTracker from 'object-invariant-test-helper';
 
 // Need to add this line as app.js includes config
 // which errors if window.config does not exist
@@ -128,12 +131,22 @@ describe('App',  () => {
   });
 
   describe('mapStateToProps', () => {
+    let tracked;
+
+    beforeEach(() => {
+      tracked = mutationTracker.trackObj(initialState);
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });
 
     describe('initialState [not logged in]', () => {
       const result = mapStateToProps({blip: initialState});
+
+      it('should not mutate state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map isLoggedIn to authenticated', () => {
         expect(result.authenticated).to.equal(initialState.isLoggedIn);
@@ -184,6 +197,11 @@ describe('App',  () => {
           },
           status: 405
         },
+        permissionsOfMembersInTargetCareTeam: {
+          a1b2c3: {
+            view: {},
+          },
+        },
         working: {
           fetchingUser: {inProgress: false},
           fetchingPatient: {inProgress: false, notification: {type: 'error'}},
@@ -191,6 +209,10 @@ describe('App',  () => {
         }
       };
       const result = mapStateToProps({blip: loggedIn});
+
+      it('should not mutate state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map isLoggedIn to authenticated', () => {
         expect(result.authenticated).to.equal(loggedIn.isLoggedIn);

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -247,7 +247,7 @@ describe('App',  () => {
         expect(result.user).to.equal(loggedIn.allUsersMap.a1b2c3);
       });
 
-      it('should retun the current patient in view as patient and empty permissions', () => {
+      it('should return the current patient in view as patient and empty permissions', () => {
         expect(result.patient).to.deep.equal(Object.assign({}, loggedIn.allUsersMap.d4e5f6, { permissions: {} }));
       });
     });

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -225,8 +225,8 @@ describe('App',  () => {
         expect(result.user).to.equal(loggedIn.allUsersMap.a1b2c3);
       });
 
-      it('should retun the current patient in view as patient', () => {
-        expect(result.patient).to.equal(loggedIn.allUsersMap.d4e5f6);
+      it('should retun the current patient in view as patient and empty permissions', () => {
+        expect(result.patient).to.deep.equal(Object.assign({}, loggedIn.allUsersMap.d4e5f6, { permissions: {} }));
       });
     });
   });

--- a/test/unit/pages/emailverification.test.js
+++ b/test/unit/pages/emailverification.test.js
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
+
 var assert = chai.assert;
 var expect = chai.expect;
 
@@ -41,7 +43,14 @@ describe('EmailVerification', function () {
         resendingEmailVerification: {inProgress: true, notification: {type: 'alert', message: 'Hi!'}}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });

--- a/test/unit/pages/login.test.js
+++ b/test/unit/pages/login.test.js
@@ -7,6 +7,7 @@ window.config = {};
 
 import React from'react';
 import TestUtils from'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
 
 import { Login } from'../../../app/pages/login/login.js';
 import { mapStateToProps } from'../../../app/pages/login/login.js';
@@ -44,7 +45,14 @@ describe('Login', function () {
         loggingIn: {inProgress: false, notification: {type: 'alert', message: 'Hi!'}}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });
@@ -75,7 +83,13 @@ describe('Login', function () {
           loggingIn: {inProgress: false, notification: null}
         }
       };
+
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map working.loggingIn.notification to notification', () => {
         expect(result.notification).to.be.null;

--- a/test/unit/pages/passwordreset/confirm.test.js
+++ b/test/unit/pages/passwordreset/confirm.test.js
@@ -7,6 +7,7 @@ window.config = {};
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
 
 import { ConfirmPasswordReset } from '../../../../app/pages/passwordreset/confirm';
 import { mapStateToProps } from '../../../../app/pages/passwordreset/confirm';
@@ -122,7 +123,14 @@ describe('ConfirmPasswordReset', function () {
         confirmingPasswordReset: {inProgress: true, notification: null}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });

--- a/test/unit/pages/passwordreset/request.test.js
+++ b/test/unit/pages/passwordreset/request.test.js
@@ -7,7 +7,7 @@ window.config = {};
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-
+import mutationTracker from 'object-invariant-test-helper';
 
 import { RequestPasswordReset } from '../../../../app/pages/passwordreset/request';
 import { mapStateToProps } from '../../../../app/pages/passwordreset/request';
@@ -82,7 +82,14 @@ describe('RequestPasswordReset', function () {
         requestingPasswordReset: {inProgress: true, notification: {type: 'alert', message: 'Hi!'}}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -482,6 +482,7 @@ describe('PatientData', function () {
             },
             fetchingPatient: false,
             fetchingPatientData: false,
+            fetchingUser: false,
             trackMetric: sinon.stub()
           };
 
@@ -514,9 +515,13 @@ describe('PatientData', function () {
           a1b2c3: [{type: 'message'}]
         },
         messageThread: [{type: 'message'}],
+        permissionsOfMembersInTargetCareTeam: {
+          a1b2c3: { root: { } },
+        },
         working: {
           fetchingPatient: {inProgress: false, notification: null},
-          fetchingPatientData: {inProgress: false, notification: null}
+          fetchingPatientData: {inProgress: false, notification: null},
+          fetchingUser: {inProgress: false, notification: null}
         }
       };
       const result = mapStateToProps({blip: state});
@@ -529,8 +534,8 @@ describe('PatientData', function () {
         expect(result.isUserPatient).to.be.true;
       });
 
-      it('should map allUsersMap.a1b2c3 to patient', () => {
-        expect(result.patient).to.deep.equal(state.allUsersMap.a1b2c3);
+      it('should map allUsersMap.a1b2c3 and permissionsOfMembersInTargetCareTeam.a1b2c3 to patient', () => {
+        expect(result.patient).to.deep.equal(Object.assign({}, state.allUsersMap.a1b2c3, { permissions: state.permissionsOfMembersInTargetCareTeam.a1b2c3 }));
       });
 
       it('should pass through patientDataMap', () => {
@@ -572,10 +577,14 @@ describe('PatientData', function () {
         patientNotesMap: {
           d4e5f6: [{type: 'message'}]
         },
+        permissionsOfMembersInTargetCareTeam: {
+          a1b2c3: { root: { } },
+        },
         messageThread: [{type: 'message'}],
         working: {
           fetchingPatient: {inProgress: false, notification: null},
-          fetchingPatientData: {inProgress: false, notification: null}
+          fetchingPatientData: {inProgress: false, notification: null},
+          fetchingUser: {inProgress: false, notification: null}
         }
       };
       const result = mapStateToProps({blip: state});
@@ -588,8 +597,8 @@ describe('PatientData', function () {
         expect(result.isUserPatient).to.be.false;
       });
 
-      it('should map allUsersMap.d4e5f6 to patient', () => {
-        expect(result.patient).to.deep.equal(state.allUsersMap.d4e5f6);
+      it('should map allUsersMap.d4e5f6 and empty permissions to patient', () => {
+        expect(result.patient).to.deep.equal(Object.assign({}, state.allUsersMap.d4e5f6, { permissions: {} }));
       });
 
       it('should pass through patientDataMap', () => {

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
 
 
 var assert = chai.assert;
@@ -524,7 +525,13 @@ describe('PatientData', function () {
           fetchingUser: {inProgress: false, notification: null}
         }
       };
+
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map allUsersMap.a1b2c3 to user', () => {
         expect(result.user).to.deep.equal(state.allUsersMap.a1b2c3);
@@ -587,7 +594,13 @@ describe('PatientData', function () {
           fetchingUser: {inProgress: false, notification: null}
         }
       };
+
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map allUsersMap.a1b2c3 to user', () => {
         expect(result.user).to.deep.equal(state.allUsersMap.a1b2c3);

--- a/test/unit/pages/patientnew.test.js
+++ b/test/unit/pages/patientnew.test.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-
+import mutationTracker from 'object-invariant-test-helper';
 
 import { PatientNew } from '../../../app/pages/patientnew';
 import { mapStateToProps } from '../../../app/pages/patientnew';
@@ -87,7 +87,14 @@ describe('PatientNew', function () {
         fetchingUser: {inProgress: false}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });

--- a/test/unit/pages/patientprofile.test.js
+++ b/test/unit/pages/patientprofile.test.js
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
+
 var assert = chai.assert;
 var expect = chai.expect;
 
@@ -24,7 +26,13 @@ describe('PatientProfile', () => {
           fetchingUser: {inProgress: false, notification: null}
         }
       };
+
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map allUsersMap.a1b2c3 to user', () => {
         expect(result.user).to.deep.equal(state.allUsersMap.a1b2c3);
@@ -56,7 +64,13 @@ describe('PatientProfile', () => {
           fetchingUser: {inProgress: false, notification: null}
         }
       };
+
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
 
       it('should map allUsersMap.a1b2c3 to user', () => {
         expect(result.user).to.deep.equal(state.allUsersMap.a1b2c3);

--- a/test/unit/pages/patients.test.js
+++ b/test/unit/pages/patients.test.js
@@ -238,7 +238,7 @@ describe('Patients', () => {
         );
 
         expect(result.patients).to.deep.equal([
-          state.allUsersMap.a1b2c3,
+          Object.assign({}, state.allUsersMap.a1b2c3, { permissions: { root: {} } }),
           u1,
           u2
         ]);

--- a/test/unit/pages/patients.test.js
+++ b/test/unit/pages/patients.test.js
@@ -9,6 +9,8 @@ import React from 'react';
 import { browserHistory } from 'react-router';
 import TestUtils from 'react-addons-test-utils';
 
+import mutationTracker from 'object-invariant-test-helper';
+
 var assert = chai.assert;
 var expect = chai.expect;
 
@@ -213,7 +215,13 @@ describe('Patients', () => {
         }
       };
 
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
+
       it('should map loggedInUserId to loggedInUserId', () => {
         expect(result.loggedInUserId).to.equal(state.loggedInUserId);
       });
@@ -281,8 +289,13 @@ describe('Patients', () => {
           fetchingUser: {inProgress: false}
         }
       };
-
+      const tracked = mutationTracker.trackObj(state);
       const result = mapStateToProps({blip: state});
+
+      it('should not mutate the state', () => {
+        expect(mutationTracker.hasMutated(tracked)).to.be.false;
+      });
+
       it('should map loggedInUserId to loggedInUserId', () => {
         expect(result.loggedInUserId).to.equal(state.loggedInUserId);
       });

--- a/test/unit/pages/share.test.js
+++ b/test/unit/pages/share.test.js
@@ -8,6 +8,8 @@ import TestUtils from 'react-addons-test-utils';
 var assert = chai.assert;
 var expect = chai.expect;
 
+import mutationTracker from 'object-invariant-test-helper';
+
 import { mapStateToProps } from '../../../app/pages/share/share';
 
 describe('PatientCareTeam', () => {
@@ -37,7 +39,14 @@ describe('PatientCareTeam', () => {
         settingMemberPermissions: {inProgress: false, notification: null}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });

--- a/test/unit/pages/signup.test.js
+++ b/test/unit/pages/signup.test.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
 
 import { Signup } from '../../../app/pages/signup';
 import { mapStateToProps } from '../../../app/pages/signup';
@@ -112,7 +113,13 @@ describe('Signup', function () {
         }
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
 
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);

--- a/test/unit/pages/terms.test.js
+++ b/test/unit/pages/terms.test.js
@@ -6,9 +6,12 @@
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
+
+var assert = chai.assert;
 var expect = chai.expect;
 
-import { Terms } from '../../../app/pages/terms';
+import { Terms, mapStateToProps } from '../../../app/pages/terms';
 
 describe('Terms', () => {
 
@@ -249,6 +252,37 @@ describe('Terms', () => {
         // still not accepted
         expect(termsElem.state.agreed).to.equal(false);
       });
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const state = {
+      allUsersMap: {
+        a1b2c3: {
+          termsAccepted: '2017-01-01T00:00:00.000Z',
+        },
+      },
+      isLoggedIn: true,
+      loggedInUserId: 'a1b2c3',
+    };
+
+    const tracked = mutationTracker.trackObj(state);
+    const result = mapStateToProps({blip: state});
+
+    it('should be a function', () => {
+      assert.isFunction(mapStateToProps);
+    });
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
+    it('should map allUsersMap.a1b2c3.termsAccepted to termsAccepted', () => {
+      expect(result.termsAccepted).to.equal(state.allUsersMap.a1b2c3.termsAccepted);
+    });
+
+    it('should map isLoggedIn to authenticated', () => {
+      expect(result.authenticated).to.equal(state.isLoggedIn);
     });
   });
 });

--- a/test/unit/pages/userprofile.test.js
+++ b/test/unit/pages/userprofile.test.js
@@ -7,6 +7,8 @@ window.config = {};
 
 var React = require('react');
 var TestUtils = require('react-addons-test-utils');
+import mutationTracker from 'object-invariant-test-helper';
+
 var expect = chai.expect;
 
 var UserProfile = require('../../../app/pages/userprofile').UserProfile;
@@ -85,7 +87,13 @@ describe('UserProfile', function () {
         fetchingUser: {inProgress: false}
       }
     };
+
+    const tracked = mutationTracker.trackObj(state);
     const result = mapStateToProps({blip: state});
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
 
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);

--- a/test/unit/pages/verificationwithpassword.test.js
+++ b/test/unit/pages/verificationwithpassword.test.js
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import mutationTracker from 'object-invariant-test-helper';
+
 var assert = chai.assert;
 var expect = chai.expect;
 import * as errorMessages from '../../../app/redux/constants/errorMessages';
@@ -188,15 +190,20 @@ describe('VerificationWithPassword', () => {
       }
     };
 
+    const tracked = mutationTracker.trackObj(state);
+    const result = mapStateToProps(state);
+
+    it('should not mutate the state', () => {
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
     it('should be a function', () => {
       assert.isFunction(mapStateToProps);
     });
 
     it('should return object with notification and working populated', () => {
-      let mapped = mapStateToProps(state);
-
-      expect(mapped.notification).to.equal(state.blip.working.verifyingCustodial.notification);
-      expect(mapped.working).to.equal(state.blip.working.verifyingCustodial.inProgress);
+      expect(result.notification).to.equal(state.blip.working.verifyingCustodial.notification);
+      expect(result.working).to.equal(state.blip.working.verifyingCustodial.inProgress);
     });
   });
 


### PR DESCRIPTION
A fix that gets more to the root of the problem than #390 

As discussed @jh-bate I have a bit more to add on this:
- [x] fixing (if they fail)/adding some regression tests
- [x] a bit more state tree reorg re: patient settings

But please try it and see if it solves the issue for you!

Fuller explanation of this bug:

@jh-bate discovered a bug where blip was crashing on some accounts he had in the situation where of the three requests made when hard refreshing (w/remember me) on the data view route (/patients/:id/data) route, the fetch patient (profile, etc.) and fetch patient data requests were coming back prior to the fetch *user* request. This is pretty unusual and I'd guess is connected to very little data being present in the accounts in question. (That doesn't explain why the fetch patient is beating the fetch user request back, but `¯\_(ツ)_/¯`.)

The patient data view renders the loading GIF until both `fetchingPatient` and `fetchingPatientData` are `false`; it was assuming that `fetchingUser` was already complete. So the first step (eb0df6d7cb8fa1b57dcbf8e033e3cc82aee46cf8) was to add a check against `fetchingUser` as well. But this just...delayed the crash until after `fetchingUser` came back. So the next step was to actually figure out the crash.

The crash occurred when trying to access `permissions` on the `patient` object passed through to the Basics code (to determine whether or not the choice of site change source could be persisted). Very long story (and much debugging over Hangouts between @jebeck and @jh-bate) short, it was discovered that `permissions` looked accessible (via the state logged in the console with redux-logger) but were actually **not**, always, because we were incorrectly mutating the redux store's state directly in both app.js and patientdata.js's `mapStateToProps` function, so we had our state mutating out from under us in a way that in this case with the combination of requests coming back in an odd order and the timing of the mutation resulted in no `permissions` being available. 17cf03129d8e12e6ac4b41eca059546607f82875 solves this issue by properly creating fresh `patient` objects (including `permissions` extracted from the `membershipPermissionsInOtherCareTeams` branch of the state tree where they are stored) to pass down as props as the API of the lower components in the tree requires.

The remaining commits in this PR fix and add regression tests, checking for mutation in `mapStateToProps` using our `object-invariant-test-helper` that we already use to check for mutation in our reducer tests (for complex array or object branches of the state tree). I also dropped in the `redux-immutable-state-invariant` (the project our own `object-invariant-test-helper` is based on) in our dev middleware to warn us of any mutations to the redux store state in development (by crashing the app 😮 ). I'll admit I used to think we didn't need this tooling since we test for mutation in our reducers, but my incorrect base assumption here was that the reducers are the only place you might accidentally mutate your redux store state! We may want to move this middleware behind its own flag in the future (but in the meantime just use `export DEV_TOOLS=false` if you need to turn it off) as due to all the deep comparisons it does, it slows down the app *considerably*.

Though @jh-bate discovered this bug on `master` when he pulled in the updates from @hntrdglss's recent site change source setting work, it was **not** related to that work, but rather a combination of an unusual account situation/replicable race condition in the ordering of requests coming back and a *very* old bug dating from our migration to redux for state management in blip.