### PR TITLE
Allow clinic role to specified on signup; update platform-client

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -246,7 +246,7 @@ api.user.put = function(user, cb) {
 };
 
 function accountFromUser(user) {
-  var account = _.pick(user, 'username', 'password', 'emails');
+  var account = _.pick(user, 'username', 'password', 'emails', 'roles');
   return account;
 }
 

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -24,7 +24,7 @@ var utils = {};
 
 /**
  * Convenience function for capitalizing a string
- * 
+ *
  * @param  {String} str
  * @return {String}
  */
@@ -104,10 +104,10 @@ utils.objectDifference = (destination, source) => {
 
 /**
  * Utility function to get whether page has changed or not
- * 
+ *
  * @param  {Object} oldProps
  * @param  {[type]} newProps
- * 
+ *
  * @return {Boolean}
  */
 utils.isOnSamePage = (oldProps, newProps) => {
@@ -194,6 +194,21 @@ utils.getInviteKey = function(location) {
     }
   }
   return '';
+}
+
+utils.getRoles = function(location) {
+  if (location && location.query) {
+    let { roles } = location.query;
+
+    if(!_.isEmpty(roles)){
+      let rolesFiltered = _.reject(_.map(roles.split(','), _.trim), _.isEmpty);
+
+      if(!_.isEmpty(rolesFiltered)){
+        return rolesFiltered;
+      }
+    }
+  }
+  return [];
 }
 
 utils.processPatientData = (comp, data, queryParams, settings) => {

--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -36,6 +36,7 @@ export let Signup = React.createClass({
     configuredInviteKey: React.PropTypes.string.isRequired,
     inviteEmail: React.PropTypes.string,
     inviteKey: React.PropTypes.string,
+    roles: React.PropTypes.array,
     notification: React.PropTypes.object,
     onSubmit: React.PropTypes.func.isRequired,
     trackMetric: React.PropTypes.func.isRequired,
@@ -226,6 +227,7 @@ export let Signup = React.createClass({
       username: formValues.username,
       emails: [formValues.username],
       password: formValues.password,
+      roles: this.props.roles,
       profile: {
         fullName: formValues.fullName
       }
@@ -254,6 +256,7 @@ let mergeProps = (stateProps, dispatchProps, ownProps) => {
     configuredInviteKey: config.INVITE_KEY,
     inviteKey: utils.getInviteKey(ownProps.location),
     inviteEmail: utils.getInviteEmail(ownProps.location),
+    roles: utils.getRoles(ownProps.location),
     trackMetric: ownProps.routes[0].trackMetric,
     api: ownProps.routes[0].api,
   });

--- a/app/redux/utils/trackingMiddleware.js
+++ b/app/redux/utils/trackingMiddleware.js
@@ -31,7 +31,7 @@ const trackMetricMap = {
 const interpretMetricMap = {
   SIGNUP_SUCCESS: function(action) {
     let roles = _.get(action, 'payload.user.roles');
-    return { eventName: `Signed Up`, properties: roles ? { roles: roles } : null };
+    return { eventName: 'Signed Up', properties: roles ? { roles: roles } : null };
   },
   TURN_ON_CBG_RANGE: function(action) {
     return { eventName: `Turn on ${action.payload.range}${!_.isNaN(parseInt(action.payload.range, 10)) ? encodeURIComponent('%') : ''}` };

--- a/app/redux/utils/trackingMiddleware.js
+++ b/app/redux/utils/trackingMiddleware.js
@@ -20,7 +20,6 @@ import _ from 'lodash';
 import * as ActionTypes from '../constants/actionTypes';
 
 const trackMetricMap = {
-  SIGNUP_SUCCESS: 'Signed Up',
   LOGIN_SUCCESS: 'Logged In',
   SETUP_DATA_STORAGE_SUCCESS: 'Created Profile',
   UPDATE_PATIENT_SUCCESS: 'Updated Profile',
@@ -30,11 +29,15 @@ const trackMetricMap = {
 };
 
 const interpretMetricMap = {
+  SIGNUP_SUCCESS: function(action) {
+    let roles = _.get(action, 'payload.user.roles');
+    return { eventName: `Signed Up`, properties: roles ? { roles: roles } : null };
+  },
   TURN_ON_CBG_RANGE: function(action) {
-    return `Turn on ${action.payload.range}${!_.isNaN(parseInt(action.payload.range, 10)) ? encodeURIComponent('%') : ''}`;
+    return { eventName: `Turn on ${action.payload.range}${!_.isNaN(parseInt(action.payload.range, 10)) ? encodeURIComponent('%') : ''}` };
   },
   TURN_OFF_CBG_RANGE: function(action) {
-    return `Turn off ${action.payload.range}${!_.isNaN(parseInt(action.payload.range, 10)) ? encodeURIComponent('%') : ''}`;
+    return { eventName: `Turn off ${action.payload.range}${!_.isNaN(parseInt(action.payload.range, 10)) ? encodeURIComponent('%') : ''}` };
   }
 }
 
@@ -44,7 +47,8 @@ export default (api) => {
       api.metrics.track(trackMetricMap[action.type]);
     }
     if (interpretMetricMap[action.type]) {
-      api.metrics.track(interpretMetricMap[action.type](action));
+      let { eventName, properties } = interpretMetricMap[action.type](action)
+      api.metrics.track(eventName, properties);
     }
     return next(action);
   };

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
     "tideline": "0.5.27",
-    "tidepool-platform-client": "0.30.0",
+    "tidepool-platform-client": "0.31.0",
     "url-loader": "0.5.7",
     "webpack": "1.13.2"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.5.7",
+    "@tidepool/viz": "0.5.8",
     "async": "1.5.2",
     "autoprefixer": "6.7.2",
     "babel-core": "6.13.2",
@@ -62,7 +62,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.5.27",
+    "tideline": "0.5.28",
     "tidepool-platform-client": "0.31.0",
     "url-loader": "0.5.7",
     "webpack": "1.13.2"

--- a/test/unit/redux/utils/trackingMiddleware.test.js
+++ b/test/unit/redux/utils/trackingMiddleware.test.js
@@ -55,6 +55,24 @@ describe('trackingMiddleware', () => {
     expect(api.metrics.track.calledWith('Signed Up')).to.be.true;
   });
 
+  it('should call the metrics api for SIGNUP_SUCCESS with roles', () => {
+    const signupSuccess = {
+      type: ActionTypes.SIGNUP_SUCCESS,
+      payload: {
+        user: {
+          roles: ['clinic'],
+          ignored: true
+        },
+        ignored: true
+      },
+      ignored: true
+    };
+    expect(api.metrics.track.callCount).to.equal(0);
+    trackingMiddleware(api)(getStateObj)(next)(signupSuccess);
+    expect(api.metrics.track.callCount).to.equal(1);
+    expect(api.metrics.track.calledWith('Signed Up', { roles: ['clinic'] })).to.be.true;
+  });
+
   it('should call the metrics api for LOGIN_SUCCESS', () => {
     const loginSuccess = {
       type: ActionTypes.LOGIN_SUCCESS

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -155,6 +155,97 @@ describe('utils', function() {
       };
       expect(utils.getSignupEmail(location)).to.equal(null);
     });
-    
+  });
+
+  describe('getInviteKey', function(){
+    it('should return invite key from query property of location object', function(){
+      var location = {
+        query: {
+          inviteKey: '1234567890abcdef'
+        }
+      };
+      expect(utils.getInviteKey(location)).to.equal('1234567890abcdef');
+    });
+
+    it('should return empty string if no location object', function(){
+      expect(utils.getInviteKey()).to.equal('');
+    });
+
+    it('should return empty string if no query property of location object', function(){
+      expect(utils.getInviteKey({})).to.equal('');
+    });
+
+    it('should return empty string if no inviteKey in query property of location object', function(){
+      var location = {
+        query: {
+          signupEmail: 'jane@tidepool.org'
+        }
+      };
+      expect(utils.getInviteKey(location)).to.equal('');
+    });
+  });
+
+  describe('getRoles', function(){
+    it('should return roles from query property of location object', function(){
+      var location = {
+        query: {
+          roles: 'zero'
+        }
+      };
+      expect(utils.getRoles(location)).to.deep.equal(['zero']);
+    });
+
+    it('should return multiple roles from query property of location object', function(){
+      var location = {
+        query: {
+          roles: 'one,two,three'
+        }
+      };
+      expect(utils.getRoles(location)).to.deep.equal(['one', 'two', 'three']);
+    });
+
+    it('should return multiple roles from query property of location object with whitespace removed', function(){
+      var location = {
+        query: {
+          roles: ' ,  ,, four, ,  , five ,,  , ,six,, ,'
+        }
+      };
+      expect(utils.getRoles(location)).to.deep.equal(['four', 'five', 'six']);
+    });
+
+    it('should return empty array if no usable roles in query property of location object', function(){
+      var location = {
+        query: {
+          roles: ' ,  ,,,  , '
+        }
+      };
+      expect(utils.getRoles(location)).to.deep.equal([]);
+    });
+
+    it('should return empty array if empty roles in query property of location object', function(){
+      var location = {
+        query: {
+          roles: ''
+        }
+      };
+      expect(utils.getRoles(location)).to.deep.equal([]);
+    });
+
+    it('should return empty array if no location object', function(){
+      expect(utils.getRoles()).to.deep.equal([]);
+    });
+
+    it('should return empty array if no query property of location object', function(){
+      expect(utils.getRoles({})).to.deep.equal([]);
+    });
+
+    it('should return empty array if no roles in query property of location object', function(){
+      var location = {
+        query: {
+          signupEmail: 'jane@tidepool.org'
+        }
+      };
+      expect(utils.getRoles(location)).to.deep.equal([]);
+    });
   });
 });


### PR DESCRIPTION
@jebeck @jh-bate @krystophv This allows the signup URL to accept a new parameter `roles` (a comma-delimited array of strings, with `clinic` as the only valid value) that will automatically pass that to the create user call on the backend (`platform-client` has already been updated to pass `roles` through). The net result is that by specifying the `roles` parameter on the URL an account can be created that is immediately a VCA.

After this feature (and `shoreline`) is deployed, but prior to the new clinic signup workflow deployment, we will update the signup TypeForm to allow the user to immediately signup (with the `inviteKey` and optional `roles` parameter depending upon how they answer some of the TypeForm questions). There will be a redirect involved (with the redirect service in our infrastructure).