### PR TITLE
restore dev tools by default 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ var defineEnvPlugin = new webpack.DefinePlugin({
   __ABOUT_MAX_LENGTH__: JSON.stringify(process.env.ABOUT_MAX_LENGTH || null),
   __DEV__: isDev,
   __TEST__: false,
-  __DEV_TOOLS__: (process.env.DEV_TOOLS !== null) ? process.env.DEV_TOOLS : (isDev ? true : false)
+  __DEV_TOOLS__: (process.env.DEV_TOOLS != null) ? process.env.DEV_TOOLS : (isDev ? true : false)
 });
 
 var plugins = [


### PR DESCRIPTION
i.e., when `DEV_TOOLS` env variable is unset/undefined.

Unless y'all made a conscious decision to disable them by default? In which case (but I suspect not since I found the regression [here](https://github.com/tidepool-org/blip/commit/dc7ec489699fb5f12bdd285c669f728c674c264f#diff-11e9f7f953edc64ba14b0cc350ae7b9d)), just lemme know and I'll do a PR to update the README for you.

(I have an ulterior motive for fixing this: a small 🐛  that crashes the app in dev mode only (due to the mutation tracker). So look for that fix soon 😉 )