### PR TITLE
[WEB-785] add email verification resend banner

### DIFF
--- a/app/components/sendverificationbanner/index.js
+++ b/app/components/sendverificationbanner/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./sendverificationbanner');

--- a/app/components/sendverificationbanner/sendverificationbanner.js
+++ b/app/components/sendverificationbanner/sendverificationbanner.js
@@ -10,7 +10,7 @@ const SendVerificationBanner = (props) => {
     trackMetric,
     resendVerification,
     t,
-    resendEmailVerificationProgress: working,
+    resendEmailVerificationInProgress: working,
     resentEmailVerification: resent,
   } = props;
 
@@ -57,7 +57,7 @@ SendVerificationBanner.propTypes = {
   trackMetric: PropTypes.func.isRequired,
   patient: PropTypes.object.isRequired,
   resendVerification: PropTypes.func.isRequired,
-  resendEmailVerificationProgress: PropTypes.bool.isRequired,
+  resendEmailVerificationInProgress: PropTypes.bool.isRequired,
   resentEmailVerification: PropTypes.bool.isRequired,
 };
 

--- a/app/components/sendverificationbanner/sendverificationbanner.js
+++ b/app/components/sendverificationbanner/sendverificationbanner.js
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { translate } from 'react-i18next';
+
+import personUtils from '../../core/personutils';
+
+const SendVerificationBanner = (props) => {
+  const {
+    patient,
+    trackMetric,
+    resendVerification,
+    t,
+    resendEmailVerificationProgress: working,
+    resentEmailVerification: resent,
+  } = props;
+
+  const handleSubmit = () => {
+    if (working || resent) {
+      return;
+    }
+    resendVerification(patient.username);
+
+    if (trackMetric) {
+      const source = 'none';
+      const location = 'banner';
+      trackMetric('Clicked Banner Resend Verification', { source, location });
+    }
+  };
+
+  let buttonMessage = 'RESEND VERIFICATION EMAIL';
+  if (working) {
+    buttonMessage = 'RESENDING VERIFICATION EMAIL';
+  }
+  if (resent) {
+    buttonMessage = 'RESENT VERIFICATION EMAIL';
+  }
+
+  return (
+    <div className="sendVerificationBanner">
+      <div className="container-box-inner">
+        <div className="sendVerificationBanner-message">
+          <div className="message-text">
+            {`${personUtils.patientFullName(patient)} ${t('has not verified their email')}.`}
+          </div>
+        </div>
+        <div className="sendVerificationBanner-action">
+          <button onClick={handleSubmit} disabled={working || resent}>
+            {t(buttonMessage)}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+SendVerificationBanner.propTypes = {
+  trackMetric: PropTypes.func.isRequired,
+  patient: PropTypes.object.isRequired,
+  resendVerification: PropTypes.func.isRequired,
+  resendEmailVerificationProgress: PropTypes.bool.isRequired,
+  resentEmailVerification: PropTypes.bool.isRequired,
+};
+
+export default translate()(SendVerificationBanner);

--- a/app/components/sendverificationbanner/sendverificationbanner.less
+++ b/app/components/sendverificationbanner/sendverificationbanner.less
@@ -1,0 +1,46 @@
+.sendVerificationBanner {
+  font-size: @font-size-tiny;
+  color: @white-color;
+
+  .container-box-inner {
+    background-color: @purple-dark;
+    display: flex;
+    justify-content: center;
+    padding: 4px 10px;
+    flex-direction: row;
+    align-items: center;
+    min-height: 50px;
+  }
+}
+
+.sendVerificationBanner-message {
+  .message-text {
+    display: inline-block;
+    margin-right: 8px;
+  }
+}
+
+.sendVerificationBanner-action {
+  text-align: right;
+  margin-right: 16px;
+
+  button {
+    background-color: #8095f8;
+    color: @purple-dark;
+    border: 0;
+    border-radius: 4px;
+    padding: 4px 15px;
+    font-weight: 600;
+
+    &:hover {
+      background-color: @white-color;
+      color: @purple-dark;
+    }
+
+    &:disabled {
+      background-color: @white-color;
+      color: @gray-dark;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -315,7 +315,7 @@ export class AppComponent extends React.Component {
       patient,
       permsOfLoggedInUser,
       onResendEmailVerification,
-      resendEmailVerificationProgress,
+      resendEmailVerificationInProgress,
       resentEmailVerification,
     } = this.props;
     if (_.has(permsOfLoggedInUser, 'custodian')) {
@@ -337,7 +337,7 @@ export class AppComponent extends React.Component {
               trackMetric={this.props.context.trackMetric}
               patient={patient}
               resendVerification={onResendEmailVerification}
-              resendEmailVerificationProgress={resendEmailVerificationProgress}
+              resendEmailVerificationInProgress={resendEmailVerificationInProgress}
               resentEmailVerification={resentEmailVerification}
             />
           </div>
@@ -570,7 +570,7 @@ export function mapStateToProps(state) {
     userIsDonor,
     userHasConnectedDataSources,
     userIsSupportingNonprofit,
-    resendEmailVerificationProgress: state.blip.working.resendingEmailVerification.inProgress,
+    resendEmailVerificationInProgress: state.blip.working.resendingEmailVerification.inProgress,
     resentEmailVerification: state.blip.resentEmailVerification,
   };
 };

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -31,6 +31,7 @@ import Navbar from '../../components/navbar';
 import DonateBanner from '../../components/donatebanner';
 import DexcomBanner from '../../components/dexcombanner';
 import AddEmailBanner from '../../components/addemailbanner';
+import SendVerificationBanner from '../../components/sendverificationbanner';
 import LogoutOverlay from '../../components/logoutoverlay';
 import TidepoolNotification from '../../components/notification';
 
@@ -88,6 +89,8 @@ export class AppComponent extends React.Component {
     userIsDonor: React.PropTypes.bool.isRequired,
     userIsSupportingNonprofit: React.PropTypes.bool.isRequired,
     permsOfLoggedInUser: React.PropTypes.object,
+    resendEmailVerificationProgress: React.PropTypes.bool.isRequired,
+    resentEmailVerification: React.PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -310,17 +313,36 @@ export class AppComponent extends React.Component {
 
     const {
       patient,
-      permsOfLoggedInUser
+      permsOfLoggedInUser,
+      onResendEmailVerification,
+      resendEmailVerificationProgress,
+      resentEmailVerification,
     } = this.props;
-    if(_.has(permsOfLoggedInUser, 'custodian') && !_.has(patient, 'username')){
-      this.props.context.trackMetric('Banner displayed Add Email');
-      return (
-        <div className="App-addemailbanner">
-          <AddEmailBanner
-            trackMetric={this.props.context.trackMetric}
-            patient={patient} />
-        </div>
-      );
+    if (_.has(permsOfLoggedInUser, 'custodian')) {
+      if (!_.has(patient, 'username')) {
+        this.props.context.trackMetric('Banner displayed Add Email');
+        return (
+          <div className="App-addemailbanner">
+            <AddEmailBanner
+              trackMetric={this.props.context.trackMetric}
+              patient={patient}
+            />
+          </div>
+        );
+      } else {
+        this.props.context.trackMetric('Banner displayed Send Verification');
+        return (
+          <div className="App-sendverificationbanner">
+            <SendVerificationBanner
+              trackMetric={this.props.context.trackMetric}
+              patient={patient}
+              resendVerification={onResendEmailVerification}
+              resendEmailVerificationProgress={resendEmailVerificationProgress}
+              resentEmailVerification={resentEmailVerification}
+            />
+          </div>
+        );
+      }
     }
     return null;
   }
@@ -548,6 +570,8 @@ export function mapStateToProps(state) {
     userIsDonor,
     userHasConnectedDataSources,
     userIsSupportingNonprofit,
+    resendEmailVerificationProgress: state.blip.working.resendingEmailVerification.inProgress,
+    resentEmailVerification: state.blip.resentEmailVerification,
   };
 };
 
@@ -563,6 +587,7 @@ let mapDispatchToProps = dispatch => bindActionCreators({
   updateDataDonationAccounts: actions.async.updateDataDonationAccounts,
   showBanner: actions.sync.showBanner,
   hideBanner: actions.sync.hideBanner,
+  resendEmailVerification: actions.async.resendEmailVerification,
 }, dispatch);
 
 let mergeProps = (stateProps, dispatchProps, ownProps) => {
@@ -580,6 +605,7 @@ let mergeProps = (stateProps, dispatchProps, ownProps) => {
     onUpdateDataDonationAccounts: dispatchProps.updateDataDonationAccounts.bind(null, api),
     showBanner: dispatchProps.showBanner,
     hideBanner: dispatchProps.hideBanner,
+    onResendEmailVerification: dispatchProps.resendEmailVerification.bind(null, api),
     onLogout: dispatchProps.logout.bind(null, api)
   });
 };

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -171,6 +171,9 @@ export const resentEmailVerification = (state = initialState.resentEmailVerifica
   switch(action.type) {
     case types.RESEND_EMAIL_VERIFICATION_SUCCESS:
       return true;
+    case types.CLEAR_PATIENT_IN_VIEW:
+    case types.FETCH_PATIENT_SUCCESS:
+      return false;
     default:
       return state;
   }

--- a/app/style.less
+++ b/app/style.less
@@ -21,6 +21,7 @@
 @import "components/donatebanner/donatebanner.less";
 @import "components/dexcombanner/dexcombanner.less";
 @import "components/addemailbanner/addemailbanner.less";
+@import "components/sendverificationbanner/sendverificationbanner.less";
 @import "components/donateform/donateform.less";
 @import "components/export/export.less";
 @import "components/footerlinks/footerlinks.less";

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -200,6 +200,8 @@ describe('App', () => {
       showBanner: sinon.stub(),
       hideBanner: sinon.stub(),
       patient: {},
+      resendEmailVerificationProgress: false,
+      resentEmailVerification: false,
     });
 
     let wrapper;
@@ -209,18 +211,23 @@ describe('App', () => {
 
     it('should render the banner or not based on the patient username and permsOfLoggedInUser prop values', () => {
       expect(wrapper.find('.App-addemailbanner').length).to.equal(0);
+      expect(wrapper.find('.App-sendverificationbanner').length).to.equal(0);
 
       wrapper.setProps({ patient: {username: 'someEmail'}, permsOfLoggedInUser: {custodian:{}} });
       expect(wrapper.find('.App-addemailbanner').length).to.equal(0);
+      expect(wrapper.find('.App-sendverificationbanner').length).to.equal(1);
 
       wrapper.setProps({ patient: {}, permsOfLoggedInUser: {custodian:{}} });
       expect(wrapper.find('.App-addemailbanner').length).to.equal(1);
+      expect(wrapper.find('.App-sendverificationbanner').length).to.equal(0);
 
       wrapper.setProps({ patient: {}, permsOfLoggedInUser: {} });
       expect(wrapper.find('.App-addemailbanner').length).to.equal(0);
+      expect(wrapper.find('.App-sendverificationbanner').length).to.equal(0);
 
       wrapper.setProps({ patient: {username: 'someEmail'}, permsOfLoggedInUser: {} });
       expect(wrapper.find('.App-addemailbanner').length).to.equal(0);
+      expect(wrapper.find('.App-sendverificationbanner').length).to.equal(0);
     });
   });
 
@@ -596,6 +603,14 @@ describe('App', () => {
       it('should return null for permsOfLoggedInUser', () => {
         expect(result.permsOfLoggedInUser).to.be.null;
       });
+
+      it('should map working.resendingEmailVerification.inProgress to resendingEmailVerification', () => {
+        expect(result.resendEmailVerificationProgress).to.be.false;
+      });
+
+      it('should map resentEmailVerification to resentEmailVerification', () => {
+        expect(result.resentEmailVerification).to.be.false;
+      });
     });
 
     describe('logged-in state', () => {
@@ -632,8 +647,10 @@ describe('App', () => {
           fetchingPendingSentInvites: {inProgress: false},
           updatingDataDonationAccounts: {inProgress: false},
           fetchingPatient: {inProgress: false, notification: {type: 'error'}},
-          loggingOut: {inProgress: false}
-        }
+          loggingOut: {inProgress: false},
+          resendingEmailVerification: {inProgress: false},
+        },
+        resentEmailVerification: false,
       };
       const result = mapStateToProps({blip: loggedIn});
 
@@ -718,7 +735,8 @@ describe('App', () => {
             fetchingPendingSentInvites: {inProgress: false},
             updatingDataDonationAccounts: {inProgress: false},
             fetchingPatient: {inProgress: false, notification: {type: 'error'}},
-            loggingOut: {inProgress: false}
+            loggingOut: {inProgress: false},
+            resendingEmailVerification: {inProgress: false},
           }
         };
         const careTeamMemberUploadResult = mapStateToProps({blip: careTeamMemberUpload});
@@ -763,7 +781,8 @@ describe('App', () => {
             fetchingPendingSentInvites: {inProgress: false},
             updatingDataDonationAccounts: {inProgress: false},
             fetchingPatient: {inProgress: false, notification: {type: 'error'}},
-            loggingOut: {inProgress: false}
+            loggingOut: {inProgress: false},
+            resendingEmailVerification: {inProgress: false},
           }
         };
         const careTeamMemberNoUploadResult = mapStateToProps({blip: careTeamMemberNoUpload});

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -604,8 +604,8 @@ describe('App', () => {
         expect(result.permsOfLoggedInUser).to.be.null;
       });
 
-      it('should map working.resendingEmailVerification.inProgress to resendingEmailVerification', () => {
-        expect(result.resendEmailVerificationProgress).to.be.false;
+      it('should map working.resendingEmailVerification.inProgress to resendEmailVerificationInProgress', () => {
+        expect(result.resendEmailVerificationInProgress).to.be.false;
       });
 
       it('should map resentEmailVerification to resentEmailVerification', () => {

--- a/test/unit/components/sendverificationbanner.test.js
+++ b/test/unit/components/sendverificationbanner.test.js
@@ -1,0 +1,66 @@
+/* global chai */
+/* global describe */
+/* global context */
+/* global sinon */
+/* global it */
+/* global beforeEach */
+/* global afterEach */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SendVerificationBanner from '../../../app/components/sendverificationbanner';
+
+const expect = chai.expect;
+
+describe('SendVerificationBanner', () => {
+  const props = {
+    patient: { userid: 1234, username: 'test@example.com' },
+    trackMetric: sinon.stub(),
+    resendVerification: sinon.stub(),
+    resendEmailVerificationProgress: false,
+    resentEmailVerification: false,
+  };
+
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount(
+      <SendVerificationBanner
+        {...props}
+      />
+    );
+  });
+
+  afterEach(() => {
+    props.trackMetric.reset();
+  });
+
+  it('should render without errors when provided all required props', () => {
+    console.error = sinon.stub();
+
+    expect(wrapper.find('.sendVerificationBanner')).to.have.length(1);
+    expect(console.error.callCount).to.equal(0);
+  });
+
+  it('should render a resend verification button', () => {
+    const expectedText = 'RESEND VERIFICATION EMAIL'
+    const verificationButton = wrapper.find('button');
+
+    expect(verificationButton).to.have.length(1);
+    expect(verificationButton.text()).contains(expectedText);
+  });
+
+  it('should track when the add email button is clicked', () => {
+    const verificationButton = wrapper.find('button');
+    verificationButton.simulate('click');
+    sinon.assert.calledOnce(props.trackMetric);
+    sinon.assert.calledWith(props.trackMetric, 'Clicked Banner Resend Verification');
+  });
+
+  it('should call resendVerification when the resend verification button is clicked', () => {
+    const verificationButton = wrapper.find('button');
+    verificationButton.simulate('click');
+
+    sinon.assert.calledWith(props.resendVerification, props.patient.username);
+  });
+});

--- a/test/unit/components/sendverificationbanner.test.js
+++ b/test/unit/components/sendverificationbanner.test.js
@@ -50,7 +50,7 @@ describe('SendVerificationBanner', () => {
     expect(verificationButton.text()).contains(expectedText);
   });
 
-  it('should track when the add email button is clicked', () => {
+  it('should track when the resend verification button is clicked', () => {
     const verificationButton = wrapper.find('button');
     verificationButton.simulate('click');
     sinon.assert.calledOnce(props.trackMetric);

--- a/test/unit/redux/reducers/resentEmailVerification.test.js
+++ b/test/unit/redux/reducers/resentEmailVerification.test.js
@@ -43,4 +43,26 @@ describe('resentEmailVerification', () => {
       expect(state).to.be.true;
     });
   });
+  describe('fetchPatientSuccess', () => {
+    it('should set state to false', () => {
+      let initialStateForTest = true;
+
+      let action = actions.sync.fetchPatientSuccess();
+
+      let state = reducer(initialStateForTest, action);
+
+      expect(state).to.be.false;
+    });
+  });
+  describe('clearPatientInView', () => {
+    it('should set state to false', () => {
+      let initialStateForTest = true;
+
+      let action = actions.sync.clearPatientInView();
+
+      let state = reducer(initialStateForTest, action);
+
+      expect(state).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
For [WEB-785], adds a banner for clinicians viewing accounts with emails that are currently unclaimed allowing the clinician to resend the verification email.

Clears store state regarding sent status on `CLEAR_PATIENT_IN_VIEW` and `FETCH_PATIENT_SUCCESS`.

[WEB-785]: https://tidepool.atlassian.net/browse/WEB-785