### PR TITLE
Switch api.user.get from parallel to series

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -212,7 +212,7 @@ api.user.get = function(cb) {
     api.metadata.preferences.get(userId, cb);
   };
 
-  async.parallel({
+  async.series({
     account: getAccount,
     profile: getProfile,
     preferences: getPreferences,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.16.9",
+  "version": "0.17.0",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
Apparently another bug exists on the backend, where multiple metadata calls results in a race condition that causes, in essence, the profile to be knocked out by the preferences fetch. By changing `async.parallel` to `async.series`, we hope that profile will be fetched first, followed by preferences. See https://tidepoolteam.slack.com/archives/eng/p1487964878001211 for more info.