### PR TITLE
fixed bug with long bio

### DIFF
--- a/app/pages/patient/patientinfo.less
+++ b/app/pages/patient/patientinfo.less
@@ -115,8 +115,14 @@ a.PatientInfo-block {
   width: 110px;
 }
 
-.PatientInfo-bio--placeholder {
-  height: 40px;
+.PatientInfo-bio {
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
 }
 
 .PatientInfo-controls {


### PR DESCRIPTION
Solution to the bug where someone would make their bio a long word with no spaces (for some reason) and would hinder the page layout when resizing

see https://trello.com/c/tvrji3bT/576-long-profile-text-bug
