### PR TITLE
Distinguishing bolus override up from override down in basics view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.6.8",
+    "tideline": "0.6.9",
     "tidepool-platform-client": "0.31.1",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5251,7 +5251,7 @@ npmi@1.0.1:
     npm "^2.1.12"
     semver "^4.1.0"
 
-"npmlog@0 || 1 || 2", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
+"npmlog@0 || 1 || 2", "npmlog@0 || 1 || 2 || 3 || 4", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
   dependencies:
@@ -5259,7 +5259,7 @@ npmi@1.0.1:
     are-we-there-yet "~1.1.2"
     gauge "~1.2.5"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
+npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
   dependencies:
@@ -6646,7 +6646,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@^2.47.0, request@^2.55.0, request@~2.74.0:
+request@2, request@^2.47.0, request@^2.55.0, request@^2.74.0, request@~2.74.0:
   version "2.74.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
   dependencies:
@@ -6715,7 +6715,7 @@ request@2.53.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-request@^2.74.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7529,9 +7529,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.6.8.tgz#c9e209e3e56afee9ca83f7c5705b267fedb75de8"
+tideline@0.6.9:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.6.9.tgz#fcd1d8d15ad8063855c3af51cbcd854eb9bf3b0f"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
On the basics view, remove the 'Manual' bolus filter, and separate the the 'Overrides' filter into 'Overrides' and 'Underrides'

see https://trello.com/c/pQaZdjad for full details.

Pulling in changes from https://github.com/tidepool-org/tideline/pull/320