### PR TITLE
Reduce idle cpu usage on data views

### DIFF
--- a/app/components/chart/stats.js
+++ b/app/components/chart/stats.js
@@ -91,16 +91,18 @@ class Stats extends Component {
       : false;
   };
 
-  renderStats = stats => (_.map(stats, stat => (
+  renderStats = (stats, animate) => (_.map(stats, stat => (
     <div id={`Stat--${stat.id}`} key={stat.id}>
-      <Stat bgPrefs={this.bgPrefs} {...stat} />
+      <Stat animate={animate} bgPrefs={this.bgPrefs} {...stat} />
     </div>
   )));
 
   render = () => {
+    const { chartPrefs: { animateStats } } = this.props;
+
     return (
       <div className="Stats">
-        {this.renderStats(this.state.stats)}
+        {this.renderStats(this.state.stats, animateStats)}
       </div>
     );
   };

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -894,8 +894,9 @@ export let PatientData = translate()(React.createClass({
       var prefs = _.cloneDeep(this.state.chartPrefs);
       prefs.bolusRatio = params.dynamicCarbs ? 0.5 : 0.35;
       prefs.dynamicCarbs = params.dynamicCarbs;
+      prefs.animateStats = params.animateStats ? JSON.parse(params.animateStats) : true;
       this.setState({
-        chartPrefs: prefs
+        chartPrefs: prefs,
       });
     }
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/polyfill": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
-    "@tidepool/viz": "1.5.0",
+    "@tidepool/viz": "1.6.0-idle-cpu-usage.2",
     "async": "2.6.1",
     "autoprefixer": "9.1.5",
     "babel-core": "7.0.0-bridge.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,10 +836,10 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
 
-"@tidepool/viz@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.5.0.tgz#03b437aa01638a901364cd23f3bb2ebc39ca6fe4"
-  integrity sha512-uKSXhjYIHrNZDdpUG386UIR3jhyI55SpWIb/dDMbDiCvakWZViJ1Vej5reRH2rL69UH8El0j+T5XUZsJBxmJXA==
+"@tidepool/viz@1.6.0-idle-cpu-usage.2":
+  version "1.6.0-idle-cpu-usage.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.6.0-idle-cpu-usage.2.tgz#f52ff0893569e37fe188c9ab748bcd7791d574c0"
+  integrity sha512-dGaRwCiqbdSDBeRqUtsa1OQffEBKutTmh5LUs0PEvLK+JZddiLydWCU1WG0UVCY+n3NjybN9cEhu2zF/PKzuhw==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.0"


### PR DESCRIPTION
https://trello.com/c/kiGrj7Oo

The main fix was to ensure that the CSS loading dot animations are only happening while visible.

The other fix is a workaround for the time being, allowing the the stat animations to be disabled via a `animateStats=false` query param.

Related PR: tidepool-org/viz#156