### PR TITLE
[WEB-779] export end date time

### DIFF
--- a/app/components/export/export.js
+++ b/app/components/export/export.js
@@ -64,7 +64,7 @@ export default translate()(class Export extends Component {
     if (this.state.allTime) {
       options = _.omit(options, ['endDate', 'startDate']);
     } else {
-      options.endDate = moment(this.state.endDate).utc().toISOString();
+      options.endDate = moment(this.state.endDate).endOf('day').utc().toISOString();
       options.startDate = moment(this.state.startDate).utc().toISOString();
     }
 


### PR DESCRIPTION
For [WEB-779] adjusts the `endDate` for export to the end of that date, making the export range for the dates _inclusive_ instead of just including the entirety of the start date and ending at the beginning of the end date.

[WEB-779]: https://tidepool.atlassian.net/browse/WEB-779