### PR TITLE
updates for blip to be built/run with node v6.x LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _book
 node_modules
 npm-debug.log
 tmp
+deploy
 dist
 config/*
 !config/local.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,18 @@ node_js:
   - "6.10.2"
   - "stable"
 
+addons:
+  artifacts:
+    s3_region: "us-west-2"
+    paths:
+    - $(git ls-files -o deploy/*/*-*.tar.gz | tr "\n" ":")
+    target_paths:
+    - /
+
 script:
   - "npm run lint"
   - "npm test"
+  - "./deploy.sh"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 
 node_js:
   - "6.10.2"
+  - "stable"
 
 script:
   - "npm run lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
-sudo: required
+sudo: false
 language: node_js
 
 node_js:
-  - "0.12.7"
-  - "stable"
-
-before_install:
-  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+  - "6.10.2"
 
 script:
   - "npm run lint"

--- a/deploy-env.sh
+++ b/deploy-env.sh
@@ -1,0 +1,1 @@
+export DEPLOY_NODE_VERSION="6.10.2"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  exit 0
+fi
+
+set -u
+
+source "deploy-env.sh"
+
+if [ "${TRAVIS_NODE_VERSION}" != "${DEPLOY_NODE_VERSION}" ]; then
+  exit 0
+fi
+
+TMP_DIR="/tmp/${TRAVIS_REPO_SLUG}"
+
+DEPLOY="${TRAVIS_REPO_SLUG#tidepool-org/}"
+DEPLOY_DIR="deploy/${DEPLOY}"
+
+DEPLOY_TAG="${DEPLOY}-${TRAVIS_TAG}"
+DEPLOY_TAG_DIR="${DEPLOY_DIR}/${DEPLOY_TAG}"
+
+rm -rf deploy/ "${TMP_DIR}/" || { echo 'ERROR: Unable to delete deploy directories'; exit 1; }
+
+./build.sh || { echo 'ERROR: Unable to build project'; exit 1; }
+
+mkdir -p "${TMP_DIR}/${DEPLOY_TAG_DIR}/" || { echo 'ERROR: Unable to create deploy directory'; exit 1; }
+rsync -a --exclude='.git' . "${TMP_DIR}/${DEPLOY_TAG_DIR}/" || { echo 'ERROR: Unable to copy files for deploy'; exit 1; }
+
+mkdir -p "${DEPLOY_DIR}/" || { echo 'ERROR: Unable to create deploy directory'; exit 1; }
+tar -c -z -f "${DEPLOY_DIR}/${DEPLOY_TAG}.tar.gz" -C "${TMP_DIR}/${DEPLOY_DIR}" "${DEPLOY_TAG}" || { echo 'ERROR: Unable to create deploy artifact'; exit 1; }
+
+rm -rf "${TMP_DIR}/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "0.23.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
     "webpack-dev-server": "1.15.0"
   },
   "engines": {
-    "node": "0.12.x"
+    "node": "6.x"
   }
 }

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,11 @@
 #! /bin/bash -eu
 
+source "${NVM_DIR}/nvm.sh"
+source "deploy-env.sh"
+
+nvm ls "${DEPLOY_NODE_VERSION}" > /dev/null || { echo "ERROR: Node version ${DEPLOY_NODE_VERSION} not installed"; exit 1; }
+nvm use --delete-prefix "${DEPLOY_NODE_VERSION}"
+
 . config/env.sh
 npm run build-config
 exec node server


### PR DESCRIPTION
Ping @jh-bate and @krystophv 

Can you think of anything I missed? Updated .travis.yml and "engines" in the package.json. Didn't look like we mentioned version of node anywhere in README

Not sure if we have `engines` in tideline and viz, but I'll check.