### PR TITLE
[WEB-585] Reset to page 1 when changing search text in Table story

### DIFF
--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -135,6 +135,7 @@ export const Simple = () => {
 
   function handleSearchChange(event) {
     setSearchText(event.target.value);
+    setPage(1);
   }
 
   const handleRowsPerPageChange = event => {


### PR DESCRIPTION
Added one small fix that I'd done locally but forgotten to push before merging the PR for the Table component.

Fixes scenario where if you're, say, on page 4 of the data and you filter the results with the search input so there is only 2 pages of data, you're still on page 4 so no data shows till you click one of the page numbers.