### PR TITLE
[WEB-54] Set basics dates default extent size to 14 days, and send metrics on date changes

### DIFF
--- a/app/components/ChartDateRangeModal.js
+++ b/app/components/ChartDateRangeModal.js
@@ -175,7 +175,7 @@ export const ChartDateRangeModal = (props) => {
             </Flex>
           </Box>
           <Box mb={3}>
-            <Body1 mb={2}>{t('Or select a custom date range')}</Body1>
+            <Body1 mb={2}>{t('Or select a custom date range ({{maxDays}} days max)', { maxDays })}</Body1>
             <DateRangePicker
               startDate={dates.startDate}
               startDateId="chart-start-date"
@@ -190,7 +190,7 @@ export const ChartDateRangeModal = (props) => {
               onFocusChange={input => setDatePickerOpen(!!input)}
               themeProps={{
                 minWidth: '580px',
-                minHeight: datePickerOpen ? '300px' : undefined,
+                minHeight: datePickerOpen ? '320px' : undefined,
               }}
             />
           </Box>

--- a/app/components/PrintDateRangeModal.js
+++ b/app/components/PrintDateRangeModal.js
@@ -251,7 +251,7 @@ export const PrintDateRangeModal = (props) => {
                     </Flex>
                   </Box>
                   <Box mb={3}>
-                    <Body1 mb={2}>{t('Or select a custom date range')}</Body1>
+                    <Body1 mb={2}>{t('Or select a custom date range ({{maxDays}} days max)', { maxDays })}</Body1>
                     <DateRangePicker
                       startDate={dates[panel.key].startDate}
                       startDateId={`${[panel.key]}-start-date`}

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -94,6 +94,7 @@ export let PatientData = translate()(createReactClass({
       chartPrefs: {
         basics: {
           sections: {},
+          extentSize: 14,
         },
         daily: {
           extentSize: 1,
@@ -994,31 +995,11 @@ export let PatientData = translate()(createReactClass({
 
     const timezoneName = applyTimeZoneToStart ? getTimezoneFromTimePrefs(this.state.timePrefs) : 'UTC';
 
-    let start;
     const end = setEndToLocalCeiling
       ? getLocalizedCeiling(datetimeLocation, this.state.timePrefs).valueOf()
       : Date.parse(datetimeLocation);
 
-    switch (chartType) {
-      case 'basics':
-        start = extentSize
-          ? moment.utc(end).tz(timezoneName).subtract(extentSize, 'days').valueOf()
-          : findBasicsStart(datetimeLocation, timezoneName).valueOf();
-        break;
-
-      case 'daily':
-        start = moment.utc(end).tz(timezoneName).subtract(extentSize, 'days').valueOf();
-        break;
-
-      case 'bgLog':
-        start = moment.utc(end).tz(timezoneName).subtract(extentSize, 'days').valueOf();
-        break;
-
-      case 'trends':
-        start = moment.utc(end).tz(timezoneName).subtract(extentSize, 'days').valueOf();
-        break;
-    }
-
+    const start = moment.utc(end).tz(timezoneName).subtract(extentSize, 'days').valueOf();
     return (start && end ? [start, end] : []);
   },
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -50,7 +50,7 @@ import {
 } from '../../core/constants';
 
 const { Loader } = vizComponents;
-const { findBasicsStart, getLocalizedCeiling, getTimezoneFromTimePrefs } = vizUtils.datetime;
+const { getLocalizedCeiling, getTimezoneFromTimePrefs } = vizUtils.datetime;
 const { commonStats, getStatDefinition } = vizUtils.stat;
 
 export let PatientData = translate()(createReactClass({

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -295,8 +295,9 @@ export let PatientData = translate()(createReactClass({
   renderDatesDialog: function() {
     return (
       <ChartDateRangeModal
-        id="chart-dates-dialog"
+        chartType={this.state.chartType}
         defaultDates={_.get(this.state, 'chartEndpoints.current')}
+        id="chart-dates-dialog"
         mostRecentDatumDate={this.getMostRecentDatumTimeByChartType()}
         open={this.state.datesDialogOpen}
         onClose={this.closeDatesDialog}
@@ -327,6 +328,7 @@ export let PatientData = translate()(createReactClass({
         }}
         processing={this.state.datesDialogProcessing}
         timePrefs={this.state.timePrefs}
+        trackMetric={this.props.trackMetric}
       />
     );
   },

--- a/stories/ChartDateRangeModal.stories.js
+++ b/stories/ChartDateRangeModal.stories.js
@@ -67,6 +67,7 @@ export const ChartDateRangeModalStory = () => {
         Open Chart Dates Dialog
       </Button>
       <ChartDateRangeModal
+        chartType="basics"
         defaultDates={defaultDates}
         mostRecentDatumDate={mostRecentDatumDate}
         open={open}

--- a/test/unit/components/ChartDateRangeModal.test.js
+++ b/test/unit/components/ChartDateRangeModal.test.js
@@ -16,6 +16,7 @@ const expect = chai.expect;
 
 describe('ChartDateRangeModal', function () {
   const props = {
+    chartType: 'basics',
     defaultDates: [
       moment.utc('2020-03-01T00:00:00.000Z').valueOf(),
       moment.utc('2020-03-10T00:00:00.000Z').valueOf() + 1,
@@ -28,6 +29,7 @@ describe('ChartDateRangeModal', function () {
     timePrefs: {
       timezoneName: 'UTC',
     },
+    trackMetric: sinon.stub(),
   };
 
   let wrapper;
@@ -38,6 +40,7 @@ describe('ChartDateRangeModal', function () {
   afterEach(() => {
     props.onClose.reset();
     props.onSubmit.reset();
+    props.trackMetric.reset();
   });
 
   it('should be visible when open prop is true', () => {
@@ -125,6 +128,26 @@ describe('ChartDateRangeModal', function () {
 
       expect(error()).to.have.lengthOf(1);
       expect(error().text()).to.equal('Please select a date range');
+    });
+
+    it('should send metric for print options', () => {
+      const datesRangeSelectedPreset = () => wrapper.find('#days-chart').find('.selected').hostNodes();
+
+      // Change range to 30 days
+      const datesRangePreset3 = wrapper.find('#days-chart').find('button').at(2).hostNodes();
+      datesRangePreset3.simulate('click');
+
+      expect(datesRangeSelectedPreset().prop('value')).to.equal(30);
+
+      sinon.assert.notCalled(props.trackMetric);
+
+      // Submit form
+      submitButton().simulate('click');
+
+      sinon.assert.calledWith(props.trackMetric, 'Set Custom Chart Dates', {
+        chartType: 'basics',
+        dateRange: '30 days',
+      });
     });
   });
 

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -1059,6 +1059,7 @@ describe('PatientData', function () {
       expect(wrapper.state().chartPrefs).to.eql({
         basics: {
           sections: {},
+          extentSize: 14,
         },
         daily: {
           extentSize: 1,
@@ -1406,21 +1407,27 @@ describe('PatientData', function () {
         });
       });
 
-      it('should return the valueOf `findBasicsStart` for the start value when timezone not set', () => {
+      it('should return the valueOf `chartPrefs.basics.extentSize` days prior to the endpoint', () => {
+        wrapper.setState({ chartPrefs: { basics: { extentSize: 14 } } });
         const result = instance.getChartEndpoints(datetimeLocation);
-        expect(result[0]).to.be.a('number').and.to.equal(Date.parse('2019-11-11T00:00:00.000Z'));
+        expect(result[0]).to.be.a('number').and.to.equal(Date.parse('2019-11-14T00:00:00.000Z'));
+
+        wrapper.setState({ chartPrefs: { basics: { extentSize: 15 } } });
+        const result2 = instance.getChartEndpoints(datetimeLocation);
+        expect(result2[0]).to.be.a('number').and.to.equal(Date.parse('2019-11-13T00:00:00.000Z'));
       });
 
-      it('should return the valueOf `findBasicsStart` for the start value when timezone is set', () => {
+      it('should return the valueOf `chartPrefs.basics.extentSize` days prior to the endpoint when timezone is set', () => {
         wrapper.setState({
           timePrefs: {
             timezoneAware: true,
             timezoneName: 'US/Eastern',
           },
+          chartPrefs: { basics: { extentSize: 14 } }
         });
 
         const result = instance.getChartEndpoints(datetimeLocation);
-        expect(result[0]).to.be.a('number').and.to.equal(Date.parse('2019-11-11T05:00:00.000Z')); // GMT-5 for US/Eastern
+        expect(result[0]).to.be.a('number').and.to.equal(Date.parse('2019-11-14T05:00:00.000Z')); // GMT-5 for US/Eastern
       });
     });
 


### PR DESCRIPTION
Some additional requirements stemming from the comments on [WEB-54]

Default dates for basics is now the latest 14 days to match the new print view defaults.

As well, added a kissmetric event to track date changes, and a note regarding the 90 days max custom range.

[WEB-54]: https://tidepool.atlassian.net/browse/WEB-54