### PR TITLE
[WEB-767] retain MRN when user edits profile

### DIFF
--- a/app/pages/patient/patientinfo.js
+++ b/app/pages/patient/patientinfo.js
@@ -759,10 +759,12 @@ var PatientInfo = translate()(React.createClass({
       }
     }
 
-    if (!formValues.mrn) {
-      delete updatedPatientProfile.mrn;
-    } else {
-      updatedPatientProfile.mrn = formValues.mrn;
+    if (personUtils.isClinic(this.props.user)) {
+      if (!formValues.mrn && updatedPatientProfile.mrn) {
+        delete updatedPatientProfile.mrn;
+      } else {
+        updatedPatientProfile.mrn = formValues.mrn;
+      }
     }
 
     return updatedPatient;

--- a/test/unit/pages/patient/patientinfo.test.js
+++ b/test/unit/pages/patient/patientinfo.test.js
@@ -842,8 +842,86 @@ describe('PatientInfo', function () {
       expect(result.profile.patient.about).to.be.an('undefined');
     });
 
-    it('should prepare full form and return expected values', function() {
+    it('should remove empty mrn field if user account is clinician', function() {
       var props = {
+        user: {
+          roles: ['clinic'],
+        },
+        patient: {
+          profile : {
+            patient: {
+              mrn: 'abcd1234'
+            },
+          },
+        },
+      };
+
+      var patientInfoElem = React.createElement(PatientInfo, props);
+      var elem = TestUtils.renderIntoDocument(patientInfoElem).getWrappedInstance();
+      var formValues = {
+        mrn: '',
+      };
+      var result = elem.prepareFormValuesForSubmit(formValues);
+
+      expect(result.profile.patient.mrn).to.be.an('undefined');
+    });
+
+    it('should not remove empty mrn field for non-clinical users', function() {
+      var props = {
+        patient: {
+          profile : {
+            patient: {
+              mrn: 'abcd1234',
+            },
+          },
+        },
+      };
+
+      var patientInfoElem = React.createElement(PatientInfo, props);
+      var elem = TestUtils.renderIntoDocument(patientInfoElem).getWrappedInstance();
+      var formValues = {};
+      var result = elem.prepareFormValuesForSubmit(formValues);
+
+      expect(result.profile.patient.mrn).to.equal('abcd1234');
+    });
+
+    it('should prepare full form and return expected values for normal user', function() {
+      var props = {
+        patient: {
+          profile : {
+            patient: {},
+          },
+        },
+      };
+
+      var patientInfoElem = React.createElement(PatientInfo, props);
+      var elem = TestUtils.renderIntoDocument(patientInfoElem).getWrappedInstance();
+      var formValues = {
+        about: 'I am a testing developer.',
+        birthday: '02-02-1990',
+        diagnosisDate: '04-05-2001',
+        diagnosisType: 'type1',
+        email: 'exampleEmail@example.com',
+      };
+      var result = elem.prepareFormValuesForSubmit(formValues);
+
+      expect(result.profile.patient.about).to.equal('I am a testing developer.');
+      expect(result.profile.patient.birthday).to.equal('1990-02-02');
+      expect(result.profile.patient.diagnosisDate).to.equal('2001-04-05');
+      expect(result.profile.patient.diagnosisType).to.equal('type1');
+      expect(result.emails).to.have.length(1);
+      expect(result.emails[0]).to.equal('exampleEmail@example.com');
+      expect(result.username).to.equal('exampleEmail@example.com');
+      expect(result.profile.emails).to.have.length(1)
+      expect(result.profile.emails[0]).to.equal('exampleEmail@example.com');
+      expect(result.profile.patient.email).to.equal('exampleEmail@example.com');
+    });
+
+    it('should prepare full form and return expected values for clinic', function() {
+      var props = {
+        user: {
+          roles: ['clinic'],
+        },
         patient: {
           profile : {
             patient: {},


### PR DESCRIPTION
Takes care of [WEB-767] by not considering an empty MRN form field to represent an intentional deletion of that field by a normal user (for whom the MRN field doesn't render). 

[WEB-767]: https://tidepool.atlassian.net/browse/WEB-767