### PR TITLE
Added health check endpoint.

### DIFF
--- a/server.js
+++ b/server.js
@@ -87,6 +87,10 @@ app.get('*', (req, res) => {
   res.send(res.locals.htmlWithNonces);
 });
 
+app.get('/healthz', (req, res) => {
+  res.status(200).end();
+});
+
 app.post('/event/csp-report/violation', (req, res) => {
   if (req.body) {
     console.log('CSP Violation: ', req.body);


### PR DESCRIPTION
The intent of this is to create a [readiness probe for use in Kubernetes](https://supergiant.io/blog/creating-liveness-probes-for-your-node-js-application-in-kubernetes/).

This adds a `/healthz` endpoint that simply returns a 200 status when called. The idea is that while yarn is build the app on startup, calls to this endpoint will FAIL. Only when the server is started and ready to serve traffic will this Kubernetes send traffic to it, as indicated when this endpoint returns status 200.