### PR TITLE
fix display name to be fullname of pwd

### DIFF
--- a/app/components/peopletable/peopletable.js
+++ b/app/components/peopletable/peopletable.js
@@ -76,9 +76,10 @@ class PeopleTable extends React.Component {
       if (bday) {
         bday = ` ${sundial.translateMask(bday, 'YYYY-MM-DD', 'M/D/YYYY')}`;
       }
+
       return {
-        fullName: personUtils.fullName(person),
-        fullNameOrderable: personUtils.fullName(person).toLowerCase(),
+        fullName: personUtils.patientFullName(person),
+        fullNameOrderable: personUtils.patientFullName(person).toLowerCase(),
         link: person.link,
         birthday: bday,
         birthdayOrderable: new Date(bday),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
@jebeck discovered when resolving this "child account" issue https://trello.com/c/NMr0pTEF. We were displaying the account owners name not the associated patient (aka child account) name.

