### PR TITLE
[WEB-589] Add processing and disabled button states, and storybook for Primary and Secondary buttons

### DIFF
--- a/app/components/elements/Button.js
+++ b/app/components/elements/Button.js
@@ -1,6 +1,8 @@
-import React from 'react';
-import { Button as Base } from 'rebass/styled-components';
-import styled from 'styled-components';
+import React, { useContext } from 'react';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { Button as Base, Box } from 'rebass/styled-components';
+import styled, { ThemeContext } from 'styled-components';
+import cx from 'classnames';
 
 import { ButtonFont } from './FontStyles';
 
@@ -11,14 +13,47 @@ import {
 const StyledButton = styled(Base)`
   cursor: pointer;
   transition: ${transitions.easeOut};
+  position: relative;
+
+  &:disabled {
+    pointer-events: none;
+  }
+
+  &.processing {
+    pointer-events: none;
+    line-height: 0;
+
+    ${ButtonFont} {
+      visibility: hidden;
+    }
+  }
+`;
+
+const StyledCircularProgress = styled(Box)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 `;
 
 export const Button = props => {
-  const { children, ...buttonProps } = props;
+  const { children, processing, ...buttonProps } = props;
+  const classNames = cx({ processing });
+
+  const themeContext = useContext(ThemeContext);
 
   return (
-    <StyledButton {...buttonProps}>
+    <StyledButton {...buttonProps} className={classNames}>
       <ButtonFont>{children}</ButtonFont>
+      { processing && (
+        <StyledCircularProgress>
+          <CircularProgress
+            color="inherit"
+            size={themeContext.fontSizes[3]}
+            thickness={5}
+          />
+        </StyledCircularProgress>
+      )}
     </StyledButton>
   );
 };

--- a/app/themes/base/buttons.js
+++ b/app/themes/base/buttons.js
@@ -4,19 +4,29 @@ export default ({ colors, borders }) => ({
     border: borders.input,
     borderColor: colors.purpleMedium,
     color: colors.white,
-    '&:hover,&:active,&:focus': {
+    '&:hover,&:active': {
       backgroundColor: colors.text.primary,
       borderColor: colors.text.primary,
+    },
+    '&:disabled': {
+      backgroundColor: colors.lightestGrey,
+      borderColor: colors.lightestGrey,
+      color: colors.text.primaryDisabled,
     },
   },
   secondary: {
     bg: colors.white,
     color: colors.text.primary,
     border: borders.input,
-    '&:hover,&:active,&:focus': {
+    '&:hover,&:active': {
       color: colors.white,
       backgroundColor: colors.text.primary,
       borderColor: colors.text.primary,
+    },
+    '&:disabled': {
+      backgroundColor: colors.lightestGrey,
+      borderColor: colors.lightestGrey,
+      color: colors.text.primaryDisabled,
     },
   },
 });

--- a/app/themes/colorPalette.js
+++ b/app/themes/colorPalette.js
@@ -14,7 +14,7 @@ export default {
   },
   neutrals: {
     white: '#FFFFFF',
-    lightestGrey: '#F9F9F9',
+    lightestGrey: '#F6F6F6',
     lightGrey: '#EDEDED',
     mediumGrey: '#979797',
     darkGrey: '#606060',

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { withDesign } from 'storybook-addon-designs';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { ThemeProvider } from 'styled-components';
+
+import baseTheme from '../app/themes/baseTheme';
+import Button from '../app/components/elements/Button';
+
+/* eslint-disable max-len */
+
+// Wrap each story component with the base theme
+const withTheme = Story => (
+  <ThemeProvider theme={baseTheme}>
+    <Story />
+  </ThemeProvider>
+);
+
+export default {
+  title: 'Buttons',
+  decorators: [withDesign, withKnobs, withTheme],
+};
+
+const disabled = () => boolean('Disabled', false);
+const processing = () => boolean('Processing', false);
+
+export const Primary = () => {
+  const buttonText = () => text('Button Text', 'Primary');
+
+  return (
+    <React.Fragment>
+      <Button
+        variant="primary"
+        disabled={disabled()}
+        onClick={action('onClick called')}
+        processing={processing()}
+      >
+        {buttonText()}
+      </Button>
+    </React.Fragment>
+  );
+};
+
+Primary.story = {
+  name: 'Primary',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/iuXkrpuLTXExSnuPJE3Jtn/Tidepool-Design-System-Sprint-1?node-id=3%3A2',
+    },
+  },
+};
+
+export const Secondary = () => {
+  const buttonText = () => text('Button Text', 'Secondary');
+
+  return (
+    <React.Fragment>
+      <Button
+        variant="secondary"
+        disabled={disabled()}
+        onClick={action('onClick called')}
+        processing={processing()}
+      >
+        {buttonText()}
+      </Button>
+    </React.Fragment>
+  );
+};
+
+Secondary.story = {
+  name: 'Secondary',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/iuXkrpuLTXExSnuPJE3Jtn/Tidepool-Design-System-Sprint-1?node-id=3%3A2',
+    },
+  },
+};

--- a/stories/Dialog.stories.js
+++ b/stories/Dialog.stories.js
@@ -45,7 +45,7 @@ export const DialogStory = () => {
 
     while (i > 0) {
       paragraphs.push((
-        <Body1 id={`paragraph-${i}`}>
+        <Body1 id={`paragraph-${i}`} key={`paragraph-${i}`}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </Body1>
       ));


### PR DESCRIPTION
[WEB-589]

This adds some missing disabled and processing button styles that were not present in the PR for the Dialog component, and a new `Buttons` storybook.

As well, you'll notice some reverted commits.  I'd accidentally committed these directly to the `web-559-component-library` branch, and reverted it there, which meant that I had to "revert the revert" in this branch to allow the changes to be applied.

Also includes a small console warning fix for the Dialog component

[WEB-589]: https://tidepool.atlassian.net/browse/WEB-589