### PR TITLE
Added dynamic text count

### DIFF
--- a/app/pages/patient/patientinfo.js
+++ b/app/pages/patient/patientinfo.js
@@ -357,7 +357,7 @@ var PatientInfo = translate()(React.createClass({
 
     var charCountClass;
     if (this.state.bioLength > 256) {
-      charCountClass = "PatientInfo-error-message";
+      charCountClass = 'PatientInfo-error-message';
     }
 
     var charCount = <div className={charCountClass}>{this.state.bioLength === 0 ? '' : this.state.bioLength.toString() + '/256'}</div>;

--- a/app/pages/patient/patientinfo.js
+++ b/app/pages/patient/patientinfo.js
@@ -64,7 +64,8 @@ var PatientInfo = translate()(React.createClass({
   getInitialState: function() {
     return {
       editing: false,
-      validationErrors: {}
+      validationErrors: {},
+      bioLength: 0
     };
   },
 
@@ -353,12 +354,21 @@ var PatientInfo = translate()(React.createClass({
       classes += ' PatientInfo-input-error';
       errorElem = <div className="PatientInfo-error-message">{error}</div>;
     }
+
+    var charCountClass;
+    if (this.state.bioLength > 256) {
+      charCountClass = "PatientInfo-error-message";
+    }
+
+    var charCount = <div className={charCountClass}>{this.state.bioLength === 0 ? '' : this.state.bioLength.toString() + '/256'}</div>;
     return (<div className="PatientInfo-bio">
       <textarea className={classes} ref="about"
         placeholder={t('Anything you would like to share?')}
         rows="3"
-        defaultValue={formValues.about}>
+        defaultValue={formValues.about}
+        onChange={(event) => this.setState({ bioLength : event.target.value === undefined ? 0 : event.target.value.length })}>
       </textarea>
+      {charCount}
       {errorElem}
     </div>);
   },

--- a/test/unit/pages/patient/patientinfo.test.js
+++ b/test/unit/pages/patient/patientinfo.test.js
@@ -69,7 +69,7 @@ describe('PatientInfo', function () {
       var elem = TestUtils.renderIntoDocument(patientInfoElem).getWrappedInstance();
 
       var initialState = elem.getInitialState();
-      expect(Object.keys(initialState).length).to.equal(2);
+      expect(Object.keys(initialState).length).to.equal(3);
       expect(initialState.editing).to.equal(false);
       expect(Object.keys(initialState.validationErrors).length).length.to.equal(0);
     });


### PR DESCRIPTION
Added a text count for editing a users bio (ie, 26/256 or 276/256). If a user is over the allotted count for a bio, then the counter turns error red.

Part 3 of this Trello 
https://trello.com/c/DI2bGRAa
