### PR TITLE
update .bookignore

### DIFF
--- a/.bookignore
+++ b/.bookignore
@@ -5,6 +5,7 @@ node_modules/
 test/
 web/
 .babelrc
+.bookignore
 .eslintrc
 .gitignore
 .travis.yml
@@ -14,6 +15,8 @@ buildconfig.js
 config.app.js
 config.server.js
 config.webpack.js
+deploy-env.sh
+deploy.sh
 docker-compose.yml
 favicon.ico
 index.html
@@ -23,8 +26,10 @@ loadtests.js
 nightwatch-globals.js
 nightwatch.json
 package.json
+postcss.config.js
 server.js
 start.sh
 test.config.js
 update-gh-pages.sh
 webpack.config.js
+yarn.lock


### PR DESCRIPTION
Updates to .bookignore with lots more stuff that shouldn't be copied to gh-pages to be published to the docs microsite.

Just a tooling change, so just need a quick sign-off.