### PR TITLE
[WEB-777] log original errors to rollbar

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -832,7 +832,15 @@ api.errors.log = function(error, message, properties, cb) {
   api.log('POST /errors');
 
   // Log error to Rollbar
-  _.isFunction(rollbar.error) && rollbar.error(error);
+  if (_.isFunction(rollbar.error)) {
+    const extra = {};
+    _.assign(extra, properties, message ? { message } : {});
+    if (_.isError(error.originalError)) {
+      _.assign(extra, { displayError: _.omit(error, ['originalError']) });
+      error = error.originalError;
+    }
+    rollbar.error(error, extra);
+  }
 
   return tidepool.logAppError(error, message, properties, cb);
 };

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -35,8 +35,11 @@ import utils from '../../core/utils';
 
 function createActionError(usrErrMessage, apiError) {
   const err = new Error(usrErrMessage);
-  if (apiError && apiError.status) {
-    err.status = apiError.status;
+  if (apiError) {
+    err.originalError = apiError;
+    if (apiError.status){
+      err.status = apiError.status;
+    }
   }
   return err;
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -164,7 +164,9 @@ export const requireNotVerified = (api, store) => (nextState, replace, cb) => {
         if (err.status === 401) {
           return cb();
         }
-        throw new Error('Error getting user at /email-verification');
+        const error = new Error('Error getting user at /email-verification');
+        error.originalError = err;
+        throw error;
       }
 
       checkIfVerified(user);

--- a/test/unit/app/core/api.test.js
+++ b/test/unit/app/core/api.test.js
@@ -488,6 +488,14 @@ describe('api', () => {
         sinon.assert.calledOnce(tidepool.logAppError);
         sinon.assert.calledWith(tidepool.logAppError, error, message, properties, cb);
       });
+
+      it('should log the originalError from an error object', () => {
+        const originalError = new Error('original');
+        const error = { originalError, other: 'property' };
+        api.errors.log(error);
+        sinon.assert.calledOnce(rollbar.error);
+        sinon.assert.calledWith(rollbar.error, originalError, { displayError: { other: 'property' }});
+      });
     });
   });
 });


### PR DESCRIPTION
For [WEB-777]. An analogue for changes reflected in Uploader in the following changeset: https://github.com/tidepool-org/uploader/pull/751

[WEB-777]: https://tidepool.atlassian.net/browse/WEB-777