### PR TITLE
Disable bg annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "1.8.11",
+    "tideline": "1.8.12-disable-bg-annotation.2",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.12.4",
+  "version": "1.12.5-disable-bg-annotation.1",
   "private": true,
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "shelljs": "0.7.3",
     "style-loader": "0.13.1",
     "sundial": "1.5.1",
-    "tideline": "1.8.12-disable-bg-annotation.2",
+    "tideline": "1.8.12",
     "tidepool-platform-client": "0.37.0",
     "uglify-es": "3.0.13",
     "url-loader": "0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,9 +7919,9 @@ thunkify@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@1.8.11:
-  version "1.8.11"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.8.11.tgz#41d360a3fe7aabec5148ea39633388444e4c2ed6"
+tideline@1.8.12-disable-bg-annotation.2:
+  version "1.8.12-disable-bg-annotation.2"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.8.12-disable-bg-annotation.2.tgz#045953d27453279a0a41f791ee0ffaae5d888767"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,9 +7919,9 @@ thunkify@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-tideline@1.8.12-disable-bg-annotation.2:
-  version "1.8.12-disable-bg-annotation.2"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.8.12-disable-bg-annotation.2.tgz#045953d27453279a0a41f791ee0ffaae5d888767"
+tideline@1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.8.12.tgz#64ac8c78e21cbbd8798b4a787d214c4ce0ecd8a7"
   dependencies:
     bows "1.6.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
Updated `tideline` dependency to disable `bg/out-of-range` annotations being rendered the old way. 

tideline PR: https://github.com/tidepool-org/tideline/pull/356
Trello card: https://trello.com/c/pQv4sTKV