### PR TITLE
use viz's reshapeBgClassesToBgBounds function

### DIFF
--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -32,6 +32,7 @@ const CBGDateTraceLabel = viz.components.CBGDateTraceLabel;
 const FocusedRangeLabels = viz.components.FocusedRangeLabels;
 const FocusedSMBGPointLabel = viz.components.FocusedSMBGPointLabel;
 const TrendsContainer = viz.containers.TrendsContainer;
+const reshapeBgClassesToBgBounds = viz.utils.reshapeBgClassesToBgBounds;
 
 class Trends extends PureComponent {
   static propTypes = {
@@ -59,13 +60,7 @@ class Trends extends PureComponent {
   constructor(props) {
     super(props);
 
-    const { bgPrefs: { bgClasses } } = props;
-    this.bgBounds = {
-      veryHighThreshold: bgClasses.high.boundary,
-      targetUpperBound: bgClasses.target.boundary,
-      targetLowerBound: bgClasses.low.boundary,
-      veryLowThreshold: bgClasses['very-low'].boundary,
-    };
+    this.bgBounds = reshapeBgClassesToBgBounds(props.bgPrefs);
     this.chartType = 'trends';
     this.log = bows('Trends');
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.5.6",
+    "@tidepool/viz": "0.5.7",
     "async": "1.5.2",
     "autoprefixer": "6.7.2",
     "babel-core": "6.13.2",


### PR DESCRIPTION
What it says on the tin. Since this is such a small change, I figure we can merge whenever and just check that target range is set properly on Trends page in whatever release it goes out with. Lemme know if you disagree @krystophv 