### PR TITLE
[WEB-54] Custom Basics date ranges

### DIFF
--- a/.nlu.example.json
+++ b/.nlu.example.json
@@ -18,6 +18,7 @@
     "/.git/"
   ],
   "list": [
+    "blip",
     "tidepool-platform-client",
     "tideline",
     "@tidepool/viz"

--- a/app/components/ChartDateRangeModal.js
+++ b/app/components/ChartDateRangeModal.js
@@ -129,7 +129,7 @@ export const ChartDateRangeModal = (props) => {
   }, [dates]);
 
   return (
-    <Dialog id="printDateRangePicker" maxWidth="md" open={open} onClose={handleClose}>
+    <Dialog id="ChartDateRangePicker" maxWidth="md" open={open} onClose={handleClose}>
       <DialogTitle divider={false} onClose={handleClose}>
         <MediumTitle>{title}</MediumTitle>
       </DialogTitle>
@@ -182,10 +182,10 @@ export const ChartDateRangeModal = (props) => {
         </Box>
       </DialogContent>
       <DialogActions justifyContent="space-between" py={2}>
-        <Button variant="textSecondary" className="print-cancel" onClick={handleClose}>
+        <Button variant="textSecondary" className="chart-dates-cancel" onClick={handleClose}>
           {t('Cancel')}
         </Button>
-        <Button variant="textPrimary" className="print-submit" processing={processing} onClick={handleSubmit}>
+        <Button variant="textPrimary" className="chart-dates-submit" processing={processing} onClick={handleSubmit}>
           {t('Apply')}
         </Button>
       </DialogActions>

--- a/app/components/ChartDateRangeModal.js
+++ b/app/components/ChartDateRangeModal.js
@@ -1,0 +1,219 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+import map from 'lodash/map';
+import noop from 'lodash/noop';
+import { Flex, Box } from 'rebass/styled-components';
+import moment from 'moment-timezone';
+
+import Button from './elements/Button';
+import DateRangePicker from './elements/DateRangePicker';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from './elements/Dialog';
+import { MediumTitle, Caption, Body1 } from './elements/FontStyles';
+import i18next from '../core/language';
+
+const t = i18next.t.bind(i18next);
+
+export const ChartDateRangeModal = (props) => {
+  const {
+    defaultDates: defaultDatesProp,
+    maxDays,
+    mostRecentDatumDate,
+    onClose,
+    onSubmit,
+    onDatesChange,
+    open,
+    processing,
+    timePrefs: { timezoneName = 'UTC' },
+    title,
+    presetDaysOptions,
+  } = props;
+
+  const endOfToday = useMemo(() => moment.utc().tz(timezoneName).endOf('day').subtract(1, 'ms'), [open]);
+
+  // We want the set dates to start at the floor of the start date and the ceiling of the end date
+  // to ensure we are selecting full days of data.
+  const setDateRangeToExtents = ({ startDate, endDate }) => ({
+    startDate: startDate ? moment.utc(startDate).tz(timezoneName).startOf('day') : null,
+    endDate: endDate ? moment.utc(endDate).tz(timezoneName).endOf('day').subtract(1, 'ms') : null,
+  });
+
+  const getLastNDays = days => {
+    const endDate = mostRecentDatumDate
+      ? moment.utc(mostRecentDatumDate)
+      : endOfToday;
+
+    return setDateRangeToExtents({
+      startDate: moment.utc(endDate).tz(timezoneName).subtract(days - 1, 'days'),
+      endDate,
+    });
+  };
+
+  const defaultDates = () => defaultDatesProp
+    ? setDateRangeToExtents({
+      startDate: defaultDatesProp[0],
+      endDate: defaultDatesProp[1] - 1,
+    })
+    : getLastNDays(presetDaysOptions[0], 'basics');
+
+  const defaults = useMemo(() => ({
+    datePickerOpen: false,
+    dates: defaultDates(),
+    errors: false,
+    submitted: false,
+  }), [mostRecentDatumDate, defaultDatesProp]);
+
+  const [dates, setDates] = useState(defaults.dates);
+  const [errors, setErrors] = useState(defaults.errors);
+  const [submitted, setSubmitted] = useState(defaults.submitted);
+  const [datePickerOpen, setDatePickerOpen] = useState(defaults.datePickerOpen);
+
+  const presetDateRanges = useMemo(() => map(presetDaysOptions, days => getLastNDays(days, 'basics')), [open]);
+
+  const datesMatchPreset = (dates, presetDates) => {
+    return moment(dates.startDate).isSame(presetDates.startDate) && moment(dates.endDate).isSame(presetDates.endDate);
+  };
+
+  const datesMatchDefault = () => {
+    return moment(dates.startDate).isSame(defaults.dates.startDate) && moment(dates.endDate).isSame(defaults.dates.endDate);
+  };
+
+  const validateDatesSet = dates => (!moment.isMoment(dates.startDate) || !moment.isMoment(dates.endDate)
+    ? t('Please select a date range')
+    : false
+  );
+
+  const validateDates = dates => {
+    const validationErrors = validateDatesSet(dates);
+    setErrors(validationErrors);
+    return validationErrors;
+  };
+
+  const formatDateEndpoints = dates => ([
+    dates.startDate.valueOf(),
+    moment.utc(dates.endDate).tz(timezoneName).add(1, 'day').startOf('day').valueOf(),
+  ]);
+
+  // Handlers
+  const handleSubmit = () => {
+    setSubmitted(true);
+    const validationErrors = validateDates(dates);
+    if (!isEqual(validationErrors, defaults.errors)) return;
+    if (datesMatchDefault()) return onClose();
+    onSubmit(formatDateEndpoints(dates));
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  // Set to default state when dialog is newly opened
+  useEffect(() => {
+    if (open) {
+      setDatePickerOpen(defaults.datePickerOpen);
+      setDates(defaults.dates);
+      setErrors(defaults.errors);
+      setSubmitted(defaults.submitted);
+    }
+  }, [open]);
+
+  // Validate dates if submitted and call `onDatesChange` prop method when dates change
+  useEffect(() => {
+    if (submitted) validateDates(dates);
+    onDatesChange(dates);
+  }, [dates]);
+
+  return (
+    <Dialog id="printDateRangePicker" maxWidth="md" open={open} onClose={handleClose}>
+      <DialogTitle divider={false} onClose={handleClose}>
+        <MediumTitle>{title}</MediumTitle>
+      </DialogTitle>
+      <DialogContent divider minWidth="400px" p={0}>
+        <Box px={3}>
+          <Box mb={5}>
+            <Body1 mb={2}>{t('Number of days (most recent)')}</Body1>
+            <Flex id="days-chart">
+              {map(presetDaysOptions, (days, i) => (
+                <Button
+                  mr={2}
+                  variant="chip"
+                  id={`days-chart-${i}`}
+                  name={`days-chart-${i}`}
+                  key={`days-chart-${i}`}
+                  value={days}
+                  selected={datesMatchPreset(dates, presetDateRanges[i])}
+                  onClick={() => setDates(getLastNDays(days))}
+                >
+                  {days} days
+                </Button>
+              ))}
+            </Flex>
+          </Box>
+          <Box mb={3}>
+            <Body1 mb={2}>{t('Or select a custom date range')}</Body1>
+            <DateRangePicker
+              startDate={dates.startDate}
+              startDateId="chart-start-date"
+              endDate={dates.endDate}
+              endDateId="chart-end-date"
+              onDatesChange={newDates => setDates(setDateRangeToExtents(newDates))}
+              isOutsideRange={day => (
+                endOfToday.diff(day) < 0 ||
+                (moment.isMoment(dates.endDate) && dates.endDate.diff(day, 'days') >= maxDays) ||
+                (moment.isMoment(dates.startDate) && dates.startDate.diff(day, 'days') <= -maxDays)
+              )}
+              onFocusChange={input => setDatePickerOpen(!!input)}
+              themeProps={{
+                minWidth: '580px',
+                minHeight: datePickerOpen ? '300px' : undefined,
+              }}
+            />
+          </Box>
+          {errors && (
+            <Caption mt={2} color="feedback.danger" id="chart-dates-error">
+              {errors}
+            </Caption>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions justifyContent="space-between" py={2}>
+        <Button variant="textSecondary" className="print-cancel" onClick={handleClose}>
+          {t('Cancel')}
+        </Button>
+        <Button variant="textPrimary" className="print-submit" processing={processing} onClick={handleSubmit}>
+          {t('Apply')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+ChartDateRangeModal.propTypes = {
+  maxDays: PropTypes.number.isRequired,
+  mostRecentDatumDate: PropTypes.number.isRequired,
+  onSubmit: PropTypes.func,
+  onClose: PropTypes.func,
+  onDatesChange: PropTypes.func,
+  open: PropTypes.bool,
+  processing: PropTypes.bool,
+  timePrefs: PropTypes.shape({
+    timezoneAware: PropTypes.bool,
+    timezoneName: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+ChartDateRangeModal.defaultProps = {
+  maxDays: 90,
+  onSubmit: noop,
+  onClose: noop,
+  onDatesChange: noop,
+  presetDaysOptions: [14, 21, 30],
+  title: t('Chart Date Range'),
+};
+
+export default ChartDateRangeModal;

--- a/app/components/ChartDateRangeModal.js
+++ b/app/components/ChartDateRangeModal.js
@@ -196,9 +196,9 @@ export const ChartDateRangeModal = (props) => {
 ChartDateRangeModal.propTypes = {
   maxDays: PropTypes.number.isRequired,
   mostRecentDatumDate: PropTypes.number.isRequired,
-  onSubmit: PropTypes.func,
   onClose: PropTypes.func,
   onDatesChange: PropTypes.func,
+  onSubmit: PropTypes.func,
   open: PropTypes.bool,
   processing: PropTypes.bool,
   timePrefs: PropTypes.shape({

--- a/app/components/PrintDateRangeModal.js
+++ b/app/components/PrintDateRangeModal.js
@@ -18,6 +18,9 @@ import {
   DialogTitle,
 } from './elements/Dialog';
 import { MediumTitle, Caption, Body1 } from './elements/FontStyles';
+import i18next from '../core/language';
+
+const t = i18next.t.bind(i18next);
 
 export const PrintDateRangeModal = (props) => {
   const {
@@ -97,7 +100,7 @@ export const PrintDateRangeModal = (props) => {
   };
 
   const validateDatesSet = dates => (!moment.isMoment(dates.startDate) || !moment.isMoment(dates.endDate)
-    ? 'Please select a date range'
+    ? t('Please select a date range')
     : false
   );
 
@@ -143,21 +146,21 @@ export const PrintDateRangeModal = (props) => {
   const panels = [
     {
       daysOptions: basicsDaysOptions,
-      header: 'Basics Chart',
+      header: t('Basics Chart'),
       key: 'basics',
     },
     {
       daysOptions: dailyDaysOptions,
-      header: 'Daily Charts',
+      header: t('Daily Charts'),
       key: 'daily',
     },
     {
       daysOptions: bgLogDaysOptions,
-      header: 'BG Log Chart',
+      header: t('BG Log Chart'),
       key: 'bgLog',
     },
     {
-      header: 'Device Settings',
+      header: t('Device Settings'),
       key: 'settings',
     },
   ];
@@ -208,7 +211,7 @@ export const PrintDateRangeModal = (props) => {
   return (
     <Dialog id="printDateRangePicker" maxWidth="md" open={open} onClose={handleClose}>
       <DialogTitle divider={false} onClose={handleClose}>
-        <MediumTitle>Print Report</MediumTitle>
+        <MediumTitle>{t('Print Report')}</MediumTitle>
       </DialogTitle>
       <DialogContent divider={false} minWidth="400px" p={0}>
         {map(panels, panel => (
@@ -229,7 +232,7 @@ export const PrintDateRangeModal = (props) => {
               {enabled[panel.key] && panel.daysOptions && (
                 <Box>
                   <Box mb={5}>
-                    <Body1 mb={2}>Number of days (most recent)</Body1>
+                    <Body1 mb={2}>{t('Number of days (most recent)')}</Body1>
                     <Flex id={`days-${panel.key}`}>
                       {map(panel.daysOptions, (days, i) => (
                         <Button
@@ -248,7 +251,7 @@ export const PrintDateRangeModal = (props) => {
                     </Flex>
                   </Box>
                   <Box mb={3}>
-                    <Body1 mb={2}>Or select a custom date range</Body1>
+                    <Body1 mb={2}>{t('Or select a custom date range')}</Body1>
                     <DateRangePicker
                       startDate={dates[panel.key].startDate}
                       startDateId={`${[panel.key]}-start-date`}
@@ -280,10 +283,10 @@ export const PrintDateRangeModal = (props) => {
       </DialogContent>
       <DialogActions justifyContent="space-between" py={2}>
         <Button variant="textSecondary" className="print-cancel" onClick={handleClose}>
-          Cancel
+          {t('Cancel')}
         </Button>
         <Button variant="textPrimary" className="print-submit" processing={processing} onClick={handleSubmit}>
-          Print
+          {t('Print')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -62,6 +62,13 @@ class Basics extends Component {
     title: this.getTitle(),
   });
 
+  UNSAFE_componentWillReceiveProps = nextProps => {
+    const newEndpointsRecieved = _.get(this.props, 'data.data.current.endpoints.range') !== _.get(nextProps, 'data.data.current.endpoints.range');
+    if (newEndpointsRecieved) {
+      this.setState({ title: this.getTitle(nextProps, false) });
+    }
+  };
+
   render = () => {
     const { t } = this.props;
     const dataQueryComplete = _.get(this.props, 'data.query.chartType') === 'basics';
@@ -80,6 +87,7 @@ class Basics extends Component {
           inTransition={this.state.inTransition}
           title={this.state.title}
           onClickBasics={this.handleClickBasics}
+          onClickChartDates={this.props.onClickChartDates}
           onClickOneDay={this.handleClickOneDay}
           onClickTrends={this.handleClickTrends}
           onClickRefresh={this.props.onClickRefresh}
@@ -172,13 +180,13 @@ class Basics extends Component {
     );
   };
 
-  getTitle = () => {
-    const { t } = this.props;
-    if (this.isMissingBasics()) {
+  getTitle = (props = this.props, checkMissing = true) => {
+    const { t } = props;
+    if (checkMissing && this.isMissingBasics(props)) {
       return '';
     }
 
-    const timePrefs = _.get(this.props, 'data.timePrefs', {});
+    const timePrefs = _.get(props, 'data.timePrefs', {});
     let timezone;
     if (!timePrefs.timezoneAware) {
       timezone = 'UTC';
@@ -188,12 +196,12 @@ class Basics extends Component {
     }
 
     const dtMask = t('MMM D, YYYY');
-    return sundial.formatInTimezone(_.get(this.props, 'data.data.current.endpoints.range', [])[0], timezone, dtMask) +
-      ' - ' + sundial.formatInTimezone(_.get(this.props, 'data.data.current.endpoints.range', [])[1] - 1, timezone, dtMask);
+    return sundial.formatInTimezone(_.get(props, 'data.data.current.endpoints.range', [])[0], timezone, dtMask) +
+      ' - ' + sundial.formatInTimezone(_.get(props, 'data.data.current.endpoints.range', [])[1] - 1, timezone, dtMask);
   }
 
-  isMissingBasics = () => {
-    const aggregationsByDate = _.get(this.props, 'data.data.aggregationsByDate', {});
+  isMissingBasics = (props = this.props) => {
+    const aggregationsByDate = _.get(props, 'data.data.aggregationsByDate', {});
     return isMissingBasicsData(aggregationsByDate);
   };
 

--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -2,10 +2,11 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import cx from 'classnames';
-import Loading from 'react-loading';
 import { translate } from 'react-i18next';
+import DateRangeRoundedIcon from '@material-ui/icons/DateRangeRounded';
 
 import printPng from './img/print-icon-2x.png';
+import Icon from '../elements/Icon';
 
 const Header = translate()(class Header extends Component {
   static propTypes = {
@@ -19,6 +20,7 @@ const Header = translate()(class Header extends Component {
     iconMostRecent: PropTypes.string,
     onClickBack: PropTypes.func,
     onClickBasics: PropTypes.func,
+    onClickChartDates: PropTypes.func,
     onClickTrends: PropTypes.func,
     onClickMostRecent: PropTypes.func,
     onClickNext: PropTypes.func,
@@ -26,6 +28,10 @@ const Header = translate()(class Header extends Component {
     onClickBgLog: PropTypes.func,
     onClickSettings: PropTypes.func,
     onClickPrint: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onClickChartDates: _.noop,
   };
 
   renderStandard = () => {
@@ -125,16 +131,30 @@ const Header = translate()(class Header extends Component {
           {this.renderNavButton(backClass, this.props.onClickBack, this.props.iconBack)}
           <div className={dateLinkClass}>
             {this.props.title}
+            {this.props.chartType === 'basics' && (
+              <Icon
+                variant="default"
+                sx={{
+                  ml: 2,
+                  mt: -1,
+                  color: 'white',
+                  outline: 'none',
+                }}
+                label="Close"
+                icon={DateRangeRoundedIcon}
+                onClick={this.props.onClickChartDates}
+              />
+            )}
           </div>
           {this.renderNavButton(nextClass, this.props.onClickNext, this.props.iconNext)}
           {this.renderNavButton(mostRecentClass, this.props.onClickMostRecent, this.props.iconMostRecent)}
         </div>
         <div className="app-no-print patient-data-subnav-right">
-          <a href="" className={settingsLinkClass} onClick={this.props.onClickSettings}>{t('Device settings')}</a>
           <a href="" className={printLinkClass} onClick={this.props.onClickPrint}>
             <img className="print-icon" src={printPng} alt="Print" />
             {t('Print')}
           </a>
+          <a href="" className={settingsLinkClass} onClick={this.props.onClickSettings}>{t('Device settings')}</a>
         </div>
       </div>
     );

--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -140,7 +140,7 @@ const Header = translate()(class Header extends Component {
                   color: 'white',
                   outline: 'none',
                 }}
-                label="Close"
+                label="Choose custom date range"
                 icon={DateRangeRoundedIcon}
                 onClick={this.props.onClickChartDates}
               />

--- a/app/components/elements/Accordion.js
+++ b/app/components/elements/Accordion.js
@@ -22,7 +22,9 @@ const StyledAccordion = styled(ExpansionPanel)`
   color: ${colors.text.primary};
   box-shadow: none;
   border-bottom: ${borders.divider};
-  position: static;
+  &:before {
+    background-color: transparent;
+  }
 
   &.Mui-expanded {
     margin: 0;

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1219,8 +1219,6 @@ export let PatientData = translate()(createReactClass({
 
     if (!this.state.mostRecentDatetimeLocation) state.mostRecentDatetimeLocation = opts.mostRecentDatetimeLocation;
 
-    console.log('chartTypeChanged, endpointsChanged, datetimeLocationChanged', chartTypeChanged, endpointsChanged, datetimeLocationChanged);
-
     const cb = (chartTypeChanged || endpointsChanged || datetimeLocationChanged)
       ? this.queryData.bind(this, opts.query, {
         showLoading: opts.showLoading,

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -20,7 +20,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { translate, Trans } from 'react-i18next';
-import i18next from '../../core/language';
 import { bindActionCreators } from 'redux';
 
 import _ from 'lodash';
@@ -43,6 +42,7 @@ import UploadLaunchOverlay from '../../components/uploadlaunchoverlay';
 
 import Messages from '../../components/messages';
 import UploaderButton from '../../components/uploaderbutton';
+import ChartDateRangeModal from '../../components/ChartDateRangeModal';
 import PrintDateRangeModal from '../../components/PrintDateRangeModal';
 
 import {
@@ -142,6 +142,8 @@ export let PatientData = translate()(createReactClass({
         },
         excludedDevices: [],
       },
+      datesDialogOpen: false,
+      datesDialogProcessing: false,
       printDialogOpen: false,
       printDialogProcessing: false,
       printDialogPDFOpts: null,
@@ -175,6 +177,7 @@ export let PatientData = translate()(createReactClass({
   render: function() {
     const patientData = this.renderPatientData();
     const messages = this.renderMessagesContainer();
+    const datesDialog = this.renderDatesDialog();
     const printDialog = this.renderPrintDialog();
     const showLoader = this.isInitialProcessing() || this.state.transitioningChartType;
 
@@ -182,6 +185,7 @@ export let PatientData = translate()(createReactClass({
       <div className="patient-data js-patient-data-page">
         {messages}
         {patientData}
+        {datesDialog}
         {printDialog}
         <Loader show={showLoader} />
       </div>
@@ -285,6 +289,57 @@ export let PatientData = translate()(createReactClass({
 
   renderUploadOverlay: function() {
     return <UploadLaunchOverlay modalDismissHandler={()=>{this.setState({showUploadOverlay: false})}}/>
+  },
+
+  renderDatesDialog: function() {
+    return (
+      <ChartDateRangeModal
+        id="chart-dates-dialog"
+        defaultDates={_.get(this.state, 'chartEndpoints.current')}
+        mostRecentDatumDate={this.getMostRecentDatumTimeByChartType()}
+        open={this.state.datesDialogOpen}
+        onClose={this.closeDatesDialog}
+        onSubmit={dates => {
+          this.setState({ datesDialogProcessing: true })
+          console.log('dates', dates);
+          // this.handleChartDateRangeUpdate()
+
+          // Determine the earliest startDate needed to fetch data to.
+          const startDate = moment.utc(dates[0]).tz(getTimezoneFromTimePrefs(this.state.timePrefs)).toISOString()
+          const endDate = moment.utc(dates[1]).tz(getTimezoneFromTimePrefs(this.state.timePrefs)).toISOString()
+          const fetchedUntil = _.get(this.props, 'data.fetchedUntil');
+
+          if (startDate < fetchedUntil) {
+            if (!this.props.fetchingPatientData && newChartRangeNeedsDataFetch) {
+              const options = {
+                showLoading: true,
+                returnData: false
+              };
+
+              this.fetchEarlierData(options);
+            }
+
+            // this.fetchEarlierData({
+            //   returnData: false,
+            //   showLoading: false,
+            //   startDate,
+            // });
+
+            // this.setState({ printDialogPDFOpts: opts });
+          } else {
+            const updateOpts = {
+              showLoading: true,
+              updateChartEndpoints: true,
+            };
+
+            this.updateChart(this.state.chartType, endDate, dates, updateOpts);
+            this.closeDatesDialog();
+          }
+        }}
+        processing={this.state.datesDialogProcessing}
+        timePrefs={this.state.timePrefs}
+      />
+    );
   },
 
   renderPrintDialog: function() {
@@ -397,6 +452,7 @@ export let PatientData = translate()(createReactClass({
             onSwitchToSettings={this.handleSwitchToSettings}
             onSwitchToBgLog={this.handleSwitchToBgLog}
             onUpdateChartDateRange={this.handleChartDateRangeUpdate}
+            onClickChartDates={this.handleClickChartDates}
             patient={this.props.patient}
             permsOfLoggedInUser={this.props.permsOfLoggedInUser}
             aggregations={aggregations}
@@ -520,6 +576,12 @@ export let PatientData = translate()(createReactClass({
           timePrefs={this.state.timePrefs} />
       );
     }
+  },
+
+  closeDatesDialog: function() {
+    this.setState({
+      datesDialogOpen: false,
+    });
   },
 
   closePrintDialog: function() {
@@ -844,6 +906,17 @@ export let PatientData = translate()(createReactClass({
     this.setState({ printDialogOpen: true });
   },
 
+  handleClickChartDates: function() {
+    this.props.trackMetric('Clicked Chart Dates', {
+      fromChart: this.state.chartType
+    });
+
+    this.setState({
+      datesDialogOpen: true,
+      datesDialogProcessing: false,
+    });
+  },
+
   handleClickRefresh: function(e) {
     this.handleRefresh(e);
     this.props.trackMetric('Clicked Refresh');
@@ -935,7 +1008,9 @@ export let PatientData = translate()(createReactClass({
 
     switch (chartType) {
       case 'basics':
-        start = findBasicsStart(datetimeLocation, timezoneName).valueOf();
+        start = extentSize
+          ? moment.utc(end).tz(timezoneName).subtract(extentSize, 'days').valueOf()
+          : findBasicsStart(datetimeLocation, timezoneName).valueOf();
         break;
 
       case 'daily':
@@ -1152,6 +1227,8 @@ export let PatientData = translate()(createReactClass({
     }
 
     if (!this.state.mostRecentDatetimeLocation) state.mostRecentDatetimeLocation = opts.mostRecentDatetimeLocation;
+
+    console.log('chartTypeChanged, endpointsChanged, datetimeLocationChanged', chartTypeChanged, endpointsChanged, datetimeLocationChanged);
 
     const cb = (chartTypeChanged || endpointsChanged || datetimeLocationChanged)
       ? this.queryData.bind(this, opts.query, {

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -42,8 +42,8 @@
 }
 
 .patient-data-subnav-text {
-  display: inline-block;
-
+  display: flex;
+  align-items: center;
   text-align: center;
 }
 
@@ -97,15 +97,20 @@
 
 .patient-data-subnav-center {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   padding: @patient-data-subnav-vertical-padding @spacing-small;
 }
 
 .patient-data-subnav-left {
+  display: flex;
+  align-items: center;
   padding: @patient-data-subnav-vertical-padding @spacing-small;
 }
 
 .patient-data-subnav-right {
+  display: flex;
+  align-items: center;
   padding: @patient-data-subnav-vertical-padding @spacing-small;
 }
 

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "sundial": "1.6.0",
     "terser": "4.8.0",
     "terser-webpack-plugin": "2.2.1",
-    "tideline": "1.20.0-web-54-basics-date-range-selection.2",
+    "tideline": "1.20.0-web-54-basics-date-range-selection.3",
     "tidepool-platform-client": "0.44.0",
     "tidepool-standard-action": "0.1.1",
     "url-loader": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "sundial": "1.6.0",
     "terser": "4.8.0",
     "terser-webpack-plugin": "2.2.1",
-    "tideline": "1.19.0",
+    "tideline": "1.20.0-web-54-basics-date-range-selection.2",
     "tidepool-platform-client": "0.44.0",
     "tidepool-standard-action": "0.1.1",
     "url-loader": "1.1.1",

--- a/stories/ChartDateRangeModal.stories.js
+++ b/stories/ChartDateRangeModal.stories.js
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import moment from 'moment-timezone';
+import { withDesign } from 'storybook-addon-designs';
+import { action } from '@storybook/addon-actions';
+import { ThemeProvider } from 'styled-components';
+import at from 'lodash/at';
+import map from 'lodash/map';
+import min from 'lodash/min';
+import keys from 'lodash/keys';
+
+import baseTheme from '../app/themes/baseTheme';
+import Button from '../app/components/elements/Button';
+import ChartDateRangeModal from '../app/components/ChartDateRangeModal';
+
+/* eslint-disable max-len */
+const sleep = m => new Promise(r => setTimeout(r, m));
+
+// Wrap each story component with the base theme
+const withTheme = Story => (
+  <ThemeProvider theme={baseTheme}>
+    <Story />
+  </ThemeProvider>
+);
+
+export default {
+  title: 'Chart Date Range Modals',
+  decorators: [withDesign, withTheme],
+};
+
+export const ChartDateRangeModalStory = () => {
+  const [open, setOpen] = useState(true);
+
+  const handleClickOpen = () => setOpen(true);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const [processing, setProcessing] = React.useState(false);
+
+  const fetchedUntil = moment.utc().subtract(32, 'days').valueOf();
+
+  const handleClickPrint = async (opts) => {
+    action('Clicked Apply')(opts);
+    setProcessing(true);
+
+    // Determine the earliest startDate needed to fetch data to.
+    const fetchUntil = min(at(opts, map(keys(opts), key => `${key}.endpoints.0`)));
+
+    // If fetchUntil is earlier than the point to which we've fetched data, we need to first fetch
+    // data to that date prior to generating the PDF
+    if (fetchUntil < fetchedUntil) {
+      action('Fetching Data for PDF')(opts);
+      await sleep(2000);
+    }
+
+    action('Generating PDF')(opts);
+    await sleep(1000);
+    setProcessing(false);
+    action('Open PDF')(opts);
+  };
+
+  const mostRecentDatumDate = moment.utc().subtract(2, 'd').valueOf();
+
+  const defaultDates = [
+    moment.utc(mostRecentDatumDate).subtract(5, 'd').valueOf(),
+    mostRecentDatumDate,
+  ];
+
+  return (
+    <React.Fragment>
+      <Button variant="primary" onClick={handleClickOpen}>
+        Open Chart Dates Dialog
+      </Button>
+      <ChartDateRangeModal
+        defaultDates={defaultDates}
+        mostRecentDatumDate={mostRecentDatumDate}
+        open={open}
+        onClose={handleClose}
+        onSubmit={handleClickPrint}
+        onDatesChange={dates => action('Updated Dates')(dates)}
+        processing={processing}
+        timePrefs={{
+          timezoneName: 'UTC',
+        }}
+      />
+    </React.Fragment>
+  );
+};
+
+ChartDateRangeModalStory.story = {
+  name: 'Chart Date Range Modal',
+};

--- a/stories/ChartDateRangeModal.stories.js
+++ b/stories/ChartDateRangeModal.stories.js
@@ -3,10 +3,6 @@ import moment from 'moment-timezone';
 import { withDesign } from 'storybook-addon-designs';
 import { action } from '@storybook/addon-actions';
 import { ThemeProvider } from 'styled-components';
-import at from 'lodash/at';
-import map from 'lodash/map';
-import min from 'lodash/min';
-import keys from 'lodash/keys';
 
 import baseTheme from '../app/themes/baseTheme';
 import Button from '../app/components/elements/Button';
@@ -38,26 +34,24 @@ export const ChartDateRangeModalStory = () => {
 
   const [processing, setProcessing] = React.useState(false);
 
-  const fetchedUntil = moment.utc().subtract(32, 'days').valueOf();
+  const fetchedUntil = moment.utc().subtract(30, 'days').valueOf();
 
-  const handleClickPrint = async (opts) => {
-    action('Clicked Apply')(opts);
+  const handleClickPrint = async range => {
+    action('Clicked Apply')(range);
     setProcessing(true);
 
-    // Determine the earliest startDate needed to fetch data to.
-    const fetchUntil = min(at(opts, map(keys(opts), key => `${key}.endpoints.0`)));
+    // Determine the earliest start date needed to fetch data to.
+    const fetchUntil = range[0];
 
-    // If fetchUntil is earlier than the point to which we've fetched data, we need to first fetch
-    // data to that date prior to generating the PDF
+    // If fetchUntil is earlier than the point to which we've fetched data, we need to fetch more.
     if (fetchUntil < fetchedUntil) {
-      action('Fetching Data for PDF')(opts);
+      action('Fetching Data')(range);
       await sleep(2000);
     }
 
-    action('Generating PDF')(opts);
     await sleep(1000);
     setProcessing(false);
-    action('Open PDF')(opts);
+    action('Applying Dates')(range);
   };
 
   const mostRecentDatumDate = moment.utc().subtract(2, 'd').valueOf();

--- a/stories/PrintDateRangeModal.stories.js
+++ b/stories/PrintDateRangeModal.stories.js
@@ -66,7 +66,6 @@ export const PrintDateRangeModalStory = () => {
         Open Print Dialog
       </Button>
       <PrintDateRangeModal
-        fetchedUntil={fetchedUntil}
         mostRecentDatumDates={{
           basics: moment.utc().valueOf(),
           bgLog: moment.utc().subtract(2, 'd').valueOf(),

--- a/test/unit/components/ChartDateRangeModal.test.js
+++ b/test/unit/components/ChartDateRangeModal.test.js
@@ -1,0 +1,142 @@
+/* global chai */
+/* global describe */
+/* global sinon */
+/* global it */
+/* global beforeEach */
+/* global afterEach */
+/* global context */
+
+import React from 'react';
+import moment from 'moment-timezone';
+import { mount } from 'enzyme';
+
+import ChartDateRangeModal from '../../../app/components/ChartDateRangeModal';
+
+const expect = chai.expect;
+
+describe('ChartDateRangeModal', function () {
+  const props = {
+    defaultDates: [
+      moment.utc('2020-03-01T00:00:00.000Z').valueOf(),
+      moment.utc('2020-03-10T00:00:00.000Z').valueOf() + 1,
+    ],
+    mostRecentDatumDate: Date.parse('2020-03-10T00:00:00.000Z'),
+    open: true,
+    onClose: sinon.stub(),
+    onSubmit: sinon.stub(),
+    processing: false,
+    timePrefs: {
+      timezoneName: 'UTC',
+    },
+  };
+
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount( <ChartDateRangeModal {...props} /> );
+  });
+
+  afterEach(() => {
+    props.onClose.reset();
+    props.onSubmit.reset();
+  });
+
+  it('should be visible when open prop is true', () => {
+    const dialog = () => wrapper.find('.MuiDialog-container').hostNodes();
+    expect(dialog().prop('style').opacity).to.equal(1);
+
+    wrapper.setProps({ ...props, open: false });
+    wrapper.update();
+
+    expect(dialog().prop('style').opacity).to.equal(0);
+  });
+
+  it('should provide date range preset options', () => {
+    const datesRangePreset1 = wrapper.find('#days-chart').find('button').at(0).hostNodes();
+    const datesRangePreset2 = wrapper.find('#days-chart').find('button').at(1).hostNodes();
+    const datesRangePreset3 = wrapper.find('#days-chart').find('button').at(2).hostNodes();
+
+    expect(datesRangePreset1.prop('value')).to.equal(14);
+    expect(datesRangePreset2.prop('value')).to.equal(21);
+    expect(datesRangePreset3.prop('value')).to.equal(30);
+  });
+
+  it('should set default dates as provided by props', () => {
+    const dateFormat = 'MMM D, YYYY';
+    // Note: we expect the start dates to show a date that is the preset range MINUS 1 day prior
+    // to the end date, since the resulting date range goes from the first ms of the start date
+    // to the last ms of the end date
+    const startDate = wrapper.find('#chart-start-date').hostNodes();
+    const endDate = wrapper.find('#chart-end-date').hostNodes();
+    expect(startDate.prop('value')).to.equal('Mar 1, 2020');
+    expect(endDate.prop('value')).to.equal('Mar 10, 2020');
+
+    // Use 'US/Pacific' time zone
+    const pacificWrapper = mount( <ChartDateRangeModal {...{ ...props, timePrefs: { timezoneName: 'US/Pacific' } }} /> )
+
+    const startDateInPacific = pacificWrapper.find('#chart-start-date').hostNodes();
+    const endDateInPacific = pacificWrapper.find('#chart-end-date').hostNodes();
+
+    expect(moment.utc('Mar 01, 2020', dateFormat).tz('US/Pacific').format(dateFormat)).to.equal('Feb 29, 2020');
+    expect(startDateInPacific.prop('value')).to.equal('Feb 29, 2020');
+
+    expect(moment.utc('Mar 10, 2020', dateFormat).tz('US/Pacific').format(dateFormat)).to.equal('Mar 9, 2020');
+    expect(endDateInPacific.prop('value')).to.equal('Mar 9, 2020');
+  });
+
+  context('form is submitted', () => {
+    let submitButton;
+
+    beforeEach(() => {
+      submitButton = () => wrapper.find('button.chart-dates-submit').hostNodes();
+    });
+
+    it('should call `onSubmit` prop method with appropriate print ranges and disabled statuses', () => {
+      const datesRangeSelectedPreset = () => wrapper.find('#days-chart').find('.selected').hostNodes();
+
+      // Change range to 30 days
+      const datesRangePreset3 = wrapper.find('#days-chart').find('button').at(2).hostNodes();
+      datesRangePreset3.simulate('click');
+
+      expect(datesRangeSelectedPreset().prop('value')).to.equal(30);
+
+      // Submit form
+      submitButton().simulate('click');
+      sinon.assert.calledOnce(props.onSubmit);
+      sinon.assert.calledWith(props.onSubmit, [
+          moment.utc(Date.parse('2020-03-11T00:00:00.000Z')).subtract(30, 'days').valueOf(),
+          Date.parse('2020-03-11T00:00:00.000Z'),
+      ]);
+    });
+
+    it('should not call `onSubmit` if there are date validation errors and render error message', () => {
+      const datesClearButton = () => wrapper.find('button.DateRangePickerInput_clearDates').hostNodes();
+      const startDate = () => wrapper.find('#chart-start-date').hostNodes();
+      const endDate = () => wrapper.find('#chart-end-date').hostNodes();
+      const error = () => wrapper.find('#chart-dates-error').hostNodes();
+
+      // Clear dates
+      datesClearButton().simulate('click');
+      expect(startDate().prop('value')).to.equal('');
+      expect(endDate().prop('value')).to.equal('');
+      expect(error()).to.have.lengthOf(0);
+
+      submitButton().simulate('click');
+      sinon.assert.notCalled(props.onSubmit);
+
+      expect(error()).to.have.lengthOf(1);
+      expect(error().text()).to.equal('Please select a date range');
+    });
+  });
+
+  it('should run `onClose` prop method when "Cancel" button is clicked', () => {
+    const cancelButton = wrapper.find('button.chart-dates-cancel').hostNodes();
+    cancelButton.simulate('click');
+    sinon.assert.calledOnce(props.onClose);
+  });
+
+  it('should run `onClose` prop method when the close icon is clicked', () => {
+    const closeIcon = wrapper.find('span[aria-label="close dialog"]').hostNodes();
+    closeIcon.simulate('click');
+    sinon.assert.calledOnce(props.onClose);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -18398,10 +18398,10 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tideline@1.20.0-web-54-basics-date-range-selection.2:
-  version "1.20.0-web-54-basics-date-range-selection.2"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.20.0-web-54-basics-date-range-selection.2.tgz#2f05442454dcccf4792bc5149ed2eec7dc7171ae"
-  integrity sha512-FNxWdPRcmwh1oh4CkDgFjCqaQ34pUvy/t/yffWwuOkDiqesgx6rVzEk8N2yCJOVzRzXIf21w6e03wU2n2LUyMA==
+tideline@1.20.0-web-54-basics-date-range-selection.3:
+  version "1.20.0-web-54-basics-date-range-selection.3"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.20.0-web-54-basics-date-range-selection.3.tgz#3302d6c8686f4fe961398205c31f9c4819dd0acd"
+  integrity sha512-R92h+4kKwT3Ccrc3SHAemtBln7LoS1OR3gcxMpiCZBPWta//xxt5D3i9PkXlKCkaYsBigRcTbJ/57ZXQ/mgwqg==
   dependencies:
     bows "1.7.0"
     classnames "2.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18398,10 +18398,10 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tideline@1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.19.0.tgz#0028e69e341c8d10261fb44914d9f1135047d45f"
-  integrity sha512-yKIdWk24SJd4it5fUtIz3/TBkmErKgYZmBwAK8KgHflk6Kz9Nzin0RMXgPEFpqSRN8+0U1ds/3ces/3KI1nIqg==
+tideline@1.20.0-web-54-basics-date-range-selection.2:
+  version "1.20.0-web-54-basics-date-range-selection.2"
+  resolved "https://registry.yarnpkg.com/tideline/-/tideline-1.20.0-web-54-basics-date-range-selection.2.tgz#2f05442454dcccf4792bc5149ed2eec7dc7171ae"
+  integrity sha512-FNxWdPRcmwh1oh4CkDgFjCqaQ34pUvy/t/yffWwuOkDiqesgx6rVzEk8N2yCJOVzRzXIf21w6e03wU2n2LUyMA==
   dependencies:
     bows "1.7.0"
     classnames "2.2.6"


### PR DESCRIPTION
See [WEB-54]

Implements a custom date range picker on the basics view via a calendar icon beside the dates.  Similar to the implementation of the print view date dialog, we have a 90-day limit, and identical defaults/presets to the print view to facilitate a 1:1 experience.

Supporting PR: tidepool-org/tideline#408


[WEB-54]: https://tidepool.atlassian.net/browse/WEB-54