### PR TITLE
allow claimed accounts to validate as isOtherPerson [WEB-474]

### DIFF
--- a/app/pages/verificationwithpassword/verificationwithpassword.js
+++ b/app/pages/verificationwithpassword/verificationwithpassword.js
@@ -155,7 +155,7 @@ export let VerificationWithPassword = translate()(React.createClass({
       { type: 'password', name: 'password', label: t('password'), value: formValues.password},
       { type: 'confirmPassword', name: 'passwordConfirm', label: t('confirm password'), value: formValues.passwordConfirm, prerequisites: { password: formValues.password } }
     ];
-    var validationErrors = validateForm(form);
+    var validationErrors = validateForm(form, true);
 
     if (!_.isEmpty(validationErrors)) {
       this.setState({


### PR DESCRIPTION
This is to take care of [WEB-474]. The new param passed tells the initial patient claim form validation to treat the values as it would an `isOtherPerson` account when a user is signing up on behalf of a minor. This will allow clinicians to send invites to parents of children accounts and allow them to claim them properly at home. 

[WEB-474]: https://tidepool.atlassian.net/browse/WEB-474