### PR TITLE
[WEB-559] Add IconButton component with required aria labels

### DIFF
--- a/app/components/elements/.eslintrc
+++ b/app/components/elements/.eslintrc
@@ -17,6 +17,7 @@
     "import/no-extraneous-dependencies": 0,
     "import/no-named-as-default": 0,
     "import/no-named-as-default-member": 0,
+    "import/no-named-default": 0,
     "import/no-useless-path-segments": 0,
     "import/order": 0,
     "import/prefer-default-export": 0,

--- a/app/components/elements/DatePicker.js
+++ b/app/components/elements/DatePicker.js
@@ -9,6 +9,7 @@ import noop from 'lodash/noop';
 import styled from 'styled-components';
 
 import { DatePicker as StyledDatePickerBase } from './InputStyles';
+import { IconButton } from './IconButton';
 
 import {
   colors,
@@ -62,9 +63,9 @@ export const DatePicker = (props) => {
         placeholder="mm/dd/yyyy"
         displayFormat="MMM D, YYYY"
         verticalSpacing={0}
-        navNext={<NavigateNextRoundedIcon />}
-        navPrev={<NavigateBeforeRoundedIcon />}
-        customCloseIcon={<CloseRoundedIcon />}
+        navNext={<IconButton label="next month" icon={NavigateNextRoundedIcon} />}
+        navPrev={<IconButton label="previous month" icon={NavigateBeforeRoundedIcon} />}
+        customCloseIcon={<IconButton label="clear dates" icon={CloseRoundedIcon} />}
         isOutsideRange={props.isOutsideRange}
         daySize={36}
         enableOutsideDays

--- a/app/components/elements/DateRangePicker.js
+++ b/app/components/elements/DateRangePicker.js
@@ -10,6 +10,7 @@ import noop from 'lodash/noop';
 import styled from 'styled-components';
 
 import { DatePicker as StyledDatePickerBase } from './InputStyles';
+import { IconButton } from './IconButton';
 
 import {
   colors,
@@ -98,10 +99,10 @@ export const DateRangePicker = (props) => {
         numberOfMonths={2}
         displayFormat="MMM D, YYYY"
         verticalSpacing={0}
-        navNext={<NavigateNextRoundedIcon />}
-        navPrev={<NavigateBeforeRoundedIcon />}
-        customCloseIcon={<CloseRoundedIcon />}
-        customArrowIcon={<ArrowRightAltRoundedIcon />}
+        navNext={<IconButton label="next month" icon={NavigateNextRoundedIcon} />}
+        navPrev={<IconButton label="previous month" icon={NavigateBeforeRoundedIcon} />}
+        customCloseIcon={<IconButton label="clear dates" icon={CloseRoundedIcon} />}
+        customArrowIcon={<IconButton label="to" icon={ArrowRightAltRoundedIcon} />}
         isOutsideRange={props.isOutsideRange}
         enableOutsideDays={props.enableOutsideDays}
         daySize={36}

--- a/app/components/elements/IconButton.js
+++ b/app/components/elements/IconButton.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { default as IconButtonBase } from '@material-ui/core/IconButton';
+
+export const IconButton = props => {
+  const { icon: Icon, label, ...buttonProps } = props;
+  const StyledIconButton = styled(IconButtonBase)`
+    padding: 0;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background: none;
+    }
+  `;
+
+  return (
+    <StyledIconButton disableFocusRipple disableRipple aria-label={label} {...buttonProps}>
+      <Icon />
+    </StyledIconButton>
+  );
+};
+
+IconButton.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+};
+
+export default IconButton;

--- a/app/themes/.eslintrc
+++ b/app/themes/.eslintrc
@@ -18,6 +18,7 @@
     "import/no-named-as-default": 0,
     "import/no-named-as-default-member": 0,
     "import/no-useless-path-segments": 0,
+    "import/no-named-default": 0,
     "import/order": 0,
     "import/prefer-default-export": 0,
     "jsx-a11y/alt-text": 0,


### PR DESCRIPTION
Updated the various Date Picker icons to use a new `IconButton` component that requires an aria-label prop to be passed to it to enforce better accessibility