### PR TITLE
[WEB-591] Update Date Range Picker story to be responsive and simplify component API wrapper

### DIFF
--- a/app/components/elements/DatePicker.js
+++ b/app/components/elements/DatePicker.js
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
-import momentPropTypes from 'react-moment-proptypes';
 import { SingleDatePicker, SingleDatePickerShape } from 'react-dates';
 import NavigateBeforeRoundedIcon from '@material-ui/icons/NavigateBeforeRounded';
 import NavigateNextRoundedIcon from '@material-ui/icons/NavigateNextRounded';
 import CloseRoundedIcon from '@material-ui/icons/CloseRounded';
-import omit from 'lodash/omit';
 import noop from 'lodash/noop';
 import styled from 'styled-components';
 
@@ -41,22 +39,26 @@ const StyledDatePicker = styled(StyledDatePickerBase)`
 `;
 
 export const DatePicker = props => {
-  const [date, setDate] = useState(props.initialDate);
-  const [focused, setFocused] = useState(props.initialFocused);
+  const {
+    date: dateProp,
+    focused: focusedProp,
+    isOutsideRange,
+    onDateChange,
+    onFocusChange,
+    ...datePickerProps
+  } = props;
+  const [date, setDate] = useState(dateProp);
+  const [focused, setFocused] = useState(focusedProp);
 
   return (
     <StyledDatePicker>
       <SingleDatePicker
-        {...omit(props, [
-          'initialFocused',
-          'initialDate',
-        ])}
         date={date}
-        onDateChange={newDate => setDate(newDate) && props.onDateChange(newDate)}
+        onDateChange={newDate => setDate(newDate) && onDateChange(newDate)}
         focused={focused}
         onFocusChange={({ focused: newFocused }) => {
           setFocused(newFocused);
-          props.onFocusChange(newFocused);
+          onFocusChange(newFocused);
         }}
         id={props.id}
         numberOfMonths={1}
@@ -66,25 +68,22 @@ export const DatePicker = props => {
         navNext={<IconButton label="next month" icon={NavigateNextRoundedIcon} />}
         navPrev={<IconButton label="previous month" icon={NavigateBeforeRoundedIcon} />}
         customCloseIcon={<IconButton label="clear dates" icon={CloseRoundedIcon} />}
-        isOutsideRange={props.isOutsideRange}
+        isOutsideRange={isOutsideRange}
         daySize={36}
         enableOutsideDays
         hideKeyboardShortcutsPanel
         showClearDate
+        {...datePickerProps}
       />
     </StyledDatePicker>
   );
 };
 
-DatePicker.propTypes = {
-  ...SingleDatePickerShape,
-  initialDate: momentPropTypes.momentObj,
-  initialFocused: SingleDatePickerShape.focused,
-};
+DatePicker.propTypes = SingleDatePickerShape;
 
 DatePicker.defaultProps = {
-  initialDate: null,
-  initialFocused: false,
+  date: null,
+  focused: false,
   onDateChange: noop,
   onFocusChange: noop,
   isOutsideRange: noop,

--- a/app/components/elements/DateRangePicker.js
+++ b/app/components/elements/DateRangePicker.js
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import momentPropTypes from 'react-moment-proptypes';
 import { DateRangePicker as DateRangePickerBase, DateRangePickerShape } from 'react-dates';
 import ArrowRightAltRoundedIcon from '@material-ui/icons/ArrowRightAltRounded';
 import NavigateBeforeRoundedIcon from '@material-ui/icons/NavigateBeforeRounded';
 import NavigateNextRoundedIcon from '@material-ui/icons/NavigateNextRounded';
 import CloseRoundedIcon from '@material-ui/icons/CloseRounded';
-import omit from 'lodash/omit';
 import noop from 'lodash/noop';
 import styled from 'styled-components';
 
@@ -72,20 +70,22 @@ const StyledDateRangePicker = styled(StyledDatePickerBase)`
 `;
 
 export const DateRangePicker = props => {
-  const [dates, setDates] = useState({
-    startDate: props.initialStartDate,
-    endDate: props.initialEndDate,
-  });
-  const [focusedInput, setFocusedInput] = useState(props.initialFocusedInput);
+  const {
+    startDate,
+    endDate,
+    focusedInput: focusedInputProp,
+    isOutsideRange,
+    onDateChange,
+    onFocusChange,
+    ...datePickerProps
+  } = props;
+
+  const [dates, setDates] = useState({ startDate, endDate });
+  const [focusedInput, setFocusedInput] = useState(focusedInputProp);
 
   return (
     <StyledDateRangePicker>
       <DateRangePickerBase
-        {...omit(props, [
-          'initialStartDate',
-          'initialEndDate',
-          'initialFocusedInput',
-        ])}
         startDate={dates.startDate}
         startDateId={props.startDateId}
         endDate={dates.endDate}
@@ -103,27 +103,21 @@ export const DateRangePicker = props => {
         navPrev={<IconButton label="previous month" icon={NavigateBeforeRoundedIcon} />}
         customCloseIcon={<IconButton label="clear dates" icon={CloseRoundedIcon} />}
         customArrowIcon={<IconButton label="to" icon={ArrowRightAltRoundedIcon} />}
-        isOutsideRange={props.isOutsideRange}
-        enableOutsideDays={props.enableOutsideDays}
         daySize={36}
         hideKeyboardShortcutsPanel
         showClearDates
+        {...datePickerProps}
       />
     </StyledDateRangePicker>
   );
 };
 
-DateRangePicker.propTypes = {
-  ...DateRangePickerShape,
-  initialStartDate: momentPropTypes.momentObj,
-  initialEndDate: momentPropTypes.momentObj,
-  initialFocusedInput: DateRangePickerShape.focusedInput,
-};
+DateRangePicker.propTypes = DateRangePickerShape;
 
 DateRangePicker.defaultProps = {
-  initialStartDate: null,
-  initialEndDate: null,
-  initialFocusedInput: null,
+  startDate: null,
+  endDate: null,
+  focusedInput: null,
   onDatesChange: noop,
   onFocusChange: noop,
   isOutsideRange: noop,

--- a/stories/Datepicker.stories.js
+++ b/stories/Datepicker.stories.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import moment from 'moment';
+import WindowSizeListener from 'react-window-size-listener';
 
 import { withDesign } from 'storybook-addon-designs';
 import { withKnobs, boolean, date, optionsKnob as options } from '@storybook/addon-knobs';
@@ -21,7 +22,7 @@ export default {
 export const DatePickerStory = () => {
   const initialDate = new Date();
 
-  const initialDateKnob = (name, defaultValue) => {
+  const dateKnob = (name, defaultValue) => {
     const stringTimestamp = date(name, defaultValue);
     return moment.utc(stringTimestamp);
   };
@@ -30,8 +31,8 @@ export const DatePickerStory = () => {
 
   return <DatePicker
     id="singleDatePicker"
-    initialFocused={getFocused()}
-    initialDate={initialDateKnob('Initial Date', initialDate)}
+    focused={getFocused()}
+    date={dateKnob('Initial Date', initialDate)}
   />;
 };
 
@@ -50,7 +51,7 @@ export const DateRangePickerStory = () => {
   const initialEndDate = new Date();
   initialEndDate.setDate(initialEndDate.getDate() + 7);
 
-  const initialDateKnob = (name, defaultValue) => {
+  const dateKnob = (name, defaultValue) => {
     const stringTimestamp = date(name, defaultValue);
     return moment.utc(stringTimestamp);
   };
@@ -71,13 +72,25 @@ export const DateRangePickerStory = () => {
     return options(label, valuesObj, defaultValue, optionsObj);
   };
 
-  return <DateRangePicker
-    startDateId="dateRangeStart"
-    endDateId="dateRangeEnd"
-    initialFocusedInput={focusedInputKnob()}
-    initialStartDate={initialDateKnob('Initial Start Date', initialStartDate)}
-    initialEndDate={initialDateKnob('Initial End Date', initialEndDate)}
-  />;
+  const [orientation, setOrientation] = useState('horizontal');
+
+  const handleWindowResize = size => {
+    setOrientation(size.windowWidth > 550 ? 'horizontal' : 'vertical');
+  };
+
+  return (
+    <React.Fragment>
+      <DateRangePicker
+        startDateId="dateRangeStart"
+        endDateId="dateRangeEnd"
+        orientation={orientation}
+        focusedInput={focusedInputKnob()}
+        startDate={dateKnob('Initial Start Date', initialStartDate)}
+        endDate={dateKnob('Initial End Date', initialEndDate)}
+      />
+      <WindowSizeListener onResize={handleWindowResize} />
+    </React.Fragment>
+  );
 };
 
 DateRangePickerStory.story = {


### PR DESCRIPTION
This PR updates the example date range picker in the storybook to be responsive.

I also made a couple of small changes to the datepicker component wrapper props. Initially, I had a couple of "extra" props available for setting initial values.

After taking a more minimalist approach on the Dialog component wrappers, I wanted to apply the same approach here to simplify them a little.  There is no lost functionality.  The extra props were not necessary, as they performed the same function as existing props, only with different names.