### PR TITLE
Update glucose defaults to reflect standards

### DIFF
--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -268,7 +268,7 @@ var Daily = React.createClass({
             }}
             side={this.state.hoveredBolus.side}
             bolus={this.state.hoveredBolus.data}
-            bgPrefs = {this.props.bgPrefs}
+            bgPrefs={this.props.bgPrefs}
             timePrefs={this.props.timePrefs}
           />}
       </div>

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -268,6 +268,7 @@ var Daily = React.createClass({
             }}
             side={this.state.hoveredBolus.side}
             bolus={this.state.hoveredBolus.data}
+            bgPrefs = {this.props.bgPrefs}
             timePrefs={this.props.timePrefs}
           />}
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.8-standardbgdefaultsfix.4",
+  "version": "1.10.8-standardbgdefaultsfix.5",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.8-standardbgdefaultsfix.1",
+  "version": "1.10.8-standardbgdefaultsfix.2",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.10.1",
+    "@tidepool/viz": "0.10.2-standardbgdefaultsfix.1",
     "async": "1.5.2",
     "autoprefixer": "6.7.2",
     "babel-core": "6.13.2",
@@ -74,7 +74,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.7.4-standardbgdefaultsfix.1",
+    "tideline": "0.7.4-standardbgdefaultsfix.2",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.7.1",
+    "tideline": "0.7.4-standardbgdefaultsfix.1",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.7.4-standardbgdefaultsfix.6",
+    "tideline": "0.7.4-standardbgdefaultsfix.7",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.7",
+  "version": "1.10.8-standardbgdefaultsfix.1",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.8-standardbgdefaultsfix.2",
+  "version": "1.10.8-standardbgdefaultsfix.3",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.10.2-standardbgdefaultsfix.1",
+    "@tidepool/viz": "0.10.2-standardbgdefaultsfix.2",
     "async": "1.5.2",
     "autoprefixer": "6.7.2",
     "babel-core": "6.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.8-standardbgdefaultsfix.3",
+  "version": "1.10.8-standardbgdefaultsfix.4",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve-docs": "./node_modules/.bin/gitbook serve"
   },
   "dependencies": {
-    "@tidepool/viz": "0.10.2-standardbgdefaultsfix.2",
+    "@tidepool/viz": "0.10.2",
     "async": "1.5.2",
     "autoprefixer": "6.7.2",
     "babel-core": "6.13.2",
@@ -74,7 +74,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.7.4-standardbgdefaultsfix.7",
+    "tideline": "0.7.4",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.8-standardbgdefaultsfix.6",
+  "version": "1.10.8-standardbgdefaultsfix.7",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.10.8-standardbgdefaultsfix.5",
+  "version": "1.10.8-standardbgdefaultsfix.6",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.7.4-standardbgdefaultsfix.2",
+    "tideline": "0.7.4-standardbgdefaultsfix.5",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "0.7.4-standardbgdefaultsfix.5",
+    "tideline": "0.7.4-standardbgdefaultsfix.6",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7672,9 +7672,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.7.4-standardbgdefaultsfix.6:
-  version "0.7.4-standardbgdefaultsfix.6"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.6.tgz#c7701bedb4bf3209df70030cfa4963fd61c88b9d"
+tideline@0.7.4-standardbgdefaultsfix.7:
+  version "0.7.4-standardbgdefaultsfix.7"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.7.tgz#2195456121f9bab397e4d4c18c1b80778bbe5b70"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tidepool/viz@0.10.2-standardbgdefaultsfix.1":
-  version "0.10.2-standardbgdefaultsfix.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.10.2-standardbgdefaultsfix.1.tgz#ec87f3e925d1a629883491185057af1586dcd076"
+"@tidepool/viz@0.10.2-standardbgdefaultsfix.2":
+  version "0.10.2-standardbgdefaultsfix.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.10.2-standardbgdefaultsfix.2.tgz#6d99b332b58597b9ed90828f7615153573953827"
   dependencies:
     bluebird "3.5.0"
     crossfilter "1.3.12"
@@ -5342,7 +5342,7 @@ npmi@1.0.1:
     npm "^2.1.12"
     semver "^4.1.0"
 
-"npmlog@0 || 1 || 2", "npmlog@0 || 1 || 2 || 3 || 4", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
+"npmlog@0 || 1 || 2", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
   dependencies:
@@ -5350,7 +5350,7 @@ npmi@1.0.1:
     are-we-there-yet "~1.1.2"
     gauge "~1.2.5"
 
-npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
   dependencies:
@@ -6759,7 +6759,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@^2.47.0, request@^2.55.0, request@^2.74.0, request@~2.74.0:
+request@2, request@^2.47.0, request@^2.55.0, request@~2.74.0:
   version "2.74.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
   dependencies:
@@ -6828,7 +6828,7 @@ request@2.53.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-request@^2.81.0:
+request@^2.74.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5342,7 +5342,7 @@ npmi@1.0.1:
     npm "^2.1.12"
     semver "^4.1.0"
 
-"npmlog@0 || 1 || 2", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
+"npmlog@0 || 1 || 2", "npmlog@0 || 1 || 2 || 3 || 4", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
   dependencies:
@@ -5350,7 +5350,7 @@ npmi@1.0.1:
     are-we-there-yet "~1.1.2"
     gauge "~1.2.5"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
+npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
   dependencies:
@@ -6759,7 +6759,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@^2.47.0, request@^2.55.0, request@~2.74.0:
+request@2, request@^2.47.0, request@^2.55.0, request@^2.74.0, request@~2.74.0:
   version "2.74.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
   dependencies:
@@ -6828,7 +6828,7 @@ request@2.53.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-request@^2.74.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7672,9 +7672,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.7.4-standardbgdefaultsfix.2:
-  version "0.7.4-standardbgdefaultsfix.2"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.2.tgz#43e6d0bb83e451b0d6b4dfcf05ef946c507c6354"
+tideline@0.7.4-standardbgdefaultsfix.5:
+  version "0.7.4-standardbgdefaultsfix.5"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.5.tgz#da1e39aa92c12f7f5c33f25373d066ebe13620c5"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tidepool/viz@0.10.2-standardbgdefaultsfix.2":
-  version "0.10.2-standardbgdefaultsfix.2"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.10.2-standardbgdefaultsfix.2.tgz#6d99b332b58597b9ed90828f7615153573953827"
+"@tidepool/viz@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.10.2.tgz#f213ff882f8ff00cd37c2009edb0715d8af56379"
   dependencies:
     bluebird "3.5.0"
     crossfilter "1.3.12"
@@ -5342,7 +5342,7 @@ npmi@1.0.1:
     npm "^2.1.12"
     semver "^4.1.0"
 
-"npmlog@0 || 1 || 2", "npmlog@0 || 1 || 2 || 3 || 4", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
+"npmlog@0 || 1 || 2", "npmlog@0.1 || 1 || 2", npmlog@~2.0.0, "npmlog@~2.0.0 || ~3.1.0", npmlog@~2.0.2, npmlog@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
   dependencies:
@@ -5350,7 +5350,7 @@ npmi@1.0.1:
     are-we-there-yet "~1.1.2"
     gauge "~1.2.5"
 
-npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
   dependencies:
@@ -6759,7 +6759,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@^2.47.0, request@^2.55.0, request@^2.74.0, request@~2.74.0:
+request@2, request@^2.47.0, request@^2.55.0, request@~2.74.0:
   version "2.74.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
   dependencies:
@@ -6828,7 +6828,7 @@ request@2.53.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-request@^2.81.0:
+request@^2.74.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7672,9 +7672,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.7.4-standardbgdefaultsfix.7:
-  version "0.7.4-standardbgdefaultsfix.7"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.7.tgz#2195456121f9bab397e4d4c18c1b80778bbe5b70"
+tideline@0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4.tgz#20cb1a113d3ad97604db635dad1c412a6ff09747"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7672,9 +7672,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.7.4-standardbgdefaultsfix.5:
-  version "0.7.4-standardbgdefaultsfix.5"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.5.tgz#da1e39aa92c12f7f5c33f25373d066ebe13620c5"
+tideline@0.7.4-standardbgdefaultsfix.6:
+  version "0.7.4-standardbgdefaultsfix.6"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.6.tgz#c7701bedb4bf3209df70030cfa4963fd61c88b9d"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tidepool/viz@0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.10.1.tgz#123235951cc915ff1a008db4f969ebb378ddf81f"
+"@tidepool/viz@0.10.2-standardbgdefaultsfix.1":
+  version "0.10.2-standardbgdefaultsfix.1"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-0.10.2-standardbgdefaultsfix.1.tgz#ec87f3e925d1a629883491185057af1586dcd076"
   dependencies:
     bluebird "3.5.0"
     crossfilter "1.3.12"
@@ -7672,9 +7672,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.7.4-standardbgdefaultsfix.1:
-  version "0.7.4-standardbgdefaultsfix.1"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.1.tgz#7b17d6a97941010a832565f87c5d9c46159d37b2"
+tideline@0.7.4-standardbgdefaultsfix.2:
+  version "0.7.4-standardbgdefaultsfix.2"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.2.tgz#43e6d0bb83e451b0d6b4dfcf05ef946c507c6354"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5483,7 +5483,7 @@ optimist@0.6.1, optimist@>=0.3.5, optimist@^0.6.1, optimist@~0.6.0, optimist@~0.
     wordwrap "~0.0.2"
 
 optional@0.1.3:
-  version "0.1.3"
+  version v0.1.3
   resolved "https://registry.yarnpkg.com/optional/-/optional-0.1.3.tgz#f87537517b59a5e732cfd8f18e4f7eea7ab4761e"
 
 optionator@^0.8.1:
@@ -7672,9 +7672,9 @@ thunkify@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.1.tgz#3ce59b734d72c1f841c1facc792f55641ce8e477"
+tideline@0.7.4-standardbgdefaultsfix.1:
+  version "0.7.4-standardbgdefaultsfix.1"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-0.7.4-standardbgdefaultsfix.1.tgz#7b17d6a97941010a832565f87c5d9c46159d37b2"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
See https://trello.com/c/OKj6Qyji for details.

Related PRs:
tidepool-org/tideline#338
tidepool-org/viz#107

This PR is required due to a side effect of a rounding fix applied to the tideline PR in the nurseshark plugin that was rounding the BG values when converting from the stored `mmol/L` values to `mg/dL` prior to categorization.  

This PR simply passes the `bgPrefs` in to the BolusTooltip component to allow BG formatting there.