### PR TITLE
Create deploy artifacts via Travis; update start script to use node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _book
 node_modules
 npm-debug.log
 tmp
+deploy
 dist
 config/*
 !config/local.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,18 @@ node_js:
   - "6.10.2"
   - "stable"
 
+addons:
+  artifacts:
+    s3_region: "us-west-2"
+    paths:
+    - $(git ls-files -o deploy/*/*-*.tar.gz | tr "\n" ":")
+    target_paths:
+    - /
+
 script:
   - "npm run lint"
   - "npm test"
+  - "./deploy.sh"
 
 matrix:
   allow_failures:

--- a/deploy-env.sh
+++ b/deploy-env.sh
@@ -1,0 +1,1 @@
+export DEPLOY_NODE_VERSION="6.10.2"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  exit 0
+fi
+
+set -u
+
+source "deploy-env.sh"
+
+if [ "${TRAVIS_NODE_VERSION}" != "${DEPLOY_NODE_VERSION}" ]; then
+  exit 0
+fi
+
+TMP_DIR="/tmp/${TRAVIS_REPO_SLUG}"
+
+DEPLOY="${TRAVIS_REPO_SLUG#tidepool-org/}"
+DEPLOY_DIR="deploy/${DEPLOY}"
+
+DEPLOY_TAG="${DEPLOY}-${TRAVIS_TAG}"
+DEPLOY_TAG_DIR="${DEPLOY_DIR}/${DEPLOY_TAG}"
+
+rm -rf deploy/ "${TMP_DIR}/" || { echo 'ERROR: Unable to delete deploy directories'; exit 1; }
+
+./build.sh || { echo 'ERROR: Unable to build project'; exit 1; }
+
+mkdir -p "${TMP_DIR}/${DEPLOY_TAG_DIR}/" || { echo 'ERROR: Unable to create deploy directory'; exit 1; }
+rsync -a --exclude='.git' . "${TMP_DIR}/${DEPLOY_TAG_DIR}/" || { echo 'ERROR: Unable to copy files for deploy'; exit 1; }
+
+mkdir -p "${DEPLOY_DIR}/" || { echo 'ERROR: Unable to create deploy directory'; exit 1; }
+tar -c -z -f "${DEPLOY_DIR}/${DEPLOY_TAG}.tar.gz" -C "${TMP_DIR}/${DEPLOY_DIR}" "${DEPLOY_TAG}" || { echo 'ERROR: Unable to create deploy artifact'; exit 1; }
+
+rm -rf "${TMP_DIR}/"

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,11 @@
 #! /bin/bash -eu
 
+source "${NVM_DIR}/nvm.sh"
+source "deploy-env.sh"
+
+nvm ls "${DEPLOY_NODE_VERSION}" > /dev/null || { echo "ERROR: Node version ${DEPLOY_NODE_VERSION} not installed"; exit 1; }
+nvm use --delete-prefix "${DEPLOY_NODE_VERSION}"
+
 . config/env.sh
 npm run build-config
 exec node server


### PR DESCRIPTION
@jebeck @jh-bate @pazaan Adds "deploy" process which builds "binary" artifact for later deployment. Update start script to utilize the targeted version of node. Uses shared environment variable to ensure artifact build and deployed execution use same exact version of node.

To move to a new version of node, we will need to: 1) update infrastructure configuration to automatically install new target version (outside of blip); 2) update `travis.yaml` here to include target version (under `node_js:`); and 3) update `deploy-env.sh` to specify target version used to build artifact and run service.