### PR TITLE
Extendeding no bolus period limit for aggregating data from 24 to 72 hours

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.5.33",
+    "tideline": "0.5.36",
     "tidepool-platform-client": "0.31.1",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.5.13",
+  "version": "1.5.17",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7504,9 +7504,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.5.33:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.5.33.tgz#c726109329b56821d062b170e13e8bde1080f70f"
+tideline@0.5.36:
+  version "0.5.36"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.5.36.tgz#472437e647f4f664a98bc41124f0475c35512a1d"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
Coincides with https://github.com/tidepool-org/tideline/pull/317