### PR TITLE
[WEB-783] use series instead of parallel for user.put

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -303,7 +303,7 @@ api.user.put = function(user, cb) {
   const profile = profileFromUser(user);
   const preferences = preferencesFromUser(user);
 
-  async.parallel({
+  async.series({
     account: tidepool.updateCurrentUser.bind(tidepool, account),
     profile: tidepool.addOrUpdateProfile.bind(tidepool, user.userid, profile),
     preferences: tidepool.addOrUpdatePreferences.bind(tidepool, user.userid, preferences)


### PR DESCRIPTION
For [WEB-783] to prevent race condition between the `preferences` and `profile` calls, specifically.

[WEB-783]: https://tidepool.atlassian.net/browse/WEB-783