### PR TITLE
Ensure we use up-to-date state timeprefs for daily print view

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -454,7 +454,7 @@ export let PatientData = React.createClass({
           ['basal', 'bolus', 'cbg', 'message', 'smbg']
         ),
         6,
-        this.state.timePrefs,
+        state.timePrefs,
       );
 
       const pdfData = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.1",
+  "version": "1.10.2-daily-print-time-fix.1",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
See https://trello.com/c/dr9EeALW

The changes made for the data paging/processing feature meant that at the time the initial print view generation was called, it was not yet set to state in the PatientData instance.

I've changed it to use the incoming `nextState` as supplied from the `componentWillUpdate` hook.

This is actually how I'd intended it to work when the initial print view was released.  I simply forgot to change one instance of `this.state` to `state`. 