### PR TITLE
[WEB-768,WEB-770] Release v1.31.1 to master

### DIFF
--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -254,9 +254,10 @@ class Daily extends Component {
     const newDataAdded = this.props.addingData.inProgress && nextProps.addingData.completed;
     const dataUpdated = this.props.updatingDatum.inProgress && nextProps.updatingDatum.completed;
     const newDataRecieved = this.props.queryDataCount !== nextProps.queryDataCount;
+    const wrappedInstance = _.get(this.refs, 'chart.wrappedInstance');
 
-    if (this.refs.chart && (loadingJustCompleted || newDataAdded || dataUpdated || newDataRecieved)) {
-      this.refs.chart.getWrappedInstance().rerenderChart(nextProps);
+    if (wrappedInstance && (loadingJustCompleted || newDataAdded || dataUpdated || newDataRecieved)) {
+      wrappedInstance.rerenderChart(nextProps);
     }
   };
 

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -270,6 +270,7 @@ class Daily extends Component {
   render = () => {
     const timePrefs = _.get(this.props, 'data.timePrefs', {});
     const bgPrefs = _.get(this.props, 'data.bgPrefs', {});
+    const dayDataReady = _.get(this.props, 'data.data.current.endpoints.days') === 1;
 
     return (
       <div id="tidelineMain" className="daily">
@@ -297,7 +298,7 @@ class Daily extends Component {
           <div className="container-box-inner patient-data-content-inner">
             <div className="patient-data-content">
               <Loader show={!!this.refs.chart && this.props.loading} overlay={true} />
-              {this.renderChart()}
+              {dayDataReady && this.renderChart()}
             </div>
           </div>
           <div className="container-box-inner patient-data-sidebar">

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -700,7 +700,7 @@ export let PatientData = translate()(React.createClass({
   },
 
   handleSwitchToDaily: function(datetime, title) {
-    this.props.trackMetric('Clicked Basics '+title+' calendar', {
+    if (title) this.props.trackMetric(`Clicked Basics ${title} calendar`, {
       fromChart: this.state.chartType
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.1-rc.2",
+  "version": "1.31.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.0",
+  "version": "1.31.1-web-768.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.1-rc.1",
+  "version": "1.31.1-rc.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/polyfill": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
-    "@tidepool/viz": "1.11.1-rc.1",
+    "@tidepool/viz": "1.11.2",
     "async": "2.6.1",
     "autoprefixer": "9.1.5",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.31.1-web-768.1",
+  "version": "1.31.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/polyfill": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
-    "@tidepool/viz": "1.11.0",
+    "@tidepool/viz": "1.11.1-rc.1",
     "async": "2.6.1",
     "autoprefixer": "9.1.5",
     "babel-core": "7.0.0-bridge.0",

--- a/test/unit/components/chart/daily.test.js
+++ b/test/unit/components/chart/daily.test.js
@@ -169,12 +169,20 @@ describe('Daily', () => {
       sinon.assert.callCount(props.onClickPrint, 1);
     });
 
-    it('should show a loader when loading prop is true', () => {
-      var props = _.assign({}, baseProps, {
+    it('should show a loader when loading prop is true and the daily chart is rendered', () => {
+      var dayDataReadyProps = _.assign({}, baseProps, {
         loading: false,
+        data: {
+          data: { current: { endpoints: { days: 1 } } },
+          bgPrefs,
+          timePrefs: {
+            timezoneAware: false,
+            timezoneName: 'US/Pacific',
+          },
+        },
       });
 
-      wrapper.setProps(props);
+      wrapper.setProps(dayDataReadyProps);
 
       const loader = () => wrapper.find(Loader);
 
@@ -183,6 +191,27 @@ describe('Daily', () => {
 
       wrapper.setProps({ loading: true });
       expect(loader().props().show).to.be.true;
+    });
+
+    it('should only render the daily chart when the daily data is ready', () => {
+      var dayDataReadyProps = _.assign({}, baseProps, {
+        loading: false,
+        data: {
+          data: { current: { endpoints: { days: 1 } } },
+          bgPrefs,
+          timePrefs: {
+            timezoneAware: false,
+            timezoneName: 'US/Pacific',
+          },
+        },
+      });
+
+      const chart = () => wrapper.find('.fake-daily-chart');
+
+      expect(chart().length).to.equal(0);
+
+      wrapper.setProps(dayDataReadyProps);
+      expect(chart().length).to.equal(1);
     });
 
     it('should render the bg toggle', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,10 +841,10 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
 
-"@tidepool/viz@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.11.0.tgz#a52f8f0faea43c1da01ba5f9a20355168ce21e1d"
-  integrity sha512-mMZHFDaxf6JvMoYy8fYQz2XMtfbpar4+8QHOSeOQEvYkmPKSSM8JTbXD840qIuGtMgC4/CYqQJ3ev7zrj6N/Ow==
+"@tidepool/viz@1.11.1-rc.1":
+  version "1.11.1-rc.1"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.11.1-rc.1.tgz#0312a84cd555aba7637c905fd6e2d28fb2899d49"
+  integrity sha512-3ClaGG97EGJXTROKp3CweucqPALQkGb5kvLsvMYaoRpe7VTCDTvO4/vr6MwAtbLJYDQhohD17zu4ENbFxZo8cw==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.0"
@@ -10081,7 +10081,7 @@ reduce-component@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/reduce-component/-/reduce-component-1.0.1.tgz#e0c93542c574521bea13df0f9488ed82ab77c5da"
 
-reductio@crossfilter/reductio#0c45b03559:
+"reductio@github:crossfilter/reductio#0c45b03559":
   version "0.6.3"
   resolved "https://codeload.github.com/crossfilter/reductio/tar.gz/0c45b0355950101d395d6482e2083ce1cdbcf435"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,10 +841,10 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
 
-"@tidepool/viz@1.11.1-rc.1":
-  version "1.11.1-rc.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.11.1-rc.1.tgz#0312a84cd555aba7637c905fd6e2d28fb2899d49"
-  integrity sha512-3ClaGG97EGJXTROKp3CweucqPALQkGb5kvLsvMYaoRpe7VTCDTvO4/vr6MwAtbLJYDQhohD17zu4ENbFxZo8cw==
+"@tidepool/viz@1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.11.2.tgz#6e1480d53aec1cc376db8c3e77d9c7c140249de1"
+  integrity sha512-7E3LeEBi1t4q92k6tg/8ho3R2B0oGVyhBbKs1J1b/omT0VEULoVoCd6BafXMNNdFlVaBot+jVb8h82Q27VULdA==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10081,7 +10081,7 @@ reduce-component@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/reduce-component/-/reduce-component-1.0.1.tgz#e0c93542c574521bea13df0f9488ed82ab77c5da"
 
-"reductio@github:crossfilter/reductio#0c45b03559":
+reductio@crossfilter/reductio#0c45b03559:
   version "0.6.3"
   resolved "https://codeload.github.com/crossfilter/reductio/tar.gz/0c45b0355950101d395d6482e2083ce1cdbcf435"
   dependencies:


### PR DESCRIPTION
Addresses [WEB-768] and [WEB-770]

Related PR: 
tidepool-org/viz#193

This PR addresses the 'rerenderChart' error found via rollbar, including getting to the root cause which was that sometimes the chart was being initialized with incorrect data (such as the data queried to determine the default initial view, or the PDF data).  This PR ensures that the daily data has been provided before initializing the chart.

It also helps in that if there is a chart error while initializing, the error popup doesn't fire indefinitely anymore.  It fires once, and then can be closed by the user and they can interact with the application again.

It also pulls in a fix from `viz` that addresses an issue where under certain circumstances, a user with no device settings data will show the settings data of the previously loaded user.

[WEB-768]: https://tidepool.atlassian.net/browse/WEB-768
[WEB-770]: https://tidepool.atlassian.net/browse/WEB-770