### PR TITLE
restore VCA ability to change site change source if still custodian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,16 @@
 sudo: required
 language: node_js
 
-services:
-  - docker
-
 node_js:
   - "0.12.7"
   - "stable"
 
-addons:
-  apt:
-    packages:
-    - google-chrome-stable
-    - xvfb
-
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-  - docker-compose up -d
 
 script:
   - "npm run lint"
   - "npm test"
-#  - "npm run nightwatch"
 
 matrix:
   allow_failures:

--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -38,6 +38,7 @@ var Basics = React.createClass({
     timePrefs: React.PropTypes.object.isRequired,
     patient: React.PropTypes.object.isRequired,
     patientData: React.PropTypes.object.isRequired,
+    permsOfLoggedInUser: React.PropTypes.object.isRequired,
     onClickRefresh: React.PropTypes.func.isRequired,
     onClickNoDataRefresh: React.PropTypes.func.isRequired,
     onSwitchToBasics: React.PropTypes.func.isRequired,
@@ -98,6 +99,7 @@ var Basics = React.createClass({
           onSelectDay={this.handleSelectDay}
           patient={this.props.patient}
           patientData={this.props.patientData}
+          permsOfLoggedInUser={this.props.permsOfLoggedInUser}
           timePrefs={this.props.timePrefs}
           updateBasicsData={this.props.updateBasicsData}
           updateBasicsSettings={this.props.updateBasicsSettings}

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -638,7 +638,16 @@ export function mapStateToProps(state) {
         state.blip.currentPatientInViewId,
         {}
       );
-      permsOfLoggedInUser = state.blip.permissionsOfMembersInTargetCareTeam[state.blip.loggedInUserId];
+      // if the logged-in user is viewing own data, we pass through their own permissions as permsOfLoggedInUser
+      if (state.blip.currentPatientInViewId === state.blip.loggedInUserId) {
+        permsOfLoggedInUser = permissions;
+      }
+      // otherwise, we need to pull the perms of the loggedInUser wrt the patient in view from membershipPermissionsInOtherCareTeams
+      else {
+        if (!_.isEmpty(state.blip.membershipPermissionsInOtherCareTeams)) {
+          permsOfLoggedInUser = state.blip.membershipPermissionsInOtherCareTeams[state.blip.currentPatientInViewId];
+        }
+      }
     }
   }
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -235,6 +235,7 @@ export let PatientData = React.createClass({
             timePrefs={this.state.timePrefs}
             patient={this.props.patient}
             patientData={this.state.processedPatientData}
+            permsOfLoggedInUser={this.props.permsOfLoggedInUser}
             onClickRefresh={this.handleClickRefresh}
             onClickNoDataRefresh={this.handleClickNoDataRefresh}
             onSwitchToBasics={this.handleSwitchToBasics}
@@ -619,6 +620,7 @@ export function mapStateToProps(state) {
   let user = null;
   let patient = null;
   let permissions = {};
+  let permsOfLoggedInUser = {};
 
   if (state.blip.allUsersMap){
     if (state.blip.loggedInUserId) {
@@ -636,6 +638,7 @@ export function mapStateToProps(state) {
         state.blip.currentPatientInViewId,
         {}
       );
+      permsOfLoggedInUser = state.blip.permissionsOfMembersInTargetCareTeam[state.blip.loggedInUserId];
     }
   }
 
@@ -645,6 +648,7 @@ export function mapStateToProps(state) {
     patient: { permissions, ...patient },
     patientDataMap: state.blip.patientDataMap,
     patientNotesMap: state.blip.patientNotesMap,
+    permsOfLoggedInUser: permsOfLoggedInUser,
     messageThread: state.blip.messageThread,
     fetchingPatient: state.blip.working.fetchingPatient.inProgress,
     fetchingPatientData: state.blip.working.fetchingPatientData.inProgress,

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -322,6 +322,10 @@ export const membershipPermissionsInOtherCareTeams = (state = initialState.membe
       const { context } = action.payload.acceptedReceivedInvite;
       return update(state, { $merge: { [creatorId]: context }});
     }
+    case types.FETCH_PATIENT_SUCCESS: {
+      const { patient } = action.payload;
+      return update(state, { $set: { [patient.userid]: patient.permissions } });
+    }
     case types.FETCH_PATIENTS_SUCCESS: {
       let permissions = {};
       action.payload.patients.forEach((p) => permissions[p.userid] = p.permissions);

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -553,6 +553,10 @@ describe('PatientData', function () {
         expect(result.patientNotesMap).to.deep.equal(state.patientNotesMap);
       });
 
+      it('should pass through the logged-in user\'s permissions on self as permsOfLoggedInUser', () => {
+        expect(result.permsOfLoggedInUser).to.deep.equal(state.permissionsOfMembersInTargetCareTeam[state.currentPatientInViewId]);
+      });
+
       it('should pass through messageThread', () => {
         expect(result.messageThread).to.deep.equal(state.messageThread);
       });
@@ -583,6 +587,12 @@ describe('PatientData', function () {
         },
         patientNotesMap: {
           d4e5f6: [{type: 'message'}]
+        },
+        membershipPermissionsInOtherCareTeams: {
+          d4e5f6: {
+            note: {},
+            view: {},
+          },
         },
         permissionsOfMembersInTargetCareTeam: {
           a1b2c3: { root: { } },
@@ -620,6 +630,10 @@ describe('PatientData', function () {
 
       it('should pass through patientNotesMap', () => {
         expect(result.patientNotesMap).to.deep.equal(state.patientNotesMap);
+      });
+
+      it('should pass through logged-in user\'s permissions as permsOfLoggedInUser', () => {
+        expect(result.permsOfLoggedInUser).to.deep.equal(state.membershipPermissionsInOtherCareTeams[state.currentPatientInViewId]);
       });
 
       it('should pass through messageThread', () => {

--- a/test/unit/redux/reducers/membershipPermissionsInOtherCareTeams.test.js
+++ b/test/unit/redux/reducers/membershipPermissionsInOtherCareTeams.test.js
@@ -60,6 +60,33 @@ describe('membershipPermissionsInOtherCareTeams', () => {
     });
   });
 
+  describe('fetchPatientSuccess', () => {
+    it('should set the permissions of logged-in user wrt patient', () => {
+      const patient = {
+        userid: 'a1b2c3',
+        permissions: {
+          custodian: {},
+          view: {},
+          upload: {},
+        },
+      };
+
+      const initialStateForTest = {};
+
+      const tracked = mutationTracker.trackObj(initialStateForTest);
+      const action = actions.sync.fetchPatientSuccess(patient);
+
+      const state = reducer(initialStateForTest, action);
+
+      expect(Object.keys(state).length).to.equal(1);
+      expect(Object.keys(state.a1b2c3).length).to.equal(3);
+      expect(state.a1b2c3.custodian).to.exist;
+      expect(state.a1b2c3.view).to.exist;
+      expect(state.a1b2c3.upload).to.exist;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+  });
+
   describe('fetchPatientsSuccess', () => {
     it('should set state to a hash map of permissions in other care teams', () => {
       let patients = [


### PR DESCRIPTION
Changes involved:
- membershipPermissionsInOtherCareTeams reducer handles FETCH_PATIENT_SUCCESS so that hard refresh works
- PatientData extracts permsOfLoggedInUser appropriately depending on whether logged-in user is the patient in view or not and passes it through to the Basics (goes with [tideline PR #306](https://github.com/tidepool-org/tideline/pull/306))
- tests for both of these changes, natch