### PR TITLE
[WEB-982] add metrics for export to `release-1.38.0`

### DIFF
--- a/app/components/export/export.js
+++ b/app/components/export/export.js
@@ -28,6 +28,7 @@ export default translate()(class Export extends Component {
     api: PropTypes.object.isRequired,
     patient: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
+    trackMetric: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -53,6 +54,7 @@ export default translate()(class Export extends Component {
   }
 
   handleSubmit(event) {
+    this.props.trackMetric('Clicked "export data"');
     event.preventDefault();
     this.setState({ error: null });
     let options = _.pick(this.state, [
@@ -107,6 +109,25 @@ export default translate()(class Export extends Component {
       }
     }
 
+    let metric;
+
+    switch (name) {
+      case 'format':
+        metric = 'Selected file format';
+        break;
+      case 'startDate':
+      case 'endDate':
+        metric = 'Selected custom start/end date';
+        break;
+      case 'bgUnits':
+        metric = 'Selected diabetes data format';
+        break;
+      default:
+        break;
+    }
+
+    metric && this.props.trackMetric(metric);
+
     this.setState({
       [name]: value
     });
@@ -128,6 +149,7 @@ export default translate()(class Export extends Component {
       endDate,
       startDate,
     });
+    this.props.trackMetric('Selected pre-determined date range');
   }
 
   render() {

--- a/app/pages/patient/patientinfo.js
+++ b/app/pages/patient/patientinfo.js
@@ -520,10 +520,15 @@ var PatientInfo = translate()(class extends React.Component {
       <div className="PatientPage-export">
         <div className="PatientPage-sectionTitle">Export My Data</div>
         <div className="PatientInfo-content">
-          <Export api={this.props.api} patient={this.props.patient} user={this.props.user}/>
+          <Export
+            api={this.props.api}
+            patient={this.props.patient}
+            user={this.props.user}
+            trackMetric={this.props.trackMetric}
+          />
         </div>
       </div>
-    )
+    );
   };
 
   isSamePersonUserAndPatient = () => {

--- a/test/unit/components/export.test.js
+++ b/test/unit/components/export.test.js
@@ -30,6 +30,7 @@ describe('Export', () => {
     user: {
       userID: 'def456'
     },
+    trackMetric: sinon.stub(),
   };
   const mmollProps = {
     api: {
@@ -48,6 +49,7 @@ describe('Export', () => {
     user: {
       userID: 'def456'
     },
+    trackMetric: sinon.stub(),
   };
   const expectedInitialState = {
     allTime: false,
@@ -81,6 +83,7 @@ describe('Export', () => {
 
   afterEach(() => {
     props.api.tidepool.getExportDataURL.reset();
+    props.trackMetric.reset();
   });
 
   it('should be a function', () => {
@@ -147,12 +150,17 @@ describe('Export', () => {
       startDate.simulate('change', {
         target: { name: 'startDate', value: newStartDate }
       });
+      sinon.assert.calledOnce(props.trackMetric);
+      sinon.assert.calledWith(props.trackMetric, 'Selected custom start/end date');
       expect(wrappedInstance.state.startDate).to.equal(
         newStartDate
       );
+      props.trackMetric.reset();
       endDate.simulate('change', {
         target: { name: 'endDate', value: newEndDate }
       });
+      sinon.assert.calledOnce(props.trackMetric);
+      sinon.assert.calledWith(props.trackMetric, 'Selected custom start/end date');
       expect(wrappedInstance.state.endDate).to.equal(
         newEndDate
       );
@@ -204,12 +212,17 @@ describe('Export', () => {
       expect(wrapper.instance().getWrappedInstance().state.format).to.equal(
         'excel'
       );
+      sinon.assert.calledOnce(props.trackMetric);
+      sinon.assert.calledWith(props.trackMetric, 'Selected file format');
+      props.trackMetric.reset();
       json.simulate('change', {
         target: { name: 'format', checked: true, value: 'json' }
       });
       expect(wrapper.instance().getWrappedInstance().state.format).to.equal(
         'json'
       );
+      sinon.assert.calledOnce(props.trackMetric);
+      sinon.assert.calledWith(props.trackMetric, 'Selected file format');
     });
   });
 
@@ -232,6 +245,8 @@ describe('Export', () => {
     it('should call getExportDataURL', () => {
       button.simulate('submit');
       sinon.assert.calledOnce(props.api.tidepool.getExportDataURL);
+      sinon.assert.calledOnce(props.trackMetric)
+      sinon.assert.calledWith(props.trackMetric, 'Clicked "export data"');
     });
 
     it('should set error state if callback errors', () => {
@@ -272,6 +287,8 @@ describe('Export', () => {
       expect(wrappedInstance.state.endDate).to.eql(
         moment().format(JS_DATE_FORMAT)
       );
+      sinon.assert.calledOnce(props.trackMetric);
+      sinon.assert.calledWith(props.trackMetric, 'Selected pre-determined date range');
     });
     it('should set the start date to expected span', () => {
       const wrappedInstance = wrapper.instance().getWrappedInstance();
@@ -291,7 +308,7 @@ describe('Export', () => {
   });
 
   describe('toggleOptions', () => {
-    it('should negate current expanded options state'),
+    it('should negate current expanded options state',
       () => {
         expect(
           wrapper.instance().getWrappedInstance().state.extraExpanded
@@ -310,6 +327,6 @@ describe('Export', () => {
         expect(
           wrapper.instance().getWrappedInstance().state.extraExpanded
         ).to.eql(false);
-      };
+      });
   });
 });


### PR DESCRIPTION
For [WEB-982], adds metrics events for various interactions in the export interface

Replaces https://github.com/tidepool-org/blip/pull/799 targeting release branch instead of develop

[WEB-982]: https://tidepool.atlassian.net/browse/WEB-982