### PR TITLE
Libre data not being calculated due to insufficient data points

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.9.2",
+  "version": "1.9.3-basics-libre-avg-cbg-fix.1",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.9.6",
+    "@tidepool/viz": "0.9.7-basics-libre-avg-cbg-fix.alpha.1",
     "async": "1.5.2",
     "autoprefixer": "6.7.2",
     "babel-core": "6.13.2",
@@ -72,7 +72,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.6.13",
+    "tideline": "0.6.14-basics-libre-avg-cbg-fix.alpha.1",
     "tidepool-platform-client": "0.34.3",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tidepool/viz@0.9.6":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.9.6.tgz#488e7b49850682e64130fb808a4e72c3c0552d4f"
+"@tidepool/viz@0.9.7-basics-libre-avg-cbg-fix.alpha.1":
+  version "0.9.7-basics-libre-avg-cbg-fix.alpha.1"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.9.7-basics-libre-avg-cbg-fix.alpha.1.tgz#19e5497e2f0dd8eb4952ca896c6748737b75aaca"
   dependencies:
     bluebird "3.5.0"
     crossfilter "1.3.12"
@@ -6941,13 +6941,13 @@ selenium-standalone@5.5.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
 
-"semver@2 || 3 || 4", semver@^4.1.0, semver@~4.3.3:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
-
-semver@^2.3.0:
+"semver@2 || 3 || 4", semver@^2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-2.3.2.tgz#b9848f25d6cf36333073ec9ef8856d42f1233e52"
+
+semver@^4.1.0, semver@~4.3.3:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
 semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
@@ -7563,9 +7563,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.6.13:
-  version "0.6.13"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.6.13.tgz#f40c2417ee0f468481725568795f2fd6e4156907"
+tideline@0.6.14-basics-libre-avg-cbg-fix.alpha.1:
+  version "0.6.14-basics-libre-avg-cbg-fix.alpha.1"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.6.14-basics-libre-avg-cbg-fix.alpha.1.tgz#be9ecb58b7f7e037822e58173d2152b89d9bdbf4"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
Libre CBG data is not being calculated in a number of locations due to having an insufficient number of data points collected in a day.

This is because the minimum data thresholds are all based on getting a certain percentage of the day covered, based on getting a new reading every 5 minutes.  The Libre, however, only gets readings every 15 minutes, so we have to reduce the minimum amount of readings expected for Libre data threefold.

This PR only pulls in updated versions of `tideline` and `@tidepool/viz` which contain the actual fixes.

See https://trello.com/c/FNlDqd1A for details.

Goes hand-in-hand with:
https://github.com/tidepool-org/viz/pull/96
https://github.com/tidepool-org/tideline/pull/326