### PR TITLE
[WEB-831] Hotfix for js error when switching to daily view with a date beyond the latest renderable datum

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -716,7 +716,7 @@ export let PatientData = translate()(React.createClass({
       .toISOString();
 
     const mostRecentDatumTime = this.getMostRecentDatumTimeByChartType(this.props, chartType);
-    const dateCeiling = getLocalizedCeiling(datetime || mostRecentDatumTime, this.state.timePrefs);
+    const dateCeiling = getLocalizedCeiling(_.min([Date.parse(datetime), mostRecentDatumTime]), this.state.timePrefs);
     const datetimeLocation = getDatetimeLocation(dateCeiling);
 
     const updateOpts = { updateChartEndpoints: true };
@@ -738,7 +738,7 @@ export let PatientData = translate()(React.createClass({
       .toISOString();
 
     const mostRecentDatumTime = this.getMostRecentDatumTimeByChartType(this.props, chartType);
-    const dateCeiling = getLocalizedCeiling(datetime || mostRecentDatumTime, this.state.timePrefs);
+    const dateCeiling = getLocalizedCeiling(_.min([Date.parse(datetime), mostRecentDatumTime]), this.state.timePrefs);
     const datetimeLocation = getDatetimeLocation(dateCeiling);
 
     const updateOpts = { updateChartEndpoints: true };
@@ -760,10 +760,6 @@ export let PatientData = translate()(React.createClass({
       .subtract(12, 'hours')
       .toISOString();
 
-    // TODO: for all views, we will not be able to determine mostRecentDatumTime till after the data has been queried.
-    // It will currently be based on the current data, not the data for the upcoming view.
-    // This is likely what's causing all sorts of issues. In fact, we should likely not change the chartType till
-    // the new data has been loaded.
     const mostRecentDatumTime = this.getMostRecentDatumTimeByChartType(this.props, chartType);
     const dateCeiling = getLocalizedCeiling(_.min([Date.parse(datetime), mostRecentDatumTime]), this.state.timePrefs);
     const datetimeLocation = getDatetimeLocation(dateCeiling);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.33.0",
+  "version": "1.33.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.33.1-rc.1",
+  "version": "1.33.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -3713,6 +3713,22 @@ describe('PatientData', function () {
       // Should set to previous day because the provided datetime filter is exclusive
       expect(wrapper.state('datetimeLocation')).to.equal('2018-03-02T12:00:00.000Z');
     });
+
+    it('should set the `datetimeLocation` state to noon for the previous day of the latest applicable datum time if provided datetime is beyond it', () => {
+      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const instance = wrapper.instance();
+
+      instance.updateChart = sinon.stub();
+      instance.getMostRecentDatumTimeByChartType = sinon.stub().returns(Date.parse('2018-02-05T00:00:00.000Z'));
+      instance.getChartEndpoints = sinon.stub().returns('endpoints stub');
+
+      // Provide a datetime that is beyond the one returned by getMostRecentDatumTimeByChartType
+      instance.handleSwitchToDaily('2018-03-03T00:00:00.000Z');
+      sinon.assert.calledWith(instance.updateChart, 'daily', '2018-02-04T12:00:00.000Z', 'endpoints stub', {
+        mostRecentDatetimeLocation: '2018-02-04T12:00:00.000Z',
+        updateChartEndpoints: true,
+      });
+    });
   });
 
   describe('handleSwitchToTrends', function() {
@@ -3789,6 +3805,22 @@ describe('PatientData', function () {
       instance.handleSwitchToTrends('2018-03-03T00:00:00.000Z');
       expect(wrapper.state('datetimeLocation')).to.equal('2018-03-03T00:00:00.000Z');
     });
+
+    it('should set the `datetimeLocation` state to the end of day for the latest applicable datum time if provided datetime is beyond it', () => {
+      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const instance = wrapper.instance();
+
+      instance.updateChart = sinon.stub();
+      instance.getMostRecentDatumTimeByChartType = sinon.stub().returns(Date.parse('2018-02-04T08:00:00.000Z'));
+      instance.getChartEndpoints = sinon.stub().returns('endpoints stub');
+
+      // Provide a datetime that is beyond the one returned by getMostRecentDatumTimeByChartType
+      instance.handleSwitchToTrends('2018-03-03T00:00:00.000Z');
+      sinon.assert.calledWith(instance.updateChart, 'trends', '2018-02-05T00:00:00.000Z', 'endpoints stub', {
+        mostRecentDatetimeLocation: '2018-02-04T08:00:00.000Z',
+        updateChartEndpoints: true,
+      });
+    });
   });
 
   describe('handleSwitchToBgLog', function() {
@@ -3856,6 +3888,22 @@ describe('PatientData', function () {
 
       // Should set to previous day because the provided datetime filter is exclusive
       expect(wrapper.state('datetimeLocation')).to.equal('2018-03-02T12:00:00.000Z');
+    });
+
+    it('should set the `datetimeLocation` state to noon for the previous day of the latest applicable datum time if provided datetime is beyond it', () => {
+      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const instance = wrapper.instance();
+
+      instance.updateChart = sinon.stub();
+      instance.getMostRecentDatumTimeByChartType = sinon.stub().returns(Date.parse('2018-02-05T00:00:00.000Z'));
+      instance.getChartEndpoints = sinon.stub().returns('endpoints stub');
+
+      // Provide a datetime that is beyond the one returned by getMostRecentDatumTimeByChartType
+      instance.handleSwitchToBgLog('2018-03-03T00:00:00.000Z');
+      sinon.assert.calledWith(instance.updateChart, 'bgLog', '2018-02-04T12:00:00.000Z', 'endpoints stub', {
+        mostRecentDatetimeLocation: '2018-02-04T12:00:00.000Z',
+        updateChartEndpoints: true,
+      });
     });
   });
 


### PR DESCRIPTION
See [WEB-831] for details.

Also addresses passing in future dates to the trends view, though that view handles the scenario without throwing an error.

[WEB-831]: https://tidepool.atlassian.net/browse/WEB-831