### PR TITLE
Chart selection hotfix

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -838,7 +838,7 @@ export let PatientData = React.createClass({
 
   setInitialChartType: function(processedData) {
     // Determine default chart type and date from latest data
-    const uploads = processedData.grouped.upload;
+    const uploads = _.get(processedData.grouped, 'upload', []);
     const latestData = _.last(processedData.diabetesData);
 
     if (uploads && latestData) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.1-chart-selection-fix",
+  "version": "1.10.1",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.0",
+  "version": "1.10.1-chart-selection-fix",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -437,7 +437,7 @@ describe('PatientData', function () {
         elem = TestUtils.renderIntoDocument(<PatientData {...props} />);
         sinon.spy(elem, 'deriveChartTypeFromLatestData');
 
-        kickOffProcessing = (data) => {
+        kickOffProcessing = (data, includeUploads = true) => {
           let processedData;
 
           // bypass the actual processing function since that's not what we're testing here!
@@ -447,11 +447,17 @@ describe('PatientData', function () {
               return datum;
             });
 
-            processedData = {
-              grouped: {
-                upload: uploads,
-              },
-              diabetesData,
+            if(includeUploads){
+              processedData = {
+                grouped: {
+                  upload: uploads,
+                },
+                diabetesData,
+              }
+            } else {
+              processedData = {
+                diabetesData,
+              }
             }
 
             elem.setState({
@@ -605,6 +611,83 @@ describe('PatientData', function () {
           }];
 
           kickOffProcessing(data);
+
+          const view = TestUtils.findRenderedDOMComponentWithClass(elem, 'fake-weekly-view');
+          expect(view).to.be.ok;
+
+          sinon.assert.calledOnce(elem.deriveChartTypeFromLatestData);
+          sinon.assert.calledWith(elem.props.trackMetric, 'web - default to weekly');
+        });
+      });
+
+      context('with no upload records, falling back to data.type', () => {
+        it('should set the default view to <Basics /> when type is bolus', () => {
+          const data = [{
+            type: 'bolus',
+            deviceId: 'unknown',
+          }];
+
+          kickOffProcessing(data, false);
+
+          const view = TestUtils.findRenderedDOMComponentWithClass(elem, 'fake-basics-view');
+          expect(view).to.be.ok;
+
+          sinon.assert.calledOnce(elem.deriveChartTypeFromLatestData);
+          sinon.assert.calledWith(elem.props.trackMetric, 'web - default to basics');
+        });
+
+        it('should set the default view to <Basics /> when type is basal', () => {
+          const data = [{
+            type: 'basal',
+            deviceId: 'unknown',
+          }];
+
+          kickOffProcessing(data, false);
+
+          const view = TestUtils.findRenderedDOMComponentWithClass(elem, 'fake-basics-view');
+          expect(view).to.be.ok;
+
+          sinon.assert.calledOnce(elem.deriveChartTypeFromLatestData);
+          sinon.assert.calledWith(elem.props.trackMetric, 'web - default to basics');
+        });
+
+        it('should set the default view to <Basics /> when type is wizard', () => {
+          const data = [{
+            type: 'wizard',
+            deviceId: 'unknown',
+          }];
+
+          kickOffProcessing(data, false);
+
+          const view = TestUtils.findRenderedDOMComponentWithClass(elem, 'fake-basics-view');
+          expect(view).to.be.ok;
+
+          sinon.assert.calledOnce(elem.deriveChartTypeFromLatestData);
+          sinon.assert.calledWith(elem.props.trackMetric, 'web - default to basics');
+        });
+
+        it('should set the default view to <Trends /> when type is cbg', () => {
+          const data = [{
+            type: 'cbg',
+            deviceId: 'unknown',
+          }];
+
+          kickOffProcessing(data, false);
+
+          const view = TestUtils.findRenderedDOMComponentWithClass(elem, 'fake-trends-view');
+          expect(view).to.be.ok;
+
+          sinon.assert.calledOnce(elem.deriveChartTypeFromLatestData);
+          sinon.assert.calledWith(elem.props.trackMetric, 'web - default to trends');
+        });
+
+        it('should set the default view to <Weekly /> when type is smbg', () => {
+          const data = [{
+            type: 'smbg',
+            deviceId: 'unknown',
+          }];
+
+          kickOffProcessing(data, false);
 
           const view = TestUtils.findRenderedDOMComponentWithClass(elem, 'fake-weekly-view');
           expect(view).to.be.ok;


### PR DESCRIPTION
Since the possibility now arises for the initial set of data queued up for processing includes renderable diabetes data but no `upload` records, we end up in a situation where we avoid checking for which chart type we need to display. However, the system is already built to handle this case and will check for the latest data point's type in order to determine which chart to display in the event that it cannot get the type from the latest upload record, so we can safely default to an empty array should the `upload`s not exist on the `grouped` data.

This also copies a set of unit tests for determining the default chart to display and alters them such that we don't pass in a set of upload records to ensure that they have the same behavior as was already established in the application.