### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 
 COPY package.json package.json
 
-RUN apk add --no-cache fontconfig && \
+RUN apk --no-cache update && \
+    apk --no-cache upgrade && \
+    apk add --no-cache fontconfig && \
     apk add --no-cache --virtual .build-dependencies curl git && \
     curl -Ls "https://github.com/tidepool-org/tools/raw/master/alpine_phantomjs_dependencies/dockerized-phantomjs.tar.xz" | tar xJ -C / && \
     mkdir -p dist node_modules /@tidepool/viz/node_modules /tideline/node_modules /tidepool-platform-client/node_modules && \
@@ -14,7 +16,8 @@ RUN apk add --no-cache fontconfig && \
 
 USER node
 
-RUN yarn install
+RUN yarn install && \
+    yarn cache clean
 
 COPY . .
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.12.1-docker-updates",
+  "version": "1.12.1-docker-updates.1",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.12.1",
+  "version": "1.12.1-docker-updates",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
- Run `apk update` and `apk upgrade` to get latest OS patches
- Clear the yarn cache, which is basically a copy of /app/node_module
  Image is now 472MB, down from 746MB