### PR TITLE
stop reload switching from weekly to basics view with no data

### DIFF
--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -305,6 +305,7 @@ class BgLog extends Component {
         inTransition={this.state.inTransition}
         title={''}
         onClickOneDay={this.handleClickOneDay}
+        onClickBasics={this.props.onSwitchToBasics}
         onClickTrends={this.handleClickTrends}
         onClickSettings={this.props.onSwitchToSettings}
         onClickBgLog={this.handleClickBgLog}


### PR DESCRIPTION
https://trello.com/c/bsnBhR7g/701-page-reload-when-switching-to-basics-from-empty-weekly-view