### PR TITLE
Display instructions in People List if not searching or showing all

### DIFF
--- a/app/components/peopletable/peopletable.js
+++ b/app/components/peopletable/peopletable.js
@@ -195,65 +195,90 @@ class PeopleTable extends React.Component {
     this.setState({ currentRowIndex: -1 });
   }
 
-  render() {
-    const { colSortDirs, showNames, searching } = this.state;
+  renderPeopleInstructions() {
     const { containerHeight, containerWidth } = this.props;
-    let { dataList } = this.state;
+
+    return (
+      <div style={{width: containerWidth, height: containerHeight}}>
+        <div>
+          <div className="peopletable-instructions">
+            Type a patient name in the search box or click <a className="peopletable-names-showall" onClick={this.handleToggleShowNames}>Show All</a> to display all patients.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderPeopleTable() {
+    const { colSortDirs, dataList } = this.state;
+    const { containerHeight, containerWidth } = this.props;
+
+    return (
+      <Table
+        rowHeight={40}
+        headerHeight={50}
+        width={containerWidth}
+        height={containerHeight}
+        rowsCount={dataList.length}
+        rowClassNameGetter={this.getRowClassName}
+        onRowClick={this.handleRowClick}
+        onRowMouseEnter={this.handleRowMouseEnter}
+        onRowMouseLeave={this.handleRowMouseLeave}
+        {...this.props}
+      >
+        <Column
+          columnKey="fullNameOrderable"
+          header={
+            <SortHeaderCell
+              onSortChange={this.handleSortChange}
+              sortDir={colSortDirs.fullNameOrderable}
+            >
+              NAME
+            </SortHeaderCell>
+          }
+          cell={<TextCell
+            data={dataList}
+            col="fullName"
+            icon={<i className="peopletable-icon-profile icon-profile"></i>}
+          />}
+          width={320}
+        />
+        <Column
+          columnKey="birthdayOrderable"
+          header={
+            <SortHeaderCell
+              onSortChange={this.handleSortChange}
+              sortDir={colSortDirs.birthdayOrderable}
+            >
+              BIRTHDAY
+            </SortHeaderCell>
+          }
+          cell={<TextCell
+            data={dataList}
+            col="birthday"
+          />}
+          width={560}
+        />
+      </Table>
+    )
+  }
+
+  renderPeopleArea() {
+    const { showNames, searching } = this.state;
 
     if (!showNames && !searching) {
-      dataList = [];
+      return this.renderPeopleInstructions();
+    } else {
+      return this.renderPeopleTable();
     }
+  }
 
+  render() {
     return (
       <div>
         {this.renderSearchBar()}
         {this.renderShowNamesToggle()}
-        <Table
-          rowHeight={40}
-          headerHeight={50}
-          width={containerWidth}
-          height={containerHeight}
-          rowsCount={dataList.length}
-          rowClassNameGetter={this.getRowClassName}
-          onRowClick={this.handleRowClick}
-          onRowMouseEnter={this.handleRowMouseEnter}
-          onRowMouseLeave={this.handleRowMouseLeave}
-          {...this.props}
-        >
-          <Column
-            columnKey="fullNameOrderable"
-            header={
-              <SortHeaderCell
-                onSortChange={this.handleSortChange}
-                sortDir={colSortDirs.fullNameOrderable}
-              >
-                NAME
-              </SortHeaderCell>
-            }
-            cell={<TextCell
-              data={dataList}
-              col="fullName"
-              icon={<i className="peopletable-icon-profile icon-profile"></i>}
-            />}
-            width={320}
-          />
-          <Column
-            columnKey="birthdayOrderable"
-            header={
-              <SortHeaderCell
-                onSortChange={this.handleSortChange}
-                sortDir={colSortDirs.birthdayOrderable}
-              >
-                BIRTHDAY
-              </SortHeaderCell>
-            }
-            cell={<TextCell
-              data={dataList}
-              col="birthday"
-            />}
-            width={560}
-          />
-        </Table>
+        {this.renderPeopleArea()}
       </div>
     );
   }

--- a/app/components/peopletable/peopletable.less
+++ b/app/components/peopletable/peopletable.less
@@ -16,13 +16,7 @@
 @import '../../../node_modules/fixed-data-table-2/dist/fixed-data-table.css';
 
 
-.peopletable-names-toggle {
-  display: flex;
-  flex-direction: row-reverse;
-  border-bottom: 1px solid @gray-light;
-  padding-bottom: @spacing-small;
-  padding-right: @spacing-small + @spacing-base;
-
+.peopletable-names {
   color: @link-alternative-color;
 
   a {
@@ -35,6 +29,20 @@
       color: @link-alternative-hover-color;
     }
   }
+}
+
+.peopletable-names-toggle {
+  &:extend(.peopletable-names);
+
+  display: flex;
+  flex-direction: row-reverse;
+  border-bottom: 1px solid @gray-light;
+  padding-bottom: @spacing-small;
+  padding-right: @spacing-small + @spacing-base;
+}
+
+.peopletable-names-showall {
+  &:extend(.peopletable-names);
 }
 
 .peopletable-search {
@@ -67,6 +75,12 @@
   margin-bottom: @spacing-small;
   padding-left: 55px;
   width: 60%;
+}
+
+.peopletable-instructions {
+  width: 100%;
+  padding-top: 80px;
+  text-align: center;
 }
 
 .peopletable-icon-profile {

--- a/app/pages/patients/patients.js
+++ b/app/pages/patients/patients.js
@@ -335,10 +335,10 @@ export let Patients = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    let { loading, loggedInUserId, patients, invites, location, showingWelcomeMessage } = nextProps;
+    let { loading, loggedInUserId, patients, invites, location, showingWelcomeMessage, user } = nextProps;
 
     if (!loading && loggedInUserId && location.query.justLoggedIn) {
-      if (patients.length === 1 && invites.length === 0) {
+      if (!personUtils.isClinic(user) && patients.length === 1 && invites.length === 0) {
         let patient = patients[0];
         browserHistory.push(`/patients/${patient.userid}/data`);
       } else if (patients.length === 0 && invites.length === 0 && showingWelcomeMessage === null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/components/peopletable.test.js
+++ b/test/unit/components/peopletable.test.js
@@ -98,9 +98,8 @@ describe('PeopleTable', () => {
       expect(wrapper.find('.peopletable-names-toggle')).to.have.length(1);
     });
 
-    it('should have one row of data in the table by default ', function () {
-      //only one row for the header
-      expect(wrapper.find('.public_fixedDataTableRow_main')).to.have.length(1);
+    it('should have instructions displayed by default', function () {
+      expect(wrapper.find('.peopletable-instructions')).to.have.length(1);
     });
 
     it('should default searching and showNames to be false', function () {
@@ -108,6 +107,7 @@ describe('PeopleTable', () => {
       expect(wrapper.state().showNames).to.equal(false);
     });
   });
+
   describe('showNames', function() {
     it('should show a row of data for each person', function () {
       wrapper.find('.peopletable-names-toggle').simulate('click');
@@ -115,18 +115,26 @@ describe('PeopleTable', () => {
       // 5 people plus one row for the header
       expect(wrapper.find('.public_fixedDataTableRow_main')).to.have.length(6);
     });
+
     it('should trigger a call to trackMetric', function () {
       wrapper.find('.peopletable-names-toggle').simulate('click');
       expect(props.trackMetric.calledWith('Clicked Show All')).to.be.true;
       expect(props.trackMetric.callCount).to.equal(1);
     });
+
+    it('should not have instructions displayed', function () {
+      wrapper.find('.peopletable-names-toggle').simulate('click');
+      expect(wrapper.find('.peopletable-instructions')).to.have.length(0);
+    });
   });
+
   describe('searching', function() {
     it('should show a row of data for each person', function () {
       wrapper.setState({ searching: true });
       // 5 people plus one row for the header
       expect(wrapper.find('.public_fixedDataTableRow_main')).to.have.length(6);
     });
+
     it('should show a row of data for each person that matches the search value', function () {
       // showing `amanda` or `Anna`
       wrapper.find('input').simulate('change', {target: {value: 'a'}});
@@ -137,9 +145,15 @@ describe('PeopleTable', () => {
       expect(wrapper.find('.public_fixedDataTableRow_main')).to.have.length(2);
       expect(wrapper.state().searching).to.equal(true);
     });
+
     it('should NOT trigger a call to trackMetric', function () {
       wrapper.find('input').simulate('change', {target: {value: 'am'}});
       expect(props.trackMetric.callCount).to.equal(0);
+    });
+
+    it('should not have instructions displayed', function () {
+      wrapper.find('input').simulate('change', {target: {value: 'a'}});
+      expect(wrapper.find('.peopletable-instructions')).to.have.length(0);
     });
   });
 });

--- a/test/unit/pages/patients.test.js
+++ b/test/unit/pages/patients.test.js
@@ -154,6 +154,30 @@ describe('Patients', () => {
       expect(nextProps.showWelcomeMessage.callCount).to.equal(0);
     });
 
+    it('should not redirect to patient data when justLogged query param is set and only one patient available and no invites, but user is a clinic', () => {
+      var props = {};
+      var elem = React.createElement(Patients, props);
+      var render = TestUtils.renderIntoDocument(elem);
+
+      var nextProps = Object.assign({}, props, {
+        invites: [],
+        loading: false,
+        location: { query: {
+            justLoggedIn: true
+          }
+        },
+        loggedInUserId: 20,
+        patients: [ { userid: 1 } ],
+        showingWelcomeMessage: null,
+        user: {
+          roles: ['clinic']
+        }
+      });
+
+      render.componentWillReceiveProps(nextProps);
+      expect(window.location.pathname).to.not.equal('/patients/1/data');
+    });
+
     // NB: this test has to go last since it affects the global window.location.pathname!
     it('should redirect to patient data when justLogged query param is set and only one patient available and no invites', () => {
       var props = {};


### PR DESCRIPTION
@jebeck @jh-bate When you signup with a clinic account (with "&roles=clinic" on signup url) you now get automatically shared with the Jill Jellyfish account. With the existing logic, that means when you login for the first time, you end up going right into the one account you are associated with. Instead, we want to land on the Patient List screen (that's the change in `patients.js`).

Furthermore, as a first landing page immediately after signing up, the Patient List really gives no instructions so we add some here.