### PR TITLE
[WEB-779] start with local time and convert to UTC

### DIFF
--- a/app/components/export/export.js
+++ b/app/components/export/export.js
@@ -64,8 +64,8 @@ export default translate()(class Export extends Component {
     if (this.state.allTime) {
       options = _.omit(options, ['endDate', 'startDate']);
     } else {
-      options.endDate = moment.utc(this.state.endDate).toISOString();
-      options.startDate = moment.utc(this.state.startDate).toISOString();
+      options.endDate = moment(this.state.endDate).utc().toISOString();
+      options.startDate = moment(this.state.startDate).utc().toISOString();
     }
 
     this.props.api.tidepool.getExportDataURL(
@@ -105,7 +105,6 @@ export default translate()(class Export extends Component {
         value = moment().format(JS_DATE_FORMAT);
       }
     }
-    
 
     this.setState({
       [name]: value
@@ -208,7 +207,7 @@ export default translate()(class Export extends Component {
             />{' '}
             {MMOLL_UNITS}
           </div>
-          
+
           <div className="Export-filetype">
             File type:
             <input


### PR DESCRIPTION
Covers [WEB-779] by initializing the `moment` with the dates in it's localized mode and then converting to a UTC timestamp before passing on to the export service as opposed to initializing an already assumed UTC timestamp from the dates directly. This branch was taken from and is intended to be merged into the current 1.32.0 release branch.

[WEB-779]: https://tidepool.atlassian.net/browse/WEB-779