### PR TITLE
[WEB-841] Disable source maps when running tests in watch mode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,7 @@ const webpackConf = require('./webpack.config.js');
 const mochaConf = optional('./config/mocha.opts.json') || {};
 
 const testWebpackConf = _.assign({}, webpackConf, {
-  devtool: process.env.DEVTOOL === 'false' ? false : 'inline-source-map',
+  devtool: process.env.npm_lifecycle_script.indexOf('--no-single-run') === -1 ? 'inline-source-map' : false ,
   plugins: [
     new webpack.DefinePlugin({
       __DEV__: false,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,7 @@ const webpackConf = require('./webpack.config.js');
 const mochaConf = optional('./config/mocha.opts.json') || {};
 
 const testWebpackConf = _.assign({}, webpackConf, {
-  devtool: 'inline-source-map',
+  devtool: process.env.DEVTOOL === 'false' ? false : 'inline-source-map',
   plugins: [
     new webpack.DefinePlugin({
       __DEV__: false,

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",
     "pretest": "NODE_ENV=test npm run lint",
-    "browser-tests": "NODE_ENV=test ./node_modules/karma/bin/karma start--browsers Chrome",
-    "test-watch": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start --no-single-run --reporters=mocha",
+    "browser-tests": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start --browsers Chrome",
+    "test-watch": "TZ=UTC NODE_ENV=test DEVTOOL=false ./node_modules/karma/bin/karma start --no-single-run --reporters=mocha",
     "start": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --color --progress --port 3000 --host 0.0.0.0",
     "watchViz": "export NODE_OPTIONS='--max-old-space-size=4096' && cd ./packageMounts/@tidepool/viz && npm run start",
     "buildViz": "cd ./packageMounts/@tidepool/viz && npm run build-dev",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",
     "pretest": "NODE_ENV=test npm run lint",
     "browser-tests": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start --browsers Chrome",
-    "test-watch": "TZ=UTC NODE_ENV=test DEVTOOL=false ./node_modules/karma/bin/karma start --no-single-run --reporters=mocha",
+    "test-watch": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start --no-single-run --reporters=mocha",
     "start": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --color --progress --port 3000 --host 0.0.0.0",
     "watchViz": "export NODE_OPTIONS='--max-old-space-size=4096' && cd ./packageMounts/@tidepool/viz && npm run start",
     "buildViz": "cd ./packageMounts/@tidepool/viz && npm run build-dev",


### PR DESCRIPTION
Jira issue [WEB-841]

Disabling source maps while running in watch mode fixes crashes while recompiling.  Likely due to memory constraints.

Note: I was able to have source maps working by setting it to `inline-cheap-source-map` while running in watch mode instead of `false`, but the total time to recompile/run the tests jumped from about 8 seconds to 20, so I felt it was better to go with performance in this case.  If we ever really need the source maps while running unit tests, we can simply run the normal, single-run `test` command to see the output.

[WEB-841]: https://tidepool.atlassian.net/browse/WEB-841