### PR TITLE
Display date range when using browser print functionality

### DIFF
--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -135,7 +135,7 @@ class TidelineHeader extends Component {
     });
 
     return (
-      <div id="app-no-print" className="grid patient-data-subnav">
+      <div className="app-no-print grid patient-data-subnav">
         <div className="grid-item one-whole large-one-third">
             <a href="" className={basicsLinkClass} onClick={this.props.onClickBasics}>Basics</a>
             <a href="" className={dayLinkClass} onClick={this.props.onClickOneDay}>Daily</a>

--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -135,8 +135,8 @@ class TidelineHeader extends Component {
     });
 
     return (
-      <div className="app-no-print grid patient-data-subnav">
-        <div className="grid-item one-whole large-one-third">
+      <div className="grid patient-data-subnav">
+        <div className="app-no-print grid-item one-whole large-one-third">
             <a href="" className={basicsLinkClass} onClick={this.props.onClickBasics}>Basics</a>
             <a href="" className={dayLinkClass} onClick={this.props.onClickOneDay}>Daily</a>
             <a href="" className={weekLinkClass} onClick={this.props.onClickTwoWeeks}>Weekly</a>
@@ -150,7 +150,7 @@ class TidelineHeader extends Component {
           {this.renderNavButton(nextClass, this.props.onClickNext, this.props.iconNext)}
           {this.renderNavButton(mostRecentClass, this.props.onClickMostRecent, this.props.iconMostRecent)}
         </div>
-        <div className="grid-item one-whole large-one-third">
+        <div className="app-no-print grid-item one-whole large-one-third">
           <a href="" className={settingsLinkClass} onClick={this.props.onClickSettings}>Device settings</a>
           <a href="" className={printLinkClass} onClick={this.props.onClickPrint}>
             {this.props.printReady && <img className="print-icon" src={printPng} alt="Print" />}

--- a/app/pages/app/app.less
+++ b/app/pages/app/app.less
@@ -52,16 +52,16 @@
   }
 }
 
-#app-print {
+.app-print {
   display: none;
 }
 
 @media print {
-  #app-no-print {
+  .app-no-print {
     display: none;
   }
 
-  #app-print {
+  .app-print {
     display: block;
   }
 }

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -262,7 +262,7 @@ export let PatientData = React.createClass({
   renderSettings: function(){
     return (
       <div>
-        <div id="app-no-print">
+        <div class="app-no-print">
           <Settings
             bgPrefs={this.state.bgPrefs}
             chartPrefs={this.state.chartPrefs}


### PR DESCRIPTION
Tweak the CSS so that the current date range is visible in the @print media renderer.  This is a stop-gap until there are proper print views for all visualizations.   