### PR TITLE
Ease Life of developers working on windows hosts/linux guests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "nightwatch-single": "./node_modules/nightwatch/bin/nightwatch",
     "browser-tests": "NODE_ENV=test ./node_modules/karma/bin/karma start --browsers Chrome",
     "test-watch": "NODE_ENV=test ./node_modules/karma/bin/karma start --no-single-run",
-    "start": "NODE_ENV=development ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --cache --colors --progress --port 3000 --host 0.0.0.0",
+    "start": "NODE_ENV=development ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --cache --watch-poll --colors --progress --port 3000 --host 0.0.0.0",
     "build": "NODE_ENV=production npm run build-app && npm run build-config",
     "build-app": "NODE_ENV=production node buildapp",
     "build-config": "NODE_ENV=production node buildconfig",


### PR DESCRIPTION
Add --watch-poll option for webpack-dev-server
This will allow people on Windows to use Linux Vbox guest while code is on windows host,
Small enhancement that may help people on Windows making development. I f you do not have this option the changes are not automatically uploaded and you have to restart the node service after each change.
Still need to validate this change on other platforms.