### PR TITLE
[WEB-807] Fix BG Log JS errors stemming from chart mounting before data is ready 

### DIFF
--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -62,6 +62,12 @@ class Basics extends Component {
 
   render = () => {
     const { t } = this.props;
+    const dataQueryComplete = _.get(this.props, 'data.query.chartType') === 'basics';
+    let renderedContent;
+
+    if (dataQueryComplete) {
+      renderedContent = this.isMissingBasics() ? this.renderMissingBasicsMessage() : this.renderChart();
+    }
 
     return (
       <div id="tidelineMain" className="basics">
@@ -84,7 +90,7 @@ class Basics extends Component {
           <div className="container-box-inner patient-data-content-inner">
             <div className="patient-data-content">
               <Loader show={!!this.refs.chart && this.props.loading} overlay={true} />
-              {this.isMissingBasics() ? (this.props.loading ? null : this.renderMissingBasicsMessage()) : this.renderChart()}
+              {renderedContent}
             </div>
           </div>
           <div className="container-box-inner patient-data-sidebar">

--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -232,10 +232,8 @@ class BgLog extends Component {
     const dataQueryComplete = _.get(this.props, 'data.query.chartType') === 'bgLog';
     let renderedContent;
 
-    if (this.isMissingSMBG()) {
-      renderedContent = this.props.loading ? null : this.renderMissingSMBGMessage()
-    } else {
-      renderedContent = dataQueryComplete ? this.renderChart() : null;
+    if (dataQueryComplete) {
+      renderedContent = this.isMissingSMBG() ? this.renderMissingSMBGMessage() : this.renderChart();
     }
 
     return (

--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -60,6 +60,10 @@ class BgLogChart extends Component {
     this.log = bows('BgLog Chart');
   }
 
+  componentDidMount = () => {
+    this.mount();
+  };
+
   mount = (props = this.props) => {
     this.mountChart(ReactDOM.findDOMNode(this));
     this.initializeChart(props.data, props.initialDatetimeLocation, props.showingValues);
@@ -206,27 +210,15 @@ class BgLog extends Component {
     };
   };
 
-  componentDidMount = () => {
-    if (this.refs.chart) {
-      this.refs.chart.mount();
-    }
-  };
-
   componentWillReceiveProps = nextProps => {
     const loadingJustCompleted = this.props.loading && !nextProps.loading;
     const newDataRecieved = this.props.queryDataCount !== nextProps.queryDataCount;
-    if (this.refs.chart) {
-      if (!this.refs.chart.chart) {
-        this.refs.chart.mount();
-      }
-
-      if ((loadingJustCompleted || newDataRecieved)) {
-        this.refs.chart.rerenderChart(_.assign(
-          {},
-          nextProps,
-          { showingValues: this.state.showingValues },
-        ));
-      }
+    if (this.refs.chart && (loadingJustCompleted || newDataRecieved)) {
+      this.refs.chart.rerenderChart(_.assign(
+        {},
+        nextProps,
+        { showingValues: this.state.showingValues },
+      ));
     }
   };
 

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -270,7 +270,7 @@ class Daily extends Component {
   render = () => {
     const timePrefs = _.get(this.props, 'data.timePrefs', {});
     const bgPrefs = _.get(this.props, 'data.bgPrefs', {});
-    const dayDataReady = _.get(this.props, 'data.data.current.endpoints.days') === 1;
+    const dataQueryComplete = _.get(this.props, 'data.query.chartType') === 'daily';
 
     return (
       <div id="tidelineMain" className="daily">
@@ -298,7 +298,7 @@ class Daily extends Component {
           <div className="container-box-inner patient-data-content-inner">
             <div className="patient-data-content">
               <Loader show={!!this.refs.chart && this.props.loading} overlay={true} />
-              {dayDataReady && this.renderChart()}
+              {dataQueryComplete && this.renderChart()}
             </div>
           </div>
           <div className="container-box-inner patient-data-sidebar">
@@ -320,27 +320,28 @@ class Daily extends Component {
         <Footer
           chartType={this.chartType}
           onClickRefresh={this.props.onClickRefresh}
-          ref="footer" />
+          ref="footer"
+        />
         {this.state.hoveredBolus && <BolusTooltip
-            position={{
-              top: this.state.hoveredBolus.top,
-              left: this.state.hoveredBolus.left
-            }}
-            side={this.state.hoveredBolus.side}
-            bolus={this.state.hoveredBolus.data}
-            bgPrefs={bgPrefs}
-            timePrefs={timePrefs}
-          />}
+          position={{
+            top: this.state.hoveredBolus.top,
+            left: this.state.hoveredBolus.left
+          }}
+          side={this.state.hoveredBolus.side}
+          bolus={this.state.hoveredBolus.data}
+          bgPrefs={bgPrefs}
+          timePrefs={timePrefs}
+        />}
         {this.state.hoveredSMBG && <SMBGTooltip
-            position={{
-              top: this.state.hoveredSMBG.top,
-              left: this.state.hoveredSMBG.left
-            }}
-            side={this.state.hoveredSMBG.side}
-            smbg={this.state.hoveredSMBG.data}
-            timePrefs={timePrefs}
-            bgPrefs={bgPrefs}
-          />}
+          position={{
+            top: this.state.hoveredSMBG.top,
+            left: this.state.hoveredSMBG.left
+          }}
+          side={this.state.hoveredSMBG.side}
+          smbg={this.state.hoveredSMBG.data}
+          timePrefs={timePrefs}
+          bgPrefs={bgPrefs}
+        />}
         {this.state.hoveredCBG && <CBGTooltip
           position={{
             top: this.state.hoveredCBG.top,

--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -441,6 +441,7 @@ const Trends = translate()(class Trends extends PureComponent {
 
   render() {
     const { currentPatientInViewId, t } = this.props;
+    const dataQueryComplete = _.get(this.props, 'data.query.chartType') === 'trends';
 
     return (
       <div id="tidelineMain" className="trends grid">
@@ -451,11 +452,11 @@ const Trends = translate()(class Trends extends PureComponent {
             <div className="patient-data-content">
               <Loader show={!!this.refs.chart && this.props.loading} overlay={true} />
               <div id="tidelineContainer" className="patient-data-chart-trends">
-                {this.renderChart()}
+                {dataQueryComplete && this.renderChart()}
               </div>
-              {this.renderFocusedCbgDateTraceLabel()}
-              {this.renderFocusedSMBGPointLabel()}
-              {this.renderFocusedRangeLabels()}
+              {dataQueryComplete && this.renderFocusedCbgDateTraceLabel()}
+              {dataQueryComplete && this.renderFocusedSMBGPointLabel()}
+              {dataQueryComplete && this.renderFocusedRangeLabels()}
             </div>
           </div>
           <div className="container-box-inner patient-data-sidebar">

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1258,6 +1258,7 @@ export let PatientData = translate()(React.createClass({
 
     let chartQuery = {
       bgSource: _.get(this.state, ['chartPrefs', this.state.chartType, 'bgSource']),
+      chartType: this.state.chartType,
       endpoints: this.state.endpoints,
       metaData: options.metaData,
     };

--- a/test/unit/components/chart/basics.test.js
+++ b/test/unit/components/chart/basics.test.js
@@ -32,7 +32,7 @@ import Basics from '../../../../app/components/chart/basics';
 import { MGDL_UNITS } from '../../../../app/core/constants';
 import i18next from '../../../../app/core/language';
 
-describe.only('Basics', () => {
+describe('Basics', () => {
   const bgPrefs = {
     bgClasses: {
       'very-low': {

--- a/test/unit/components/chart/basics.test.js
+++ b/test/unit/components/chart/basics.test.js
@@ -32,7 +32,7 @@ import Basics from '../../../../app/components/chart/basics';
 import { MGDL_UNITS } from '../../../../app/core/constants';
 import i18next from '../../../../app/core/language';
 
-describe('Basics', () => {
+describe.only('Basics', () => {
   const bgPrefs = {
     bgClasses: {
       'very-low': {
@@ -62,7 +62,8 @@ describe('Basics', () => {
       timePrefs: {
         timezoneAware: false,
         timezoneName: 'US/Pacific',
-      }
+      },
+      query: { chartType: 'basics' },
     },
     initialDatetimeLocation: '2019-11-27T00:00:00.000Z',
     loading: false,

--- a/test/unit/components/chart/daily.test.js
+++ b/test/unit/components/chart/daily.test.js
@@ -173,7 +173,7 @@ describe('Daily', () => {
       var dayDataReadyProps = _.assign({}, baseProps, {
         loading: false,
         data: {
-          data: { current: { endpoints: { days: 1 } } },
+          query: { chartType: 'daily'},
           bgPrefs,
           timePrefs: {
             timezoneAware: false,
@@ -197,7 +197,7 @@ describe('Daily', () => {
       var dayDataReadyProps = _.assign({}, baseProps, {
         loading: false,
         data: {
-          data: { current: { endpoints: { days: 1 } } },
+          query: { chartType: 'daily'},
           bgPrefs,
           timePrefs: {
             timezoneAware: false,

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -2603,6 +2603,7 @@ describe('PatientData', function () {
         instance.queryData({ metaData: 'bar', types: 'cbg,smbg' }, { metaData: 'foo' });
         sinon.assert.calledWith(defaultProps.dataWorkerQueryDataRequest, {
           bgSource: 'smbg',
+          chartType: 'trends',
           endpoints: [100,200],
           types: 'cbg,smbg',
           metaData: 'bar',
@@ -2664,6 +2665,13 @@ describe('PatientData', function () {
           setStateSpy.resetHistory();
         });
 
+        it('should add `chartType` to the query', () => {
+          instance.queryData();
+          sinon.assert.calledWithMatch(defaultProps.dataWorkerQueryDataRequest, {
+            chartType: 'basics',
+          });
+        });
+
         it('should set the `aggregationsByDate` query', () => {
           instance.queryData();
           sinon.assert.calledWithMatch(defaultProps.dataWorkerQueryDataRequest, {
@@ -2676,6 +2684,13 @@ describe('PatientData', function () {
         beforeEach(() => {
           wrapper.setState({ chartType: 'daily' });
           setStateSpy.resetHistory();
+        });
+
+        it('should add `chartType` to the query', () => {
+          instance.queryData();
+          sinon.assert.calledWithMatch(defaultProps.dataWorkerQueryDataRequest, {
+            chartType: 'daily',
+          });
         });
 
         it('should set the `types` query', () => {
@@ -2708,6 +2723,13 @@ describe('PatientData', function () {
           setStateSpy.resetHistory();
         });
 
+        it('should add `chartType` to the query', () => {
+          instance.queryData();
+          sinon.assert.calledWithMatch(defaultProps.dataWorkerQueryDataRequest, {
+            chartType: 'bgLog',
+          });
+        });
+
         it('should set the `types` query', () => {
           instance.queryData();
           sinon.assert.calledWithMatch(defaultProps.dataWorkerQueryDataRequest, {
@@ -2729,6 +2751,13 @@ describe('PatientData', function () {
         beforeEach(() => {
           wrapper.setState({ chartType: 'trends' });
           setStateSpy.resetHistory();
+        });
+
+        it('should add `chartType` to the query', () => {
+          instance.queryData();
+          sinon.assert.calledWithMatch(defaultProps.dataWorkerQueryDataRequest, {
+            chartType: 'trends',
+          });
         });
 
         it('should set the `types` query', () => {


### PR DESCRIPTION
See [WEB-807] for details of the main bug this is addressing.

While I was going about ensuring that the BG Log chart would not mount until it had the data it needed, I thought it made sense to go back and update the daily view mitigations put in place a few weeks ago to determine that it's data had been queried.

Likewise, it seemed to make sense to apply the same mitigations to the Basics and Trends views.

[WEB-807]: https://tidepool.atlassian.net/browse/WEB-807