### PR TITLE
[WEB-559] Set up and use standard line heights in theme

### DIFF
--- a/app/components/elements/FontStyles.js
+++ b/app/components/elements/FontStyles.js
@@ -6,7 +6,10 @@ import { NavLink } from 'react-router-dom';
 import {
   borders,
   colors,
+  fonts,
   fontSizes,
+  fontWeights,
+  lineHeights,
   space,
 } from '../../themes/baseTheme';
 
@@ -36,50 +39,50 @@ export const H4 = props => (
 
 export const Display2 = Styled(H1)`
   font-size: ${fontSizes[6]}px;
-  line-height: 60px;
-  font-weight: 400;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[1]};
+  font-weight: ${fontWeights.regular};
+  font-family: ${fonts.default};
   padding: 0;
   color: ${colors.text.primary};
 `;
 
 export const Display1 = Styled(H1)`
   font-size: ${fontSizes[5]}px;
-  line-height:  44px;
-  font-weight: 400;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[1]};
+  font-weight: ${fontWeights.regular};
+  font-family: ${fonts.default};
   padding: 0;
   color: ${colors.text.primary};
 `;
 
 export const Headline = Styled(H2)`
   font-size: ${fontSizes[4]}px;
-  line-height: 32px;
-  font-weight: 400;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[2]};
+  font-weight: ${fontWeights.regular};
+  font-family: ${fonts.default};
   color: ${colors.text.primary};
 `;
 
 export const Title = Styled(H3)`
   font-size: 18px;
-  line-height:  30px;
-  font-weight: 400;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[3]};
+  font-weight: ${fontWeights.regular};
+  font-family: ${fonts.default};
   color: ${colors.text.primary};
 `;
 
 export const Subheading = Styled(H4)`
   font-size: ${fontSizes[2]}px;
-  line-height: 28px;
-  font-weight: 400;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[4]};
+  font-weight: ${fontWeights.regular};
+  font-family: ${fonts.default};
   color: ${props => (props.color ? props.color : colors.text.primary)};
 `;
 
 export const Body2 = Styled(Text)`
   font-size: ${fontSizes[2]}px;
-  line-height: 28px;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[3]};
+  font-family: ${fonts.default};
   color: ${colors.text.primary};
   margin-block-start: 0em;
   margin-block-end: 1em;
@@ -90,8 +93,8 @@ export const Body2 = Styled(Text)`
 
 export const Body1 = Styled(Text)`
   font-size: ${fontSizes[1]}px;
-  line-height: 24px;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[3]};
+  font-family: ${fonts.default};
   margin-block-start: 1em;
   margin-block-end: 1em;
   margin-bottom: 1em;
@@ -100,17 +103,17 @@ export const Body1 = Styled(Text)`
 
 export const Caption = Styled(Text)`
   font-size: ${fontSizes[0]}px;
-  line-height: 20px;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[4]};
+  font-family: ${fonts.default};
   color: ${props => (props.color ? props.color : colors.text.primary)};
 `;
 
 export const NavigationLink = Styled(Link)`
   font-size: ${fontSizes[1]}px;
   margin: 0;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
-  line-height: 14px;
-  font-weight: 400;
+  font-family: ${fonts.default};
+  line-height: ${lineHeights[0]};
+  font-weight: ${fontWeights.regular};
   color: ${colors.text.primary};
   &:hover {
     color: ${colors.text.link};
@@ -122,9 +125,9 @@ export const NavigationLink = Styled(Link)`
 export const DropdownGroupHeader = Styled(Text)`
   font-size: ${fontSizes[1]}px;
   margin: 0;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
-  line-height: 14px;
-  font-weight: 400;
+  font-family: ${fonts.default};
+  line-height: ${lineHeights[0]};
+  font-weight: ${fontWeights.regular};
   color: ${colors.text.primary};
   &:hover {
     color: ${colors.text.link};
@@ -136,8 +139,8 @@ export const DropdownGroupHeader = Styled(Text)`
 export const TextLinkDisabled = Styled(Text)`
   color: ${colors.text.link};
   cursor: pointer;
-  line-height: 20px;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[0]};
+  font-family: ${fonts.default};
   &:hover {
     color: ${colors.text.link};
     text-decoration: none;
@@ -146,7 +149,7 @@ export const TextLinkDisabled = Styled(Text)`
 
 export const TextLinkStyle = Styled(Link)`
   color: ${colors.text.primary};
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  font-family: ${fonts.default};
   &:hover {
     color: ${colors.text.link};
     text-decoration: none;
@@ -155,16 +158,16 @@ export const TextLinkStyle = Styled(Link)`
 
 export const ButtonFont = Styled(Text)`
   font-size: ${fontSizes[2]}px;
-  font-weight: 400;
-  line-height: 14px;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  font-weight: ${fontWeights.regular};
+  line-height: ${lineHeights[0]};
+  font-family: ${fonts.default};
   padding: ${space[0]}px ${space[2]}px;
   height: auto;
 `;
 
 export const BlockQuote = Styled.blockquote`
   border-left: ${borders.default};
-  font-weight: normal;
+  font-weight: ${fontWeights.regular};
   margin-left: 0;
   padding-left: 32px;
   border-width: 4px;
@@ -176,10 +179,10 @@ export const BlockQuote = Styled.blockquote`
 
 export const BadgeFont = Styled(Text)`
   font-size: ${fontSizes[0]}px;
-  font-weight: 500;
-  line-height: 12px;
-  font-family: BasisMono, monospace;
-  padding: 2px ${space[1]}px 3px ${space[1]}px ;
+  font-weight: ${fontWeights.medium};
+  line-height: ${lineHeights[0]};
+  font-family: ${fonts.monospace};
+  padding: 2px ${space[1]}px 3px ${space[1]}px;
   height: auto;
   text-transform: uppercase;
   vertical-align: baseline;
@@ -188,9 +191,9 @@ export const BadgeFont = Styled(Text)`
 export const TopNavLink = Styled(NavLink)`
   font-size: ${fontSizes[1]}px;
   margin: 0;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
-  line-height: 14px;
-  font-weight: 400;
+  font-family: ${fonts.default};
+  line-height: ${lineHeights[0]};
+  font-weight: ${fontWeights.regular};
   color: ${colors.text.primary};
   text-decoration: none;
   &:hover {
@@ -203,8 +206,8 @@ export const TopNavLink = Styled(NavLink)`
 export const TextLink = Styled(Link)`
   color: ${colors.text.link};
   text-decoration: none;
-  line-height: 20px;
-  font-family: BasisMedium, Helvetica, Ariel, sans-serif;
+  line-height: ${lineHeights[0]};
+  font-family: ${fonts.default};
   &:hover {
     color: ${colors.text.link};
     text-decoration: none;

--- a/app/themes/baseTheme.js
+++ b/app/themes/baseTheme.js
@@ -78,6 +78,7 @@ export default {
   fonts,
   fontSizes,
   fontWeights,
+  lineHeights,
   mediaQueries,
   radii,
   shadows,

--- a/app/themes/baseTheme.js
+++ b/app/themes/baseTheme.js
@@ -45,6 +45,8 @@ export const fontWeights = {
   black: 900,
 };
 
+export const lineHeights = [1, 1.25, 1.33, 1.5, 1.75, 2];
+
 export const mediaQueries = {
   phone: '@media screen and (max-width: 512px)',
   tablet: '@media screen and (max-width: 767px)',


### PR DESCRIPTION
Noticed that all the line-heights in the `FontStyles` components were hard-coded to pixel values.  I've updated them to use unit-less values from the theme.

I've requested a couple of reviewers, but I'll just merge this in once one of you approves.