### PR TITLE
remove GET on (so far unused) `preferences` in `api.user.get`

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -208,14 +208,9 @@ api.user.get = function(cb) {
     });
   };
 
-  var getPreferences = function(cb) {
-    api.metadata.preferences.get(userId, cb);
-  };
-
   async.series({
     account: getAccount,
     profile: getProfile,
-    preferences: getPreferences,
   },
   function(err, results) {
     if (err) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -18,7 +18,6 @@ import BrowserWarning from './pages/browserwarning';
 import Terms from './pages/terms';
 import VerificationWithPassword from './pages/verificationwithpassword';
 
-
 import utils from './core/utils';
 import personUtils from './core/personutils';
 
@@ -27,7 +26,7 @@ import actions from './redux/actions';
 /**
  * This function checks if the user is using chrome - if they are not it will redirect
  * the user to a browser warning page
- * 
+ *
  * @param  {Object} nextState
  * @param  {Function} replace
  */
@@ -39,7 +38,6 @@ export const requiresChrome = (utils, next) => (nextState, replace, cb)  => {
     if (next) {
       next(nextState, replace, cb);
     }
-    
   }
 }
 
@@ -161,7 +159,7 @@ export const requireNotVerified = (api, store) => (nextState, replace, cb) => {
       if (err) {
         // we expect a 401 Unauthorized when navigating to /email-verification
         // when not logged in (e.g., in a new tab after initial sign-up)
-        if (err.status === 401) {
+        if (err.status === 401 || err.status === 404) {
           return cb();
         }
         throw new Error('Error getting user at /email-verification');


### PR DESCRIPTION
@jebeck adding this just so we have the details of the latest failure 

### Successful signup redirect

```
GET https://stg-api.tidepool.org/metadata/9f4b514ff4/preferences 404 (Not Found)
GET https://stg-api.tidepool.org/auth/user 401 (Unauthorized)
```

### Failed signup redirect

```
GET https://stg-api.tidepool.org/metadata/372109737a/profile 404 (Not Found)
```

404 from here https://github.com/tidepool-org/blip/blob/master/app/core/api.js#L188

which then causes the exception here 

https://github.com/tidepool-org/blip/blob/master/app/routes.js#L164 
