### PR TITLE
[WEB-758] Pagination component

### DIFF
--- a/app/components/elements/Button.js
+++ b/app/components/elements/Button.js
@@ -5,8 +5,6 @@ import { Button as Base, Box, ButtonProps } from 'rebass/styled-components';
 import styled, { ThemeContext } from 'styled-components';
 import cx from 'classnames';
 
-import { ButtonFont } from './FontStyles';
-
 import {
   transitions,
 } from '../../themes/baseTheme';
@@ -22,15 +20,15 @@ const StyledButton = styled(Base)`
 
   &.processing {
     pointer-events: none;
-    line-height: 0;
 
-    ${ButtonFont} {
+    > div:first-child {
       visibility: hidden;
     }
   }
 `;
 
 const StyledCircularProgress = styled(Box)`
+  display: flex;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -38,14 +36,14 @@ const StyledCircularProgress = styled(Box)`
 `;
 
 export const Button = props => {
-  const { children, processing, ...buttonProps } = props;
+  const { children, processing, className = '', ...buttonProps } = props;
   const classNames = cx({ processing });
 
   const themeContext = useContext(ThemeContext);
 
   return (
-    <StyledButton variant="primary" {...buttonProps} className={classNames}>
-      <ButtonFont>{children}</ButtonFont>
+    <StyledButton variant="primary" {...buttonProps} className={`${classNames} ${className}`}>
+      <div>{children}</div>
       {processing && (
         <StyledCircularProgress>
           <CircularProgress

--- a/app/components/elements/FontStyles.js
+++ b/app/components/elements/FontStyles.js
@@ -156,15 +156,6 @@ export const TextLinkStyle = Styled(Link)`
   }
 `;
 
-export const ButtonFont = Styled(Text)`
-  font-size: ${fontSizes[2]}px;
-  font-weight: ${fontWeights.regular};
-  line-height: ${lineHeights[0]};
-  font-family: ${fonts.default};
-  padding: ${space[0]}px ${space[2]}px;
-  height: auto;
-`;
-
 export const BlockQuote = Styled.blockquote`
   border-left: ${borders.default};
   font-weight: ${fontWeights.regular};

--- a/app/components/elements/Icon.js
+++ b/app/components/elements/Icon.js
@@ -46,11 +46,11 @@ Icon.propTypes = {
   ...BoxProps,
   icon: PropTypes.elementType.isRequired,
   label: PropTypes.string.isRequired,
-  variant: PropTypes.oneOf(['static', 'button']),
+  variant: PropTypes.oneOf(['default', 'static', 'button']),
 };
 
 Icon.defaultProps = {
-  variant: 'static',
+  variant: 'default',
 };
 
 export default Icon;

--- a/app/components/elements/Pagination.js
+++ b/app/components/elements/Pagination.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { default as Base, PaginationProps } from '@material-ui/lab/Pagination';
+import { borders, colors, space } from '../../themes/baseTheme';
+
+const StyledPagination = styled(Base)``;
+
+export const Pagination = props => {
+  return <StyledPagination {...props} />;
+};
+
+Pagination.propTypes = {
+  ...PaginationProps,
+};
+
+export default Pagination;

--- a/app/components/elements/Pagination.js
+++ b/app/components/elements/Pagination.js
@@ -1,75 +1,98 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import cx from 'classnames';
-
+import remove from 'lodash/remove';
+import includes from 'lodash/includes';
+import capitalize from 'lodash/capitalize';
+import { Box, Text, BoxProps } from 'rebass/styled-components';
+import FirstPageRoundedIcon from '@material-ui/icons/FirstPageRounded';
+import LastPageRoundedIcon from '@material-ui/icons/LastPageRounded';
+import NavigateBeforeRoundedIcon from '@material-ui/icons/NavigateBeforeRounded';
+import NavigateNextRoundedIcon from '@material-ui/icons/NavigateNextRounded';
+import MoreHorizRoundedIcon from '@material-ui/icons/MoreHorizRounded';
 import { PaginationProps } from '@material-ui/lab/Pagination';
-// import { borders, colors, space } from '../../themes/baseTheme';
 import { usePagination } from '@material-ui/lab/Pagination';
 
-const StyledPagination = styled('nav')`
-  ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-  }
-`;
+import Button from './Button';
 
 export const Pagination = props => {
-  const { variation, ...itemProps } = props;
+  const { id, variant, themeProps, ...paginationProps } = props;
 
   const classNames = cx({
-    condensed: variation === 'condensed',
+    condensed: variant === 'condensed',
   })
 
-  const { items } = usePagination(itemProps);
+  const { items } = usePagination(paginationProps);
+  const prevControls = remove(items, ({type}) => includes(['first', 'previous'], type))
+  const nextControls = remove(items, ({type}) => includes(['next', 'last'], type))
 
   return (
-    <StyledPagination>
+    <Box as="nav" variant={`paginators.${variant}`} {...themeProps}>
       <ul className={classNames}>
-        {items.map(({ page, type, selected, ...item }, index) => {
-          let children;
+        <li>
+          <ul className="prev-controls">
+            {prevControls.map(({ type, ...item }, index) => (
+              <li id={`${id}-${type}`} key={index}>
+                <Button px={2} variant="pagination" {...item}>
+                  {type === 'first' && <FirstPageRoundedIcon />}
+                  {type === 'previous' && <NavigateBeforeRoundedIcon />}
+                  {variant === 'default' && <Text pl={1}>{capitalize(type)}</Text>}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </li>
+        <li>
+          <ul className="pages">
+            {items.map(({ page, type, selected, ...item }, index) => {
+              const pageClassNames = cx({
+                selected,
+              });
 
-          if (type === 'start-ellipsis' || type === 'end-ellipsis') {
-            children = '…';
-          } else if (type === 'page') {
-            children = (
-              <button type="button" style={{ fontWeight: selected ? 'bold' : null }} {...item}>
-                {page}
-              </button>
-            );
-          } else {
-            let icon;
+              const itemId = type === 'page' ? `${id}-${page}` : `${id}-${type}`;
+              let children;
 
-            children = (
-              <button type="button" {...item}>
-                {type === 'previous' && '<'}
-                {variation === 'default' && type}
-                {type === 'next' && '>'}
-              </button>
-            );
-          }
+              if (type === 'start-ellipsis' || type === 'end-ellipsis') {
+                children = <Button disabled className='ellipsis' variant="pagination"><MoreHorizRoundedIcon /></Button>;
+              } else if (type === 'page') {
+                children = (
+                  <Button className={pageClassNames} variant="pagination" {...item}>
+                    {page}
+                  </Button>
+                );
+              }
 
-          return <li key={index}>{children}</li>;
-        })}
+              return <li id={itemId} key={index}>{children}</li>;
+            })}
+          </ul>
+        </li>
+        <li>
+          <ul className="next-controls">
+            {nextControls.map(({ type, ...item }, index) => (
+              <li id={`${id}-${type}`} key={index}>
+                <Button px={2} variant="pagination" {...item}>
+                  {variant === 'default' && <Text pr={1}>{capitalize(type)}</Text>}
+                  {type === 'next' && <NavigateNextRoundedIcon />}
+                  {type === 'last' && <LastPageRoundedIcon />}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </li>
       </ul>
-    </StyledPagination>
+    </Box>
   );
-  // return <StyledPagination
-  //   className={classNames}
-  //   renderItem={CustomPaginationItem}
-  //   {...props}
-  // />;
 };
 
 Pagination.propTypes = {
+  id: PropTypes.string.isRequired,
+  themeProps: PropTypes.shape(BoxProps),
   ...PaginationProps,
-  variation: PropTypes.oneOf(['default', 'condensed']),
+  variant: PropTypes.oneOf(['default', 'condensed']),
 };
 
 Pagination.defaultProps = {
-  variation: 'default',
+  variant: 'default',
 }
 
 export default Pagination;

--- a/app/components/elements/Pagination.js
+++ b/app/components/elements/Pagination.js
@@ -14,6 +14,8 @@ import MoreHorizRoundedIcon from '@material-ui/icons/MoreHorizRounded';
 import { usePagination, PaginationProps } from '@material-ui/lab/Pagination';
 
 import Button from './Button';
+import Icon from './Icon';
+import baseTheme from '../../themes/baseTheme';
 
 export const Pagination = props => {
   const { id, variant, themeProps, ...paginationProps } = props;
@@ -34,8 +36,8 @@ export const Pagination = props => {
             {map(prevControls, ({ type, ...item }) => (
               <li id={`${id}-${type}`} key={`${id}-${type}`}>
                 <Button px={2} variant="pagination" {...item}>
-                  {type === 'first' && <FirstPageRoundedIcon />}
-                  {type === 'previous' && <NavigateBeforeRoundedIcon />}
+                  {type === 'first' && <Icon variant="static" theme={baseTheme} label="Go to first page" icon={FirstPageRoundedIcon} />}
+                  {type === 'previous' && <Icon variant="static" theme={baseTheme} label="Go to previous page" icon={NavigateBeforeRoundedIcon} />}
                   {variant === 'default' && <Text pl={1}>{capitalize(type)}</Text>}
                 </Button>
               </li>
@@ -53,7 +55,11 @@ export const Pagination = props => {
               let children;
 
               if (type === 'start-ellipsis' || type === 'end-ellipsis') {
-                children = <Button disabled className="ellipsis" variant="pagination"><MoreHorizRoundedIcon /></Button>;
+                children = (
+                  <Button disabled className="ellipsis" variant="pagination">
+                    <Icon variant="static" theme={baseTheme} label="Ellipsis for skipped pages" icon={MoreHorizRoundedIcon} />
+                  </Button>
+                );
               } else if (type === 'page') {
                 children = (
                   <Button className={pageClassNames} variant="pagination" {...item}>
@@ -72,8 +78,8 @@ export const Pagination = props => {
               <li id={`${id}-${type}`} key={`${id}-${type}`}>
                 <Button px={2} variant="pagination" {...item}>
                   {variant === 'default' && <Text pr={1}>{capitalize(type)}</Text>}
-                  {type === 'next' && <NavigateNextRoundedIcon />}
-                  {type === 'last' && <LastPageRoundedIcon />}
+                  {type === 'next' && <Icon variant="static" theme={baseTheme} label="Go to next page" icon={NavigateNextRoundedIcon} />}
+                  {type === 'last' && <Icon variant="static" theme={baseTheme} label="Go to last page" icon={LastPageRoundedIcon} />}
                 </Button>
               </li>
             ))}

--- a/app/components/elements/Pagination.js
+++ b/app/components/elements/Pagination.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import map from 'lodash/map';
 import remove from 'lodash/remove';
 import includes from 'lodash/includes';
 import capitalize from 'lodash/capitalize';
@@ -10,8 +11,7 @@ import LastPageRoundedIcon from '@material-ui/icons/LastPageRounded';
 import NavigateBeforeRoundedIcon from '@material-ui/icons/NavigateBeforeRounded';
 import NavigateNextRoundedIcon from '@material-ui/icons/NavigateNextRounded';
 import MoreHorizRoundedIcon from '@material-ui/icons/MoreHorizRounded';
-import { PaginationProps } from '@material-ui/lab/Pagination';
-import { usePagination } from '@material-ui/lab/Pagination';
+import { usePagination, PaginationProps } from '@material-ui/lab/Pagination';
 
 import Button from './Button';
 
@@ -20,19 +20,19 @@ export const Pagination = props => {
 
   const classNames = cx({
     condensed: variant === 'condensed',
-  })
+  });
 
   const { items } = usePagination(paginationProps);
-  const prevControls = remove(items, ({type}) => includes(['first', 'previous'], type))
-  const nextControls = remove(items, ({type}) => includes(['next', 'last'], type))
+  const prevControls = remove(items, ({ type }) => includes(['first', 'previous'], type));
+  const nextControls = remove(items, ({ type }) => includes(['next', 'last'], type));
 
   return (
     <Box as="nav" variant={`paginators.${variant}`} {...themeProps}>
       <ul className={classNames}>
         <li>
           <ul className="prev-controls">
-            {prevControls.map(({ type, ...item }, index) => (
-              <li id={`${id}-${type}`} key={index}>
+            {map(prevControls, ({ type, ...item }) => (
+              <li id={`${id}-${type}`} key={`${id}-${type}`}>
                 <Button px={2} variant="pagination" {...item}>
                   {type === 'first' && <FirstPageRoundedIcon />}
                   {type === 'previous' && <NavigateBeforeRoundedIcon />}
@@ -44,7 +44,7 @@ export const Pagination = props => {
         </li>
         <li>
           <ul className="pages">
-            {items.map(({ page, type, selected, ...item }, index) => {
+            {map(items, ({ page, type, selected, ...item }) => {
               const pageClassNames = cx({
                 selected,
               });
@@ -53,7 +53,7 @@ export const Pagination = props => {
               let children;
 
               if (type === 'start-ellipsis' || type === 'end-ellipsis') {
-                children = <Button disabled className='ellipsis' variant="pagination"><MoreHorizRoundedIcon /></Button>;
+                children = <Button disabled className="ellipsis" variant="pagination"><MoreHorizRoundedIcon /></Button>;
               } else if (type === 'page') {
                 children = (
                   <Button className={pageClassNames} variant="pagination" {...item}>
@@ -62,14 +62,14 @@ export const Pagination = props => {
                 );
               }
 
-              return <li id={itemId} key={index}>{children}</li>;
+              return <li id={itemId} key={itemId}>{children}</li>;
             })}
           </ul>
         </li>
         <li>
           <ul className="next-controls">
-            {nextControls.map(({ type, ...item }, index) => (
-              <li id={`${id}-${type}`} key={index}>
+            {map(nextControls, ({ type, ...item }) => (
+              <li id={`${id}-${type}`} key={`${id}-${type}`}>
                 <Button px={2} variant="pagination" {...item}>
                   {variant === 'default' && <Text pr={1}>{capitalize(type)}</Text>}
                   {type === 'next' && <NavigateNextRoundedIcon />}
@@ -93,6 +93,6 @@ Pagination.propTypes = {
 
 Pagination.defaultProps = {
   variant: 'default',
-}
+};
 
 export default Pagination;

--- a/app/components/elements/Pagination.js
+++ b/app/components/elements/Pagination.js
@@ -1,17 +1,75 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { default as Base, PaginationProps } from '@material-ui/lab/Pagination';
-import { borders, colors, space } from '../../themes/baseTheme';
+import cx from 'classnames';
 
-const StyledPagination = styled(Base)``;
+import { PaginationProps } from '@material-ui/lab/Pagination';
+// import { borders, colors, space } from '../../themes/baseTheme';
+import { usePagination } from '@material-ui/lab/Pagination';
+
+const StyledPagination = styled('nav')`
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+  }
+`;
 
 export const Pagination = props => {
-  return <StyledPagination {...props} />;
+  const { variation, ...itemProps } = props;
+
+  const classNames = cx({
+    condensed: variation === 'condensed',
+  })
+
+  const { items } = usePagination(itemProps);
+
+  return (
+    <StyledPagination>
+      <ul className={classNames}>
+        {items.map(({ page, type, selected, ...item }, index) => {
+          let children;
+
+          if (type === 'start-ellipsis' || type === 'end-ellipsis') {
+            children = '…';
+          } else if (type === 'page') {
+            children = (
+              <button type="button" style={{ fontWeight: selected ? 'bold' : null }} {...item}>
+                {page}
+              </button>
+            );
+          } else {
+            let icon;
+
+            children = (
+              <button type="button" {...item}>
+                {type === 'previous' && '<'}
+                {variation === 'default' && type}
+                {type === 'next' && '>'}
+              </button>
+            );
+          }
+
+          return <li key={index}>{children}</li>;
+        })}
+      </ul>
+    </StyledPagination>
+  );
+  // return <StyledPagination
+  //   className={classNames}
+  //   renderItem={CustomPaginationItem}
+  //   {...props}
+  // />;
 };
 
 Pagination.propTypes = {
   ...PaginationProps,
+  variation: PropTypes.oneOf(['default', 'condensed']),
 };
+
+Pagination.defaultProps = {
+  variation: 'default',
+}
 
 export default Pagination;

--- a/app/themes/base/buttons.js
+++ b/app/themes/base/buttons.js
@@ -1,48 +1,95 @@
-export default ({ colors, borders, radii }) => ({
-  primary: {
-    backgroundColor: colors.purpleMedium,
-    border: borders.input,
-    borderColor: colors.purpleMedium,
-    color: colors.white,
-    borderRadius: radii.default,
-    '&:hover,&:active': {
-      backgroundColor: colors.text.primary,
-      borderColor: colors.text.primary,
-    },
-    '&:disabled': {
-      backgroundColor: colors.lightestGrey,
-      borderColor: colors.lightestGrey,
-      color: colors.text.primaryDisabled,
-    },
-  },
-  secondary: {
-    backgroundColor: colors.white,
-    color: colors.text.primary,
-    border: borders.input,
-    borderRadius: radii.default,
-    '&:hover,&:active': {
+export default ({ colors, borders, fontSizes, radii, fonts, space, fontWeights, lineHeights }) => {
+  const defaultStyles = {
+    fontSize: `${fontSizes[2]}px`,
+    fontWeight: fontWeights.regular,
+    lineHeight: lineHeights[0],
+    fontFamily: fonts.default,
+    padding: `${space[2]}px ${space[3]}px`,
+    height: 'auto',
+  };
+
+  return {
+    primary: {
+      ...defaultStyles,
+      backgroundColor: colors.purpleMedium,
+      border: borders.input,
+      borderColor: colors.purpleMedium,
       color: colors.white,
-      backgroundColor: colors.text.primary,
-      borderColor: colors.text.primary,
+      borderRadius: radii.default,
+      '&:hover,&:active': {
+        backgroundColor: colors.text.primary,
+        borderColor: colors.text.primary,
+      },
+      '&:disabled': {
+        backgroundColor: colors.lightestGrey,
+        borderColor: colors.lightestGrey,
+        color: colors.text.primaryDisabled,
+      },
     },
-    '&:disabled': {
-      backgroundColor: colors.lightestGrey,
-      borderColor: colors.lightestGrey,
-      color: colors.text.primaryDisabled,
+    secondary: {
+      ...defaultStyles,
+      backgroundColor: colors.white,
+      color: colors.text.primary,
+      border: borders.input,
+      borderRadius: radii.default,
+      '&:hover,&:active': {
+        color: colors.white,
+        backgroundColor: colors.text.primary,
+        borderColor: colors.text.primary,
+      },
+      '&:disabled': {
+        backgroundColor: colors.lightestGrey,
+        borderColor: colors.lightestGrey,
+        color: colors.text.primaryDisabled,
+      },
     },
-  },
-  text: {
-    backgroundColor: colors.white,
-    color: colors.text.primary,
-    border: 0,
-    borderRadius: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
-    '&:hover,&:active': {
-      color: colors.text.primarySubdued,
+    text: {
+      ...defaultStyles,
+      backgroundColor: colors.white,
+      color: colors.text.primary,
+      border: 0,
+      borderRadius: 0,
+      paddingLeft: 2,
+      paddingRight: 2,
+      '&:hover,&:active': {
+        color: colors.text.primarySubdued,
+      },
+      '&:disabled': {
+        color: colors.text.primaryDisabled,
+      },
     },
-    '&:disabled': {
-      color: colors.text.primaryDisabled,
+    pagination: {
+      ...defaultStyles,
+      fontSize: fontSizes[0],
+
+      fontWeight: fontWeights.medium,
+      backgroundColor: 'transparent',
+      color: colors.text.primary,
+      border: 0,
+      borderRadius: radii.input,
+      padding: 1,
+      '> div': {
+        display: 'flex',
+        alignItems: 'center',
+      },
+      '&:hover': {
+        backgroundColor: colors.lightGrey,
+      },
+      '&:active': {
+        backgroundColor: colors.blues[0],
+        color: colors.text.link,
+      },
+      '&:disabled': {
+        color: colors.text.primaryDisabled,
+      },
+      '&.selected': {
+        backgroundColor: colors.text.primary,
+        color: colors.white,
+
+        '&:disabled': {
+          backgroundColor: colors.text.primaryDisabled,
+        },
+      },
     },
-  },
-});
+  };
+};

--- a/app/themes/base/icons.js
+++ b/app/themes/base/icons.js
@@ -11,9 +11,17 @@ export default ({ colors, fontSizes, radii, space }) => {
   };
 
   return {
-    static: {
+    default: {
       ...common,
       fontSize: fontSizes[3],
+      padding: 0,
+      '&.disabled': disabled,
+    },
+    static: {
+      ...common,
+      backgroundColor: 'inherit',
+      color: 'inherit',
+      fontSize: 'inherit',
       padding: 0,
       '&.disabled': disabled,
     },
@@ -27,7 +35,7 @@ export default ({ colors, fontSizes, radii, space }) => {
         color: colors.text.link,
         backgroundColor: colors.blues[0],
       },
-      '&:disabled': disabled,
+      '&.disabled': disabled,
     },
   };
 };

--- a/app/themes/base/paginators.js
+++ b/app/themes/base/paginators.js
@@ -20,8 +20,10 @@ export default ({ colors, fonts, fontSizes }) => {
       'ul li > *': listItemStyles,
     },
 
-    '.MuiSvgIcon-root': {
-      fontSize: `${fontSizes[2]}px`,
+    '.prev-controls, .next-controls': {
+      'span .MuiSvgIcon-root': {
+        fontSize: `${fontSizes[2]}px`,
+      },
     },
 
     '.pages li > *': {
@@ -35,7 +37,6 @@ export default ({ colors, fonts, fontSizes }) => {
         width: 'auto',
 
         '.MuiSvgIcon-root': {
-          fontSize: 'inherit',
           position: 'relative',
           top: '2px',
         },

--- a/app/themes/base/paginators.js
+++ b/app/themes/base/paginators.js
@@ -1,0 +1,64 @@
+export default ({ colors, fonts, fontSizes }) => {
+  const listItemStyles = {
+    display: 'flex',
+    justifyContent: 'center',
+    marginLeft: 1,
+    marginRight: 1,
+  };
+
+  const defaultStyles = {
+    color: colors.text.primary,
+    fontFamily: fonts.default,
+    fontSize: `${fontSizes[1]}px`,
+
+    ul: {
+      listStyle: 'none',
+      padding: 0,
+      margin: 0,
+      display: 'flex',
+
+      'ul li > *': listItemStyles,
+    },
+
+    '.MuiSvgIcon-root': {
+      fontSize: `${fontSizes[2]}px`,
+    },
+
+    '.pages li > *': {
+      ...listItemStyles,
+      width: '24px',
+
+      '&.ellipsis': {
+        fontSize: `${fontSizes[2]}px`,
+        paddingLeft: 0,
+        paddingRight: 0,
+        width: 'auto',
+
+        '.MuiSvgIcon-root': {
+          fontSize: 'inherit',
+          position: 'relative',
+          top: '2px',
+        },
+      },
+    },
+  };
+
+  return {
+    default: {
+      ...defaultStyles,
+      '> ul': {
+        justifyContent: 'space-between',
+      },
+    },
+    condensed: {
+      ...defaultStyles,
+      'ul ul li > *': {
+        ...listItemStyles,
+        width: '24px',
+      },
+      '> ul': {
+        justifyContent: 'center',
+      },
+    },
+  };
+};

--- a/app/themes/base/paginators.js
+++ b/app/themes/base/paginators.js
@@ -17,6 +17,10 @@ export default ({ colors, fonts, fontSizes }) => {
       margin: 0,
       display: 'flex',
 
+      ul: {
+        alignItems: 'center',
+      },
+
       'ul li > *': listItemStyles,
     },
 

--- a/app/themes/baseTheme.js
+++ b/app/themes/baseTheme.js
@@ -4,6 +4,7 @@ import icons from './base/icons';
 import inputs from './base/inputs';
 import links from './base/links';
 import tabGroups from './base/tabGroups';
+import paginators from './base/paginators';
 
 export const breakpoints = ['512px', '768px', '1024px', '1280px'];
 
@@ -75,19 +76,19 @@ export const transitions = {
 export const zIndices = [0, 10, 100, 1000];
 
 const linkVariants = links({ colors, fonts });
-const tabGroupVariants = tabGroups({ borders, colors, fonts, fontWeights, fontSizes });
 
 const variants = {
   icons: icons({ colors, fontSizes, radii, space }),
   inputs: inputs({ borders, colors, fonts, fontSizes, radii }),
   link: linkVariants.default,
   links: linkVariants,
-  tabGroups: tabGroupVariants,
+  tabGroups: tabGroups({ colors, fonts, fontWeights, fontSizes }),
+  paginators: paginators({ colors, fonts, fontSizes }),
 };
 
 export default {
   breakpoints,
-  buttons: buttons({ colors, borders, radii }),
+  buttons: buttons({ colors, borders, fontSizes, radii, fonts, space, fontWeights, lineHeights }),
   variants,
   colors,
   fonts,

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
   },
   "dependencies": {
     "@hot-loader/react-dom": "16.11.0",
-    "@material-ui/core": "4.9.4",
+    "@material-ui/core": "4.9.10",
     "@material-ui/icons": "4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.49",
     "@rebass/forms": "4.0.6",
     "body-parser": "1.18.3",
     "express": "4.16.3",

--- a/stories/Icon.stories.js
+++ b/stories/Icon.stories.js
@@ -27,7 +27,7 @@ export default {
 
 const disabled = () => boolean('Disabled', false);
 
-export const Static = () => (
+export const Default = () => (
   <React.Fragment>
     <Icon
       sx={{
@@ -58,8 +58,8 @@ export const Static = () => (
   </React.Fragment>
 );
 
-Static.story = {
-  name: 'Static',
+Default.story = {
+  name: 'Default',
   parameters: {
     design: {
       type: 'figma',

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -24,14 +24,23 @@ export default {
 const pageCount = () => select('Page Count', range(5, 50), 10);
 const initialPage = () => select('Initial Page', range(1, pageCount()), 1);
 const disabled = () => boolean('Disabled', false);
+const showPrevNextControls = () => boolean('Show Prev/Next Controls', true);
+const showFirstLastControls = () => boolean('Show First/Last Controls', false);
 
-
-const variations = {
+const variants = {
   Default: 'default',
   Condensed: 'condensed',
 };
 
-const variation = () => options('Variation', variations, 'default', { display: 'inline-radio' });
+const variant = () => options('Variant', variants, 'default', { display: 'inline-radio' });
+
+
+const backgrounds = {
+  None: 'transparent',
+  'Light Grey': 'lightestGrey',
+};
+
+const background = () => options('Tabs Background', backgrounds, 'transparent', { display: 'inline-radio' });
 
 export const PaginationStory = () => {
   const [page, setPage] = React.useState(initialPage());
@@ -44,18 +53,27 @@ export const PaginationStory = () => {
     <React.Fragment>
       <p>Page selected: {page}</p>
       <Pagination
+        id="my-paginator"
         page={page}
         count={pageCount()}
         onChange={handleChange}
         disabled={disabled()}
-        variation={variation()}
+        hidePrevButton={!showPrevNextControls()}
+        hideNextButton={!showPrevNextControls()}
+        showFirstButton={showFirstLastControls()}
+        showLastButton={showFirstLastControls()}
+        variant={variant()}
+        themeProps={{
+          py: '8px',
+          backgroundColor: background(),
+        }}
       />
     </React.Fragment>
   );
 };
 
 PaginationStory.story = {
-  name: 'Tab Group',
+  name: 'Default',
   parameters: {
     design: {
       type: 'figma',

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { withDesign } from 'storybook-addon-designs';
-import { withKnobs, boolean, number, select } from '@storybook/addon-knobs';
+import { withKnobs, boolean, select, optionsKnob as options } from '@storybook/addon-knobs';
 import { ThemeProvider } from 'styled-components';
-import assign from 'lodash/assign';
 import range from 'lodash/range';
 
 import baseTheme from '../app/themes/baseTheme';
@@ -26,6 +25,14 @@ const pageCount = () => select('Page Count', range(5, 50), 10);
 const initialPage = () => select('Initial Page', range(1, pageCount()), 1);
 const disabled = () => boolean('Disabled', false);
 
+
+const variations = {
+  Default: 'default',
+  Condensed: 'condensed',
+};
+
+const variation = () => options('Variation', variations, 'default', { display: 'inline-radio' });
+
 export const PaginationStory = () => {
   const [page, setPage] = React.useState(initialPage());
 
@@ -41,6 +48,7 @@ export const PaginationStory = () => {
         count={pageCount()}
         onChange={handleChange}
         disabled={disabled()}
+        variation={variation()}
       />
     </React.Fragment>
   );
@@ -51,7 +59,7 @@ PaginationStory.story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/iuXkrpuLTXExSnuPJE3Jtn/Tidepool-Design-System---Sprint-1?node-id=51%3A131',
+      url: 'https://www.figma.com/file/iuXkrpuLTXExSnuPJE3Jtn/Tidepool-Design-System---Sprint-1?node-id=4%3A992',
     },
   },
 };

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { withDesign } from 'storybook-addon-designs';
+import { withKnobs, boolean, number, select } from '@storybook/addon-knobs';
+import { ThemeProvider } from 'styled-components';
+import assign from 'lodash/assign';
+import range from 'lodash/range';
+
+import baseTheme from '../app/themes/baseTheme';
+import Pagination from '../app/components/elements/Pagination';
+
+/* eslint-disable max-len */
+
+// Wrap each story component with the base theme
+const withTheme = Story => (
+  <ThemeProvider theme={baseTheme}>
+    <Story />
+  </ThemeProvider>
+);
+
+export default {
+  title: 'Pagination',
+  decorators: [withDesign, withKnobs, withTheme],
+};
+
+const pageCount = () => select('Page Count', range(5, 50), 10);
+const initialPage = () => select('Initial Page', range(1, pageCount()), 1);
+const disabled = () => boolean('Disabled', false);
+
+export const PaginationStory = () => {
+  const [page, setPage] = React.useState(initialPage());
+
+  const handleChange = (event, newValue) => {
+    setPage(newValue);
+  };
+
+  return (
+    <React.Fragment>
+      <p>Page selected: {page}</p>
+      <Pagination
+        page={page}
+        count={pageCount()}
+        onChange={handleChange}
+        disabled={disabled()}
+      />
+    </React.Fragment>
+  );
+};
+
+PaginationStory.story = {
+  name: 'Tab Group',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/iuXkrpuLTXExSnuPJE3Jtn/Tidepool-Design-System---Sprint-1?node-id=51%3A131',
+    },
+  },
+};

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -3,6 +3,7 @@ import { withDesign } from 'storybook-addon-designs';
 import { withKnobs, boolean, select, optionsKnob as options } from '@storybook/addon-knobs';
 import { ThemeProvider } from 'styled-components';
 import range from 'lodash/range';
+import { Text } from 'rebass/styled-components';
 
 import baseTheme from '../app/themes/baseTheme';
 import Pagination from '../app/components/elements/Pagination';
@@ -51,7 +52,6 @@ export const PaginationStory = () => {
 
   return (
     <React.Fragment>
-      <p>Page selected: {page}</p>
       <Pagination
         id="my-paginator"
         page={page}
@@ -68,6 +68,15 @@ export const PaginationStory = () => {
           backgroundColor: background(),
         }}
       />
+      <Text
+        mt={4}
+        fontSize={2}
+        fontFamily="default"
+        color="text.primary"
+        textAlign="center"
+      >
+        Page Selected: <Text as="span" fontWeight="medium">{page}</Text>
+      </Text>
     </React.Fragment>
   );
 };

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -40,7 +40,7 @@ const backgrounds = {
   'Light Grey': 'lightestGrey',
 };
 
-const background = () => options('Tabs Background', backgrounds, 'transparent', { display: 'inline-radio' });
+const background = () => options('Background Color', backgrounds, 'transparent', { display: 'inline-radio' });
 
 export const PaginationStory = () => {
   const [page, setPage] = React.useState(initialPage());

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,7 +1186,7 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/hash@0.7.4", "@emotion/hash@^0.7.4":
+"@emotion/hash@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
@@ -1195,6 +1195,11 @@
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
   integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/is-prop-valid@0.8.7", "@emotion/is-prop-valid@^0.8.1", "@emotion/is-prop-valid@^0.8.3":
   version "0.8.7"
@@ -1307,20 +1312,20 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@material-ui/core@4.9.4":
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.4.tgz#796515b12845dc6ea7e21872888cfc4c0c1c1efe"
-  integrity sha512-1wqm3jBC8mGpVHu0wVOYBX7LUzkPsWxkkTtKSn0Hz66T6TDJkke72mkSIL7akNdjnxy+bRc2Vi6NiJ4YutkDcw==
+"@material-ui/core@4.9.10":
+  version "4.9.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.10.tgz#53f1d18bd274c258698b6cfdab3c4bee0edf7892"
+  integrity sha512-CQuZU9Y10RkwSdxjn785kw2EPcXhv5GKauuVQufR9LlD37kjfn21Im1yvr6wsUzn81oLhEvVPz727UWC0gbqxg==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.9.0"
-    "@material-ui/system" "^4.9.3"
-    "@material-ui/types" "^5.0.0"
-    "@material-ui/utils" "^4.7.1"
+    "@material-ui/styles" "^4.9.10"
+    "@material-ui/system" "^4.9.10"
+    "@material-ui/types" "^5.0.1"
+    "@material-ui/utils" "^4.9.6"
     "@types/react-transition-group" "^4.2.0"
-    clsx "^1.0.2"
+    clsx "^1.0.4"
     hoist-non-react-statics "^3.3.2"
-    popper.js "^1.14.1"
+    popper.js "^1.16.1-lts"
     prop-types "^15.7.2"
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
@@ -1332,18 +1337,29 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
-"@material-ui/styles@^4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.0.tgz#10c31859f6868cfa9d3adf6b6c3e32c9d676bc76"
-  integrity sha512-nJHum4RqYBPWsjL/9JET8Z02FZ9gSizlg/7LWVFpIthNzpK6OQ5OSRR4T4x9/p+wK3t1qNn3b1uI4XpnZaPxOA==
+"@material-ui/lab@4.0.0-alpha.49":
+  version "4.0.0-alpha.49"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.49.tgz#da2bd29ecad3620924f078c0bab8f4483e821475"
+  integrity sha512-Shx+wktDCj7YDlNSkgMeFhijTyqWT0CGn7wDBMck36kZlh3GQhNwaj1y5p219sCYJY44SPgnrDaCxBStlzj8KQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@emotion/hash" "^0.7.4"
-    "@material-ui/types" "^5.0.0"
-    "@material-ui/utils" "^4.7.1"
+    "@material-ui/utils" "^4.9.6"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+
+"@material-ui/styles@^4.9.10":
+  version "4.9.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.10.tgz#182ccdd0bc8525a459486499bbaebcd92b0db3ab"
+  integrity sha512-EXIXlqVyFDnjXF6tj72y6ZxiSy+mHtrsCo3Srkm3XUeu3Z01aftDBy7ZSr3TQ02gXHTvDSBvegp3Le6p/tl7eA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.0.1"
+    "@material-ui/utils" "^4.9.6"
     clsx "^1.0.2"
     csstype "^2.5.2"
-    hoist-non-react-statics "^3.2.1"
+    hoist-non-react-statics "^3.3.2"
     jss "^10.0.3"
     jss-plugin-camel-case "^10.0.3"
     jss-plugin-default-unit "^10.0.3"
@@ -1354,13 +1370,13 @@
     jss-plugin-vendor-prefixer "^10.0.3"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.9.3":
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.9.3.tgz#ee48990d7941237fdaf21b7b399981d614bb0875"
-  integrity sha512-DBGsTKYrLlFpHG8BUp0X6ZpvaOzef+GhSwn/8DwVTXUdHitphaPQoL9xucrI8X9MTBo//El+7nylko7lo7eJIw==
+"@material-ui/system@^4.9.10":
+  version "4.9.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.9.10.tgz#5de6ec7bea0f222b10b45e5bd5bb8b9a7b938926"
+  integrity sha512-E+t0baX2TBZk6ALm8twG6objpsxLdMM4MDm1++LMt2m7CetCAEc3aIAfDaprk4+tm5hFT1Cah5dRWk8EeIFQYw==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/utils" "^4.7.1"
+    "@material-ui/utils" "^4.9.6"
     prop-types "^15.7.2"
 
 "@material-ui/types@^4.1.1":
@@ -1370,15 +1386,15 @@
   dependencies:
     "@types/react" "*"
 
-"@material-ui/types@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.0.0.tgz#26d6259dc6b39f4c2e1e9aceff7a11e031941741"
-  integrity sha512-UeH2BuKkwDndtMSS0qgx1kCzSMw+ydtj0xx/XbFtxNSTlXydKwzs5gVW5ZKsFlAkwoOOQ9TIsyoCC8hq18tOwg==
+"@material-ui/types@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.0.1.tgz#c4954063cdc196eb327ee62c041368b1aebb6d61"
+  integrity sha512-wURPSY7/3+MAtng3i26g+WKwwNE3HEeqa/trDBR5+zWKmcjO+u9t7Npu/J1r+3dmIa/OeziN9D/18IrBKvKffw==
 
-"@material-ui/utils@^4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.7.1.tgz#dc16c7f0d2cd02fbcdd5cfe601fd6863ae3cc652"
-  integrity sha512-+ux0SlLdlehvzCk2zdQ3KiS3/ylWvuo/JwAGhvb8dFVvwR21K28z0PU9OQW2PGogrMEdvX3miEI5tGxTwwWiwQ==
+"@material-ui/utils@^4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.9.6.tgz#5f1f9f6e4df9c8b6a263293b68c94834248ff157"
+  integrity sha512-gqlBn0JPPTUZeAktn1rgMcy9Iczrr74ecx31tyZLVGdBGGzsxzM6PP6zeS7FuoLS6vG4hoZP7hWnOoHtkR0Kvw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     prop-types "^15.7.2"
@@ -4617,7 +4633,7 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-clsx@^1.0.2:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
@@ -12931,7 +12947,7 @@ polished@^3.3.1:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-popper.js@^1.14.1, popper.js@^1.14.4, popper.js@^1.14.7:
+popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.16.1-lts:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==


### PR DESCRIPTION
See [WEB-758] for details

Includes `default` and `condensed` variants, and a new `pagination` button variant.  As well, I've dropped the `ButtonFont` styled component and implemented it as default styles within the button variants, to allow easier overrides.

I looked at a number of pagination libraries, but found MUI pagination was actually a smaller import cost than the others, and allowed me to control the markup via a hook it exposes which was helpful for managing the variants in the Figma spec.

[WEB-758]: https://tidepool.atlassian.net/browse/WEB-758