### PR TITLE
[WEB-75] rollbar GitHub sha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ CMD ["npm", "test"]
 
 ### Stage 5 - Base image for builds to share args and environment variables
 FROM base as build-base
+RUN apk --no-cache update \
+  && apk --no-cache upgrade \
+  && apk add --no-cache git
 # ARGs
 ARG API_HOST
 ARG DISCOVERY_HOST=hakken:8000
@@ -75,6 +78,7 @@ ARG PORT=3000
 ARG PUBLISH_HOST=hakken
 ARG SERVICE_NAME=blip
 ARG ROLLBAR_POST_SERVER_TOKEN
+ARG TRAVIS_COMMIT
 # Set ENV from ARGs
 ENV \
   API_HOST=$API_HOST \
@@ -83,6 +87,7 @@ ENV \
   PUBLISH_HOST=$PUBLISH_HOST \
   SERVICE_NAME=$SERVICE_NAME \
   ROLLBAR_POST_SERVER_TOKEN=$ROLLBAR_POST_SERVER_TOKEN \
+  TRAVIS_COMMIT=$TRAVIS_COMMIT \
   NODE_ENV=production
 
 

--- a/app/rollbar.js
+++ b/app/rollbar.js
@@ -1,4 +1,4 @@
-/* global __ROLLBAR_POST_CLIENT_TOKEN__, __VERSION__, __API_HOST__, __PROD__ */
+/* global __ROLLBAR_POST_CLIENT_TOKEN__, __VERSION_SHA__, __API_HOST__, __PROD__ */
 import Rollbar from 'rollbar';
 
 let rollbar = {};
@@ -13,7 +13,7 @@ if (__PROD__) {
           client: {
             javascript: {
               /* eslint-disable camelcase */
-              code_version: __VERSION__,
+              code_version: __VERSION_SHA__,
               guess_uncaught_frames: true
               /* eslint-enable camelcase */
             }

--- a/config.webpack.js
+++ b/config.webpack.js
@@ -9,7 +9,7 @@ const VERSION = pkg.version;
 const ROLLBAR_POST_CLIENT_TOKEN = '7e29ff3610ab407f826307c8f5ad386f';
 
 const VERSION_SHA = process.env.TRAVIS_COMMIT
-  || cp.execSync('git rev-parse HEAD', { cwd: __dirname, encoding: 'utf8' });
+  || cp.execSync('git rev-parse HEAD || true', { cwd: __dirname, encoding: 'utf8' });
 
 // these values are required in the config.app.js file -- we can't use
 // process.env with webpack, we have to create these magic constants

--- a/config.webpack.js
+++ b/config.webpack.js
@@ -1,11 +1,15 @@
 const path = require('path');
 const webpack = require('webpack');
 const pkg = require('./package.json');
+const cp = require('child_process');
 
 const isDev = (process.env.NODE_ENV === 'development');
 
 const VERSION = pkg.version;
 const ROLLBAR_POST_CLIENT_TOKEN = '7e29ff3610ab407f826307c8f5ad386f';
+
+const VERSION_SHA = process.env.TRAVIS_COMMIT
+  || cp.execSync('git rev-parse HEAD', { cwd: __dirname, encoding: 'utf8' });
 
 // these values are required in the config.app.js file -- we can't use
 // process.env with webpack, we have to create these magic constants
@@ -21,6 +25,7 @@ const defineEnvPlugin = new webpack.DefinePlugin({
   __I18N_ENABLED__: JSON.stringify(process.env.I18N_ENABLED || false),
   __VERSION__: JSON.stringify(VERSION),
   __ROLLBAR_POST_CLIENT_TOKEN__: JSON.stringify(ROLLBAR_POST_CLIENT_TOKEN),
+  __VERSION_SHA__: JSON.stringify(VERSION_SHA),
   __DEV__: isDev,
   __TEST__: false,
   __DEV_TOOLS__: (process.env.DEV_TOOLS != null) ? process.env.DEV_TOOLS : (isDev ? true : false) //eslint-disable-line eqeqeq

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.0-rc.14",
+  "version": "1.31.0-rc.15",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.0-rc.13",
+  "version": "1.31.0-rc.14",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ const ROLLBAR_POST_CLIENT_TOKEN = '7e29ff3610ab407f826307c8f5ad386f';
 const ROLLBAR_POST_SERVER_TOKEN = process.env.ROLLBAR_POST_SERVER_TOKEN;
 
 const VERSION_SHA = process.env.TRAVIS_COMMIT
-  || cp.execSync('git rev-parse HEAD', { cwd: __dirname, encoding: 'utf8' });
+  || cp.execSync('git rev-parse HEAD || true', { cwd: __dirname, encoding: 'utf8' });
 
 // Enzyme as of v2.4.1 has trouble with classes
 // that do not start and *end* with an alpha character

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const RollbarSourceMapPlugin = require('rollbar-sourcemap-webpack-plugin');
 const terser = require('terser');
 const fs = require('fs');
 const pkg = require('./package.json');
+const cp = require('child_process');
 
 const isDev = (process.env.NODE_ENV === 'development');
 const isTest = (process.env.NODE_ENV === 'test');
@@ -17,6 +18,9 @@ const isProd = (process.env.NODE_ENV === 'production');
 const VERSION = pkg.version;
 const ROLLBAR_POST_CLIENT_TOKEN = '7e29ff3610ab407f826307c8f5ad386f';
 const ROLLBAR_POST_SERVER_TOKEN = process.env.ROLLBAR_POST_SERVER_TOKEN;
+
+const VERSION_SHA = process.env.TRAVIS_COMMIT
+  || cp.execSync('git rev-parse HEAD', { cwd: __dirname, encoding: 'utf8' });
 
 // Enzyme as of v2.4.1 has trouble with classes
 // that do not start and *end* with an alpha character
@@ -140,6 +144,7 @@ const plugins = [
     __I18N_ENABLED__: JSON.stringify(process.env.I18N_ENABLED || false),
     __VERSION__: JSON.stringify(VERSION),
     __ROLLBAR_POST_CLIENT_TOKEN__: JSON.stringify(ROLLBAR_POST_CLIENT_TOKEN),
+    __VERSION_SHA__: JSON.stringify(VERSION_SHA),
     __DEV__: isDev,
     __TEST__: isTest,
     __PROD__: isProd,
@@ -175,7 +180,7 @@ if (isDev) {
     /** Upload sourcemap to Rollbar */
     new RollbarSourceMapPlugin({
       accessToken: ROLLBAR_POST_SERVER_TOKEN,
-      version: VERSION,
+      version: VERSION_SHA,
       publicPath: 'https://dynamichost',
     })
   );


### PR DESCRIPTION
Uses the Github commit SHA for the version used in Rollbar.

Part of [WEB-75]

Related PR: tidepool-org/tools#83

[WEB-75]: https://tidepool.atlassian.net/browse/WEB-75