### PR TITLE
[WEB-1064] Fix for double clicking datums on BG Log not navigating to correct date in Daily

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -824,8 +824,9 @@ export let PatientData = translate()(createReactClass({
       .subtract(12, 'hours')
       .toISOString();
 
+    const datetimeInteger = _.isInteger(datetime) ? datetime : Date.parse(datetime);
     const mostRecentDatumTime = this.getMostRecentDatumTimeByChartType(this.props, chartType);
-    const dateCeiling = getLocalizedCeiling(_.min([Date.parse(datetime), mostRecentDatumTime]), this.state.timePrefs);
+    const dateCeiling = getLocalizedCeiling(_.min([datetimeInteger, mostRecentDatumTime]), this.state.timePrefs);
     const datetimeLocation = getDatetimeLocation(dateCeiling);
 
     const updateOpts = { updateChartEndpoints: true };

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -3824,13 +3824,25 @@ describe('PatientData', function () {
       });
     });
 
-    it('should set the `datetimeLocation` state to noon for the previous day of the provided datetime', () => {
+    it('should set the `datetimeLocation` state to noon for the previous day of the provided iso string datetime', () => {
       const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({datetimeLocation: '2018-03-03T00:00:00.000Z'});
 
       instance.handleSwitchToDaily('2018-03-03T00:00:00.000Z');
+
+      // Should set to previous day because the provided datetime filter is exclusive
+      expect(wrapper.state('datetimeLocation')).to.equal('2018-03-02T12:00:00.000Z');
+    });
+
+    it('should set the `datetimeLocation` state to noon for the previous day of the provided utc timestamp datetime', () => {
+      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const instance = wrapper.instance();
+
+      wrapper.setState({datetimeLocation: '2018-03-03T00:00:00.000Z'});
+
+      instance.handleSwitchToDaily(Date.parse('2018-03-03T00:00:00.000Z'));
 
       // Should set to previous day because the provided datetime filter is exclusive
       expect(wrapper.state('datetimeLocation')).to.equal('2018-03-02T12:00:00.000Z');


### PR DESCRIPTION
See [WEB-1064] 

Basicslly, the BG Log view was sending the date as a UTC timestamp, but the handler for switching to Daily was only working when the provided datetime was an ISO string.  The handler now works with both formats.

[WEB-1064]: https://tidepool.atlassian.net/browse/WEB-1064