### PR TITLE
adding bddp option to DSA signup

### DIFF
--- a/app/components/inputgroup/inputgroup.js
+++ b/app/components/inputgroup/inputgroup.js
@@ -197,7 +197,6 @@ var InputGroup = React.createClass({
   },
 
   renderSelect: function() {
-    var self = this;
     var placeholder = this.props.value === this.props.placeholder;
     var classNames = cx({
       'input-group-control': true,
@@ -224,7 +223,7 @@ var InputGroup = React.createClass({
           name={this.props.name}
           value={this.props.value}
           id={this.props.name}
-          onChange={self.handleChange}
+          onChange={this.handleChange}
           disabled={this.props.disabled}>
             {options}
         </select>

--- a/app/components/inputgroup/inputgroup.js
+++ b/app/components/inputgroup/inputgroup.js
@@ -16,6 +16,7 @@
 
 var React = require('react');
 var _ = require('lodash');
+var cx = require('classnames');
 
 var DatePicker = require('../datepicker');
 
@@ -25,7 +26,7 @@ var InputGroup = React.createClass({
     name: React.PropTypes.string,
     label: React.PropTypes.string,
     items: React.PropTypes.array,
-    text: React.PropTypes.string,
+    text: React.PropTypes.node,
     value: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.bool,
@@ -93,6 +94,10 @@ var InputGroup = React.createClass({
 
     if (type === 'radios') {
       return this.renderRadios();
+    }
+
+    if (type === 'select') {
+      return this.renderSelect();
     }
 
     if (type === 'datepicker') {
@@ -187,6 +192,42 @@ var InputGroup = React.createClass({
     return (
       <div className="input-group-radios">
         {radios}
+      </div>
+    );
+  },
+
+  renderSelect: function() {
+    var self = this;
+    var placeholder = this.props.value === this.props.placeholder;
+    var classNames = cx({
+      'input-group-control': true,
+      'form-control': true,
+      placeholder: placeholder
+    });
+    var options = _.map(this.props.items, function(option, index) {
+      return (
+        <option
+          key={option.value}
+          label={option.label}
+          value={option.value}
+          disabled={option.disabled}
+          ref={'control' + index}>
+            {option.label}
+        </option>
+      );
+    });
+
+    return (
+      <div className="input-group-select">
+        <select
+          className={classNames}
+          name={this.props.name}
+          value={this.props.value}
+          id={this.props.name}
+          onChange={self.handleChange}
+          disabled={this.props.disabled}>
+            {options}
+        </select>
       </div>
     );
   },

--- a/app/components/inputgroup/inputgroup.less
+++ b/app/components/inputgroup/inputgroup.less
@@ -50,3 +50,7 @@
   text-align: center;
   font-weight: 300;
 }
+
+.input-group-control.placeholder {
+  color: @gray-darker;
+}

--- a/app/components/inputgroup/inputgroup.less
+++ b/app/components/inputgroup/inputgroup.less
@@ -52,5 +52,5 @@
 }
 
 .input-group-control.placeholder {
-  color: @gray-darker;
+  color: @gray;
 }

--- a/app/components/inputgroup/inputgroup.less
+++ b/app/components/inputgroup/inputgroup.less
@@ -52,5 +52,5 @@
 }
 
 .input-group-control.placeholder {
-  color: @gray;
+  color: @gray-dark;
 }

--- a/app/pages/patientnew/patientnew.js
+++ b/app/pages/patientnew/patientnew.js
@@ -93,11 +93,12 @@ export let PatientNew = React.createClass({
       items: [
         {value: '', label: 'Choose a diabetes organization', 'disabled':'true'},
         {value: 'BT1', label: 'Beyond Type 1'},
+        {value: 'CARBDM', label: 'CarbDM'},
         {value: 'CWD', label: 'Children with Diabetes'},
         {value: 'CDN', label: 'College Diabetes Network'},
         {value: 'DHF', label: 'Diabetes Hands Foundation'},
         {value: 'JDRF', label: 'JDRF'},
-        {value: 'DIATRIBE', label: 'The Diatribe Foundation'},
+        {value: 'DIATRIBE', label: 'The diaTribe Foundation'},
         {value: 'NSF', label: 'Nightscout Foundation'},
         {value: 'T1DX', label: 'T1D Exchange'}
       ]

--- a/app/pages/patientnew/patientnew.js
+++ b/app/pages/patientnew/patientnew.js
@@ -78,12 +78,20 @@ export let PatientNew = React.createClass({
       type: 'checkbox'
     },
     {
+      name: 'dataDonateExplainer',
+      type: 'explanation',
+      text: (<div style={{'textAlign':'left'}}>
+        You own your data. Read all the details about Tidepool's Big Data
+        Donation project <a href="http://tidepool.org/blog">here</a>.
+      </div>)
+    },
+    {
       name: 'dataDonateDestination',
       type: 'select',
       value: '',
       placeholder: '',
       items: [
-        {value: '', label: 'Share Proceeds with', 'disabled':'true'},
+        {value: '', label: 'Choose a diabetes organization', 'disabled':'true'},
         {value: 'BT1', label: 'Beyond Type 1'},
         {value: 'CWD', label: 'Children with Diabetes'},
         {value: 'CDN', label: 'College Diabetes Network'},
@@ -98,9 +106,8 @@ export let PatientNew = React.createClass({
       name: 'donateExplainer',
       type: 'explanation',
       text: (<div style={{'textAlign':'left'}}>
-        By securely and anonymously donating your diabetes data you are helping
-        researchers, device makers, and other innovators. Read everything about
-        this project <a href="http://tidepool.org/blog">here</a>.
+        Tidepool will share 10% of the proceeds with a diabetes organization of
+        your choice.
       </div>)
     }
   ],

--- a/app/pages/patientnew/patientnew.js
+++ b/app/pages/patientnew/patientnew.js
@@ -209,9 +209,9 @@ export let PatientNew = React.createClass({
 
   getSubmitButtonText: function() {
     if (this.props.working) {
-      return 'Setting up...';
+      return 'Saving...';
     }
-    return 'Set up';
+    return 'Save';
   },
 
   isFormDisabled: function() {

--- a/app/pages/patientnew/patientnew.js
+++ b/app/pages/patientnew/patientnew.js
@@ -82,7 +82,7 @@ export let PatientNew = React.createClass({
       type: 'explanation',
       text: (<div style={{'textAlign':'left'}}>
         You own your data. Read all the details about Tidepool's Big Data
-        Donation project <a href="http://tidepool.org/all/announcing-the-tidepool-big-data-donation-project">here</a>.
+        Donation project <a target="_blank" href="http://tidepool.org/all/announcing-the-tidepool-big-data-donation-project">here</a>.
       </div>)
     },
     {

--- a/app/pages/patientnew/patientnew.js
+++ b/app/pages/patientnew/patientnew.js
@@ -82,7 +82,7 @@ export let PatientNew = React.createClass({
       type: 'explanation',
       text: (<div style={{'textAlign':'left'}}>
         You own your data. Read all the details about Tidepool's Big Data
-        Donation project <a href="http://tidepool.org/blog">here</a>.
+        Donation project <a href="http://tidepool.org/all/announcing-the-tidepool-big-data-donation-project">here</a>.
       </div>)
     },
     {

--- a/app/pages/patientnew/patientnew.js
+++ b/app/pages/patientnew/patientnew.js
@@ -97,8 +97,8 @@ export let PatientNew = React.createClass({
         {value: 'CWD', label: 'Children with Diabetes'},
         {value: 'CDN', label: 'College Diabetes Network'},
         {value: 'DHF', label: 'Diabetes Hands Foundation'},
-        {value: 'JDRF', label: 'JDRF'},
         {value: 'DIATRIBE', label: 'The diaTribe Foundation'},
+        {value: 'JDRF', label: 'JDRF'},
         {value: 'NSF', label: 'Nightscout Foundation'},
         {value: 'T1DX', label: 'T1D Exchange'}
       ]

--- a/app/pages/patientnew/patientnew.less
+++ b/app/pages/patientnew/patientnew.less
@@ -67,9 +67,18 @@
 }
 
 .PatientNew-content {
-    margin-left: auto;
-    margin-right: auto;
-    width: @PatientNew-contentWidth;
+  margin-left: auto;
+  margin-right: auto;
+  width: @PatientNew-contentWidth;
+  .input-group:nth-of-type(6) {
+    padding-top: 15px;
+  }
+  .input-group-explanation {
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 10px;
+    color: @gray-dark
+  }
 }
 
 // Form

--- a/app/pages/patientnew/patientnew.less
+++ b/app/pages/patientnew/patientnew.less
@@ -77,7 +77,7 @@
     margin-left: 0;
     margin-right: 0;
     margin-top: 0px;
-    color: @gray;
+    color: @gray-dark;
     font-size: 14px;
   }
 }

--- a/app/pages/patientnew/patientnew.less
+++ b/app/pages/patientnew/patientnew.less
@@ -76,8 +76,9 @@
   .input-group-explanation {
     margin-left: 0;
     margin-right: 0;
-    margin-top: 10px;
-    color: @gray-dark
+    margin-top: 0px;
+    color: @gray;
+    font-size: 14px;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.5.28",
+    "tideline": "0.5.29",
     "tidepool-platform-client": "0.31.0",
     "url-loader": "0.5.7",
     "webpack": "1.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/patientnew.test.js
+++ b/test/unit/pages/patientnew.test.js
@@ -1,11 +1,14 @@
+/* global beforeEach */
 /* global chai */
 /* global describe */
 /* global sinon */
 /* global it */
 
+import _ from 'lodash';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import mutationTracker from 'object-invariant-test-helper';
+import { mount } from 'enzyme';
 
 import { PatientNew } from '../../../app/pages/patientnew';
 import { mapStateToProps } from '../../../app/pages/patientnew';
@@ -18,16 +21,17 @@ describe('PatientNew', function () {
     expect(PatientNew).to.be.a('function');
   });
 
+  var props = {
+    fetchingUser: false,
+    onInviteMember: sinon.stub(),
+    onSubmit: sinon.stub(),
+    trackMetric: sinon.stub(),
+    working: false
+  };
+
   describe('render', function() {
     it('should not warn when required props are set', function() {
       console.error = sinon.spy();
-      var props = {
-        fetchingUser: false,
-        onInviteMember: sinon.stub(),
-        onSubmit: sinon.stub(),
-        trackMetric: sinon.stub(),
-        working: false
-      };
       var elem = TestUtils.renderIntoDocument(<PatientNew {...props}/>);
       expect(elem).to.be.ok;
       expect(console.error.callCount).to.equal(0);
@@ -44,6 +48,56 @@ describe('PatientNew', function () {
       expect(initialState.formValues.fullName).to.equal('');
       expect(Object.keys(initialState.validationErrors).length).to.equal(0);
       expect(initialState.notification).to.equal(null);
+    });
+  });
+
+  describe('handleSubmit', function(){
+    let wrapper = mount(
+      <PatientNew {...props}/>
+    );
+
+    let formValues = {
+      birthday: {
+        day: '1',
+        month: '0',
+        year: '1990'
+      },
+      diagnosisDate: {
+        day: '2',
+        month: '1',
+        year: '1995'
+      },
+      fullName: 'John Doh',
+      isOtherPerson: false
+    };
+
+    beforeEach(function() {
+      props.onSubmit.reset();
+      props.onInviteMember.reset();
+      props.trackMetric.reset();
+    });
+
+    it('should call onSubmit with valid form values', function(){
+      wrapper.instance().handleSubmit(formValues);
+      expect(props.onSubmit.callCount).to.equal(1);
+      expect(props.onInviteMember.callCount).to.equal(0);
+      expect(props.trackMetric.callCount).to.equal(0);
+    });
+
+    it('should call onSubmit and onInviteMember with data donation values', function(){
+      wrapper.instance().handleSubmit(_.assign({}, formValues, { dataDonate: true }));
+      expect(props.onSubmit.callCount).to.equal(1);
+      expect(props.onInviteMember.callCount).to.equal(1);
+      expect(props.onInviteMember.calledWith('bigdata@tidepool.org')).to.be.true;
+      expect(props.trackMetric.callCount).to.equal(1);
+    });
+
+    it('should call onSubmit and onInviteMember with specific values', function(){
+      wrapper.instance().handleSubmit(_.assign({}, formValues, { dataDonate: true, dataDonateDestination: 'JDRF' }));
+      expect(props.onSubmit.callCount).to.equal(1);
+      expect(props.onInviteMember.callCount).to.equal(1);
+      expect(props.onInviteMember.calledWith('bigdata+JDRF@tidepool.org')).to.be.true;
+      expect(props.trackMetric.callCount).to.equal(1);
     });
   });
 

--- a/test/unit/pages/patientnew.test.js
+++ b/test/unit/pages/patientnew.test.js
@@ -23,6 +23,7 @@ describe('PatientNew', function () {
       console.error = sinon.spy();
       var props = {
         fetchingUser: false,
+        onInviteMember: sinon.stub(),
         onSubmit: sinon.stub(),
         trackMetric: sinon.stub(),
         working: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -7283,9 +7283,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.5.28:
-  version "0.5.28"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.5.28.tgz#52c5b721ed7c39816da9d15625f9dc0222fb55a4"
+tideline@0.5.29:
+  version "0.5.29"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.5.29.tgz#ff4236f0ed6aa8d132dfc99eb058e05e6fac62b3"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
Adds the option to share data with the BDDP and specify one of a number of nonprofit partners with which to attribute the proceeds.

This necessitated the addition of a `renderSelect` addition to the `SimpleForm` system, as it previously had no notion of select elements.