### PR TITLE
[WEB-893] Dynamic lower correction range limit

### DIFF
--- a/app/core/forms.js
+++ b/app/core/forms.js
@@ -68,7 +68,9 @@ export const getFieldError = (fieldMeta, index, key) => {
  * @returns warning string or null
  */
 export const getThresholdWarning = (value, threshold) => {
-  if (value <= get(threshold, 'low.value')) return get(threshold, 'low.message');
-  if (value >= get(threshold, 'high.value')) return get(threshold, 'high.message');
+  if (isNumber(value)) {
+    if (value <= get(threshold, 'low.value')) return get(threshold, 'low.message');
+    if (value >= get(threshold, 'high.value')) return get(threshold, 'high.message');
+  }
   return null;
 };

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -64,10 +64,10 @@ export const prescriptionForm = (bgUnits = defaultUnits.bloodGlucose) => ({
       pumpId: get(props, 'prescription.latestRevision.attributes.initialSettings.pumpId', ''),
       cgmId: get(props, 'prescription.latestRevision.attributes.initialSettings.cgmId', ''),
       // insulinModel: get(props, 'prescription.latestRevision.attributes.initialSettings.insulinModel', ''),
-      // suspendThreshold: {
-      //   value: get(props, 'prescription.latestRevision.attributes.initialSettings.suspendThreshold.value', ''),
-      //   units: defaultUnits.suspendThreshold,
-      // },
+      suspendThreshold: {
+        value: get(props, 'prescription.latestRevision.attributes.initialSettings.suspendThreshold.value', ''),
+        units: defaultUnits.suspendThreshold,
+      },
       basalRateMaximum: {
         value: get(props, 'prescription.latestRevision.attributes.initialSettings.basalRateMaximum.value', defaultValues(bgUnits).basalRateMaximum),
         units: defaultUnits.basalRate,

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -71,7 +71,7 @@ export const defaultRanges = (bgUnits = defaultUnits.bloodGlucose) => {
     bolusAmountMaximum: { min: 0, max: 30, step: 1 },
     carbRatio: { min: 1, max: 150, step: 1 },
     insulinSensitivityFactor: { min: 10, max: 500, step: 1 },
-    // suspendThreshold: { min: 54, max: 180, step: 1 },
+    suspendThreshold: { min: 54, max: 180, step: 1 },
   };
 
   if (bgUnits === MMOLL_UNITS) {
@@ -83,9 +83,9 @@ export const defaultRanges = (bgUnits = defaultUnits.bloodGlucose) => {
     ranges.insulinSensitivityFactor.max = utils.roundBgTarget(utils.translateBg(ranges.insulinSensitivityFactor.max, MMOLL_UNITS), MMOLL_UNITS);
     ranges.insulinSensitivityFactor.step = 0.1;
 
-    // ranges.suspendThreshold.min = utils.roundBgTarget(utils.translateBg(ranges.suspendThreshold.min, MMOLL_UNITS), MMOLL_UNITS);
-    // ranges.suspendThreshold.max = utils.roundBgTarget(utils.translateBg(ranges.suspendThreshold.max, MMOLL_UNITS), MMOLL_UNITS);
-    // ranges.suspendThreshold.step = 0.1;
+    ranges.suspendThreshold.min = utils.roundBgTarget(utils.translateBg(ranges.suspendThreshold.min, MMOLL_UNITS), MMOLL_UNITS);
+    ranges.suspendThreshold.max = utils.roundBgTarget(utils.translateBg(ranges.suspendThreshold.max, MMOLL_UNITS), MMOLL_UNITS);
+    ranges.suspendThreshold.step = 0.1;
   }
 
   return ranges;
@@ -123,10 +123,10 @@ export const warningThresholds = (bgUnits = defaultUnits.bloodGlucose, meta) => 
       low: { value: 15, message: lowWarning },
       high: { value: 400, message: highWarning },
     },
-    // suspendThreshold: {
-    //   low: { value: 70, message: lowWarning },
-    //   high: { value: 120, message: highWarning },
-    // },
+    suspendThreshold: {
+      low: { value: 70, message: lowWarning },
+      high: { value: 120, message: highWarning },
+    },
   };
 
   if (bgUnits === MMOLL_UNITS) {
@@ -136,8 +136,8 @@ export const warningThresholds = (bgUnits = defaultUnits.bloodGlucose, meta) => 
     thresholds.insulinSensitivityFactor.low.value = utils.roundBgTarget(utils.translateBg(thresholds.insulinSensitivityFactor.low.value, MMOLL_UNITS), MMOLL_UNITS);
     thresholds.insulinSensitivityFactor.high.value = utils.roundBgTarget(utils.translateBg(thresholds.insulinSensitivityFactor.high.value, MMOLL_UNITS), MMOLL_UNITS);
 
-    // thresholds.suspendThreshold.low.value = utils.roundBgTarget(utils.translateBg(thresholds.suspendThreshold.low.value, MMOLL_UNITS), MMOLL_UNITS);
-    // thresholds.suspendThreshold.high.value = utils.roundBgTarget(utils.translateBg(thresholds.suspendThreshold.high.value, MMOLL_UNITS), MMOLL_UNITS);
+    thresholds.suspendThreshold.low.value = utils.roundBgTarget(utils.translateBg(thresholds.suspendThreshold.low.value, MMOLL_UNITS), MMOLL_UNITS);
+    thresholds.suspendThreshold.high.value = utils.roundBgTarget(utils.translateBg(thresholds.suspendThreshold.high.value, MMOLL_UNITS), MMOLL_UNITS);
   }
 
   return thresholds;
@@ -202,7 +202,7 @@ export const stepValidationFields = [
   [
     [
       'training',
-      // 'initialSettings.suspendThreshold.value',
+      'initialSettings.suspendThreshold.value',
       // 'initialSettings.insulinModel',
       'initialSettings.basalRateMaximum.value',
       'initialSettings.bolusAmountMaximum.value',

--- a/app/pages/prescription/prescriptionSchema.js
+++ b/app/pages/prescription/prescriptionSchema.js
@@ -27,7 +27,8 @@ export default (pumpId, bgUnits = defaultUnits.bloodGlucose) => {
   const rangeErrors = {
     basalRate: `Basal rate out of range. Please select a value between ${pumpMeta.ranges.basalRate.min}-${pumpMeta.ranges.basalRate.max}`,
     basalRateMaximum: `Basal limit out of range. Please select a value between ${pumpMeta.ranges.basalRateMaximum.min}-${pumpMeta.ranges.basalRateMaximum.max}`,
-    bloodGlucoseTarget: `Correction target out of range. Please select a value between ${pumpMeta.ranges.bloodGlucoseTarget.min}-${pumpMeta.ranges.bloodGlucoseTarget.max}`,
+    bloodGlucoseTargetMin: `Correction target out of range. Please select a value between ${pumpMeta.ranges.bloodGlucoseTarget.min}-${pumpMeta.ranges.bloodGlucoseTarget.max}`,
+    bloodGlucoseTargetMax: `Correction target out of range. Please select a value below ${pumpMeta.ranges.bloodGlucoseTarget.max}`,
     bolusAmountMaximum: `Bolus limit out of range. Please select a value between ${pumpMeta.ranges.bolusAmountMaximum.min}-${pumpMeta.ranges.bolusAmountMaximum.max}`,
     carbRatio: `Insulin-to-carb ratio of range. Please select a value between ${pumpMeta.ranges.carbRatio.min}-${pumpMeta.ranges.carbRatio.max}`,
     insulinSensitivityFactor: `Sensitivity factor out of range. Please select a value between ${pumpMeta.ranges.insulinSensitivityFactor.min}-${pumpMeta.ranges.insulinSensitivityFactor.max}`,
@@ -106,13 +107,16 @@ export default (pumpId, bgUnits = defaultUnits.bloodGlucose) => {
       }),
       bloodGlucoseTargetSchedule: yup.array().of(
         yup.object().shape({
+          context: yup.object().shape({
+            min: yup.number().default(pumpMeta.ranges.bloodGlucoseTarget.min),
+          }),
           high: yup.number()
-            .min(pumpMeta.ranges.bloodGlucoseTarget.min, rangeErrors.bloodGlucoseTarget)
-            .max(pumpMeta.ranges.bloodGlucoseTarget.max, rangeErrors.bloodGlucoseTarget)
+            .min(yup.ref('low') || yup.ref('context.min'), rangeErrors.bloodGlucoseTargetMin.replace(pumpMeta.ranges.bloodGlucoseTarget.min, '${min}'))
+            .max(pumpMeta.ranges.bloodGlucoseTarget.max, rangeErrors.bloodGlucoseTargetMax)
             .required(t('High target is required')),
           low: yup.number()
-            .min(pumpMeta.ranges.bloodGlucoseTarget.min, rangeErrors.bloodGlucoseTarget)
-            .max(pumpMeta.ranges.bloodGlucoseTarget.max, rangeErrors.bloodGlucoseTarget)
+            .min(yup.ref('context.min') || pumpMeta.ranges.bloodGlucoseTarget.min, rangeErrors.bloodGlucoseTargetMin.replace(pumpMeta.ranges.bloodGlucoseTarget.min, '${min}'))
+            .max(pumpMeta.ranges.bloodGlucoseTarget.max, rangeErrors.bloodGlucoseTargetMax)
             .required(t('Low target is required')),
           start: yup.number()
             .integer()

--- a/app/pages/prescription/prescriptionSchema.js
+++ b/app/pages/prescription/prescriptionSchema.js
@@ -31,7 +31,7 @@ export default (pumpId, bgUnits = defaultUnits.bloodGlucose) => {
     bolusAmountMaximum: `Bolus limit out of range. Please select a value between ${pumpMeta.ranges.bolusAmountMaximum.min}-${pumpMeta.ranges.bolusAmountMaximum.max}`,
     carbRatio: `Insulin-to-carb ratio of range. Please select a value between ${pumpMeta.ranges.carbRatio.min}-${pumpMeta.ranges.carbRatio.max}`,
     insulinSensitivityFactor: `Sensitivity factor out of range. Please select a value between ${pumpMeta.ranges.insulinSensitivityFactor.min}-${pumpMeta.ranges.insulinSensitivityFactor.max}`,
-    // suspendThreshold: `Threshold out of range. Please select a value between ${pumpMeta.ranges.suspendThreshold.min}-${pumpMeta.ranges.suspendThreshold.max}`,
+    suspendThreshold: `Threshold out of range. Please select a value between ${pumpMeta.ranges.suspendThreshold.min}-${pumpMeta.ranges.suspendThreshold.max}`,
   };
 
   return yup.object().shape({
@@ -81,13 +81,13 @@ export default (pumpId, bgUnits = defaultUnits.bloodGlucose) => {
       // insulinModel: yup.string()
       //   .oneOf(map(insulinModelOptions, 'value'))
       //   .required(t('An insulin model must be specified')),
-      // suspendThreshold: yup.object().shape({
-      //   value: yup.number()
-      //     .min(pumpMeta.ranges.suspendThreshold.min, rangeErrors.suspendThreshold)
-      //     .max(pumpMeta.ranges.suspendThreshold.max, rangeErrors.suspendThreshold)
-      //     .required(t('Suspend threshold is required')),
-      //   units: yup.string().default(bgUnits),
-      // }),
+      suspendThreshold: yup.object().shape({
+        value: yup.number()
+          .min(pumpMeta.ranges.suspendThreshold.min, rangeErrors.suspendThreshold)
+          .max(pumpMeta.ranges.suspendThreshold.max, rangeErrors.suspendThreshold)
+          .required(t('Suspend threshold is required')),
+        units: yup.string().default(bgUnits),
+      }),
       basalRateMaximum: yup.object().shape({
         value: yup.number()
           .min(pumpMeta.ranges.basalRateMaximum.min, rangeErrors.basalRateMaximum)

--- a/app/pages/prescription/reviewFormStep.js
+++ b/app/pages/prescription/reviewFormStep.js
@@ -99,12 +99,12 @@ const therapySettingsRows = meta => {
         }
       ),
     },
-    // {
-    //   id: 'suspend-threshold',
-    //   label: t('Suspend Threshold'),
-    //   value: `${meta.initialSettings.suspendThreshold.value.value} ${bgUnits}`,
-    //   warning: getThresholdWarning(meta.initialSettings.suspendThreshold.value.value, thresholds.suspendThreshold)
-    // },
+    {
+      id: 'suspend-threshold',
+      label: t('Suspend Threshold'),
+      value: `${meta.initialSettings.suspendThreshold.value.value} ${bgUnits}`,
+      warning: getThresholdWarning(meta.initialSettings.suspendThreshold.value.value, thresholds.suspendThreshold)
+    },
     // {
     //   id: 'insulin-model',
     //   label: t('Insulin Model'),

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -64,7 +64,7 @@ export const PatientTraining = props => {
   const { t, meta, ...themeProps } = props;
   const bgUnits = meta.initialSettings.bloodGlucoseUnits.value;
   const pumpId = meta.initialSettings.pumpId.value;
-  const pumpMeta = deviceMeta(pumpId, bgUnits);
+  const pumpMeta = deviceMeta(pumpId, bgUnits, meta);
 
   return (
     <Box {...fieldsetStyles} {...wideFieldsetStyles} {...borderedFieldsetStyles} {...themeProps}>
@@ -105,13 +105,37 @@ export const GlucoseSettings = props => {
   const { t, meta, ...themeProps } = props;
   const bgUnits = meta.initialSettings.bloodGlucoseUnits.value;
   const pumpId = meta.initialSettings.pumpId.value;
-  const pumpMeta = deviceMeta(pumpId, bgUnits);
+  const pumpMeta = deviceMeta(pumpId, bgUnits, meta);
   const thresholds = warningThresholds(bgUnits, meta);
 
   return (
     <Box {...fieldsetStyles} {...wideFieldsetStyles} {...borderedFieldsetStyles} {...themeProps}>
       <Title mb={3}>{t('Glucose Settings')}</Title>
       <Box px={3}>
+        <PopoverLabel
+          id='suspend-threshold'
+          label={t('Suspend Threshold')}
+          mb={2}
+          popoverContent={(
+            <Box p={3}>
+              <Paragraph2>
+                {t('When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/h and will not recommend a bolus.')}
+              </Paragraph2>
+            </Box>
+          )}
+        />
+        <FastField
+          as={TextInput}
+          type="number"
+          id="initialSettings.suspendThreshold.value"
+          name="initialSettings.suspendThreshold.value"
+          suffix={bgUnits}
+          error={getFieldError(meta.initialSettings.suspendThreshold.value)}
+          warning={getThresholdWarning(meta.initialSettings.suspendThreshold.value.value, thresholds.suspendThreshold)}
+          {...pumpMeta.ranges.suspendThreshold}
+          {...{ ...inputStyles, themeProps: { mb: 3 }}}
+        />
+
         <PopoverLabel
           id='correction-range'
           label={t('Correction Range')}
@@ -137,6 +161,7 @@ export const GlucoseSettings = props => {
                 suffix: bgUnits,
                 threshold: thresholds.bloodGlucoseTarget,
                 type: 'number',
+                ...pumpMeta.ranges.bloodGlucoseTarget,
               },
               {
                 label: t('Upper Target'),
@@ -144,35 +169,12 @@ export const GlucoseSettings = props => {
                 suffix: bgUnits,
                 threshold: thresholds.bloodGlucoseTarget,
                 type: 'number',
+                ...pumpMeta.ranges.bloodGlucoseTarget,
               },
             ]}
             separator="-"
           />
         </Box>
-
-        <PopoverLabel
-          id='suspend-threshold'
-          label={t('Suspend Threshold')}
-          mb={2}
-          popoverContent={(
-            <Box p={3}>
-              <Paragraph2>
-                {t('When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/h and will not recommend a bolus.')}
-              </Paragraph2>
-            </Box>
-          )}
-        />
-        <FastField
-          as={TextInput}
-          type="number"
-          id="initialSettings.suspendThreshold.value"
-          name="initialSettings.suspendThreshold.value"
-          suffix={bgUnits}
-          error={getFieldError(meta.initialSettings.suspendThreshold.value)}
-          warning={getThresholdWarning(meta.initialSettings.suspendThreshold.value.value, thresholds.suspendThreshold)}
-          {...pumpMeta.ranges.suspendThreshold}
-          {...{ ...inputStyles, themeProps: { mb: 3 }}}
-        />
       </Box>
     </Box>
   );
@@ -184,7 +186,7 @@ export const InsulinSettings = props => {
   const { t, meta, ...themeProps } = props;
   const bgUnits = meta.initialSettings.bloodGlucoseUnits.value;
   const pumpId = meta.initialSettings.pumpId.value;
-  const pumpMeta = deviceMeta(pumpId, bgUnits);
+  const pumpMeta = deviceMeta(pumpId, bgUnits, meta);
   const thresholds = warningThresholds(bgUnits, meta);
 
   return (

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -150,29 +150,29 @@ export const GlucoseSettings = props => {
           />
         </Box>
 
-        {/* <PopoverLabel
-            id='suspend-threshold'
-            label={t('Suspend Threshold')}
-            mb={2}
-            popoverContent={(
-              <Box p={3}>
-                <Paragraph2>
-                  {t('When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/h and will not recommend a bolus.')}
-                </Paragraph2>
-              </Box>
-            )}
-          />
-          <FastField
-            as={TextInput}
-            type="number"
-            id="initialSettings.suspendThreshold.value"
-            name="initialSettings.suspendThreshold.value"
-            suffix={bgUnits}
-            error={getFieldError(meta.initialSettings.suspendThreshold.value)}
-            warning={getThresholdWarning(meta.initialSettings.suspendThreshold.value.value, thresholds.suspendThreshold)}
-            {...pumpMeta.ranges.suspendThreshold}
-            {...{ ...inputStyles, themeProps: { mb: 3 }}}
-          /> */}
+        <PopoverLabel
+          id='suspend-threshold'
+          label={t('Suspend Threshold')}
+          mb={2}
+          popoverContent={(
+            <Box p={3}>
+              <Paragraph2>
+                {t('When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/h and will not recommend a bolus.')}
+              </Paragraph2>
+            </Box>
+          )}
+        />
+        <FastField
+          as={TextInput}
+          type="number"
+          id="initialSettings.suspendThreshold.value"
+          name="initialSettings.suspendThreshold.value"
+          suffix={bgUnits}
+          error={getFieldError(meta.initialSettings.suspendThreshold.value)}
+          warning={getThresholdWarning(meta.initialSettings.suspendThreshold.value.value, thresholds.suspendThreshold)}
+          {...pumpMeta.ranges.suspendThreshold}
+          {...{ ...inputStyles, themeProps: { mb: 3 }}}
+        />
       </Box>
     </Box>
   );

--- a/test/unit/app/core/forms.test.js
+++ b/test/unit/app/core/forms.test.js
@@ -181,5 +181,10 @@ describe('forms', function() {
       expect(formUtils.getThresholdWarning(11, threshold)).to.equal(null);
       expect(formUtils.getThresholdWarning(49, threshold)).to.equal(null);
     });
+
+    it('should return `null` if non-numeric value is passed in', () => {
+      expect(formUtils.getThresholdWarning('', threshold)).to.equal(null);
+      expect(formUtils.getThresholdWarning('6', threshold)).to.equal(null);
+    });
   });
 });

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -97,10 +97,10 @@ describe('prescriptionFormConstants', function() {
           low: { value: 15, message: lowWarning },
           high: { value: 400, message: highWarning },
         },
-        // suspendThreshold: {
-        //   low: { value: 70, message: lowWarning },
-        //   high: { value: 120, message: highWarning },
-        // },
+        suspendThreshold: {
+          low: { value: 70, message: lowWarning },
+          high: { value: 120, message: highWarning },
+        },
       });
     });
 
@@ -113,8 +113,8 @@ describe('prescriptionFormConstants', function() {
       expect(thresholds.insulinSensitivityFactor.low.value).to.equal(0.8);
       expect(thresholds.insulinSensitivityFactor.high.value).to.equal(22.2);
 
-      // expect(thresholds.suspendThreshold.low.value).to.equal(3.9);
-      // expect(thresholds.suspendThreshold.high.value).to.equal(6.7);
+      expect(thresholds.suspendThreshold.low.value).to.equal(3.9);
+      expect(thresholds.suspendThreshold.high.value).to.equal(6.7);
     });
   });
 
@@ -137,7 +137,7 @@ describe('prescriptionFormConstants', function() {
         bolusAmountMaximum: { min: 0, max: 30, step: 1 },
         carbRatio: { min: 1, max: 150, step: 1 },
         insulinSensitivityFactor: { min: 10, max: 500, step: 1 },
-        // suspendThreshold: { min: 54, max: 180, step: 1 },
+        suspendThreshold: { min: 54, max: 180, step: 1 },
       });
     });
 
@@ -152,9 +152,9 @@ describe('prescriptionFormConstants', function() {
       expect(ranges.insulinSensitivityFactor.max).to.equal(27.8);
       expect(ranges.insulinSensitivityFactor.step).to.equal(0.1);
 
-      // expect(ranges.suspendThreshold.min).to.equal(3);
-      // expect(ranges.suspendThreshold.max).to.equal(10);
-      // expect(ranges.suspendThreshold.step).to.equal(0.1);
+      expect(ranges.suspendThreshold.min).to.equal(3);
+      expect(ranges.suspendThreshold.max).to.equal(10);
+      expect(ranges.suspendThreshold.step).to.equal(0.1);
     });
   });
 
@@ -170,7 +170,7 @@ describe('prescriptionFormConstants', function() {
             bolusAmountMaximum: { min: 0, max: 30, step: 1 },
             carbRatio: { min: 1, max: 150, step: 1 },
             insulinSensitivityFactor: { min: 10, max: 500, step: 1 },
-            // suspendThreshold: { min: 54, max: 180, step: 1 },
+            suspendThreshold: { min: 54, max: 180, step: 1 },
           },
         });
       });

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import * as prescriptionFormConstants from '../../../../app/pages/prescription/prescriptionFormConstants';
+import { MGDL_UNITS } from '../../../../app/core/constants';
 
 /* global chai */
 /* global describe */
@@ -139,6 +140,20 @@ describe('prescriptionFormConstants', function() {
         insulinSensitivityFactor: { min: 10, max: 500, step: 1 },
         suspendThreshold: { min: 54, max: 180, step: 1 },
       });
+    });
+
+    it('should set the min bloodGlucoseTarget value to the set value of the suspendThreshold field', () => {
+      const meta = {
+        initialSettings: {
+          suspendThreshold: {
+            value: {
+              value: 78,
+            },
+          },
+        },
+      };
+
+      expect(prescriptionFormConstants.defaultRanges(MGDL_UNITS, meta).bloodGlucoseTarget.min).to.equal(78);
     });
 
     it('should export the default ranges with mmoll/L as provided', () => {

--- a/test/unit/pages/prescription/prescriptionSchema.test.js
+++ b/test/unit/pages/prescription/prescriptionSchema.test.js
@@ -40,7 +40,7 @@ describe('prescriptionSchema', function() {
       'pumpId',
       'cgmId',
       // 'insulinModel',
-      // 'suspendThreshold',
+      'suspendThreshold',
       'basalRateMaximum',
       'bolusAmountMaximum',
       'bloodGlucoseTargetSchedule',
@@ -49,10 +49,10 @@ describe('prescriptionSchema', function() {
       'insulinSensitivitySchedule',
     ]);
 
-    // expect(schema.fields.initialSettings.fields.suspendThreshold._nodes).to.be.an('array').and.have.members([
-    //   'value',
-    //   'units',
-    // ]);
+    expect(schema.fields.initialSettings.fields.suspendThreshold._nodes).to.be.an('array').and.have.members([
+      'value',
+      'units',
+    ]);
 
     expect(schema.fields.initialSettings.fields.basalRateMaximum._nodes).to.be.an('array').and.have.members([
       'value',

--- a/test/unit/pages/prescription/prescriptionSchema.test.js
+++ b/test/unit/pages/prescription/prescriptionSchema.test.js
@@ -67,9 +67,15 @@ describe('prescriptionSchema', function() {
 
     expect(schema.fields.initialSettings.fields.bloodGlucoseTargetSchedule.type).to.equal('array');
     expect(schema.fields.initialSettings.fields.bloodGlucoseTargetSchedule._subType._nodes).to.be.an('array').and.have.members([
+      'context',
       'high',
       'low',
       'start',
+    ]);
+
+    expect(schema.fields.initialSettings.fields.bloodGlucoseTargetSchedule._subType.fields.context.type).to.equal('object');
+    expect(schema.fields.initialSettings.fields.bloodGlucoseTargetSchedule._subType.fields.context._nodes).to.be.an('array').and.have.members([
+      'min',
     ]);
 
     expect(schema.fields.initialSettings.fields.basalRateSchedule.type).to.equal('array');

--- a/test/unit/pages/prescription/therapySettingsFormStep.test.js
+++ b/test/unit/pages/prescription/therapySettingsFormStep.test.js
@@ -11,7 +11,7 @@ const expect = chai.expect;
 const meta = {
   training: { valid: true },
   initialSettings: {
-    // suspendThreshold: { value: { valid: true } },
+    suspendThreshold: { value: { valid: true } },
     // insulinModel: { valid: true },
     basalRateMaximum: { value: { valid: true } },
     bolusAmountMaximum: { value: { valid: true } },
@@ -42,7 +42,7 @@ describe('therapySettingsFormStep', function() {
   it('should disable the complete button for any invalid fields', () => {
     expect(therapySettingsFormStep(meta).disableComplete).to.be.false;
     expect(therapySettingsFormStep(invalidateMeta('training')).disableComplete).to.be.true;
-    // expect(therapySettingsFormStep(invalidateMeta('initialSettings.suspendThreshold.value')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(invalidateMeta('initialSettings.suspendThreshold.value')).disableComplete).to.be.true;
     // expect(therapySettingsFormStep(invalidateMeta('initialSettings.insulinModel')).disableComplete).to.be.true;
     expect(therapySettingsFormStep(invalidateMeta('initialSettings.basalRateMaximum.value')).disableComplete).to.be.true;
     expect(therapySettingsFormStep(invalidateMeta('initialSettings.bolusAmountMaximum.value')).disableComplete).to.be.true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14881,7 +14881,7 @@ reduce-component@1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-component/-/reduce-component-1.0.1.tgz#e0c93542c574521bea13df0f9488ed82ab77c5da"
   integrity sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=
 
-"reductio@github:crossfilter/reductio#0c45b03559":
+reductio@crossfilter/reductio#0c45b03559:
   version "0.6.3"
   resolved "https://codeload.github.com/crossfilter/reductio/tar.gz/0c45b0355950101d395d6482e2083ce1cdbcf435"
   dependencies:


### PR DESCRIPTION
See [WEB-893] for details.

I had to re-enable the commented-out `suspendThreshold` field, which is not yet implemented in the backend, but should be soon (via tidepool-org/platform#462).  Currently, this means the suspendThreshold input works, but the value will not be saved to the backend.

This also contains a few small fixes for issues I noticed with the therapy settings section while developing:

1. The threshold warnings now only show when numerical values are present.  This avoids them showing when set to a default empty string value.
2. The input step props were missing from the correction range schedule inputes
3. In addition to the logic defined by the Jira ticket, enforcing that the low correction range targets are not below the suspend threshold, I've also set it so that a High target cannot be set lower than a Low target.

[WEB-893]: https://tidepool.atlassian.net/browse/WEB-893