### PR TITLE
[WEB-981] Pre-open a PDF window async data fetch is required

### DIFF
--- a/app/components/chart/header.js
+++ b/app/components/chart/header.js
@@ -4,8 +4,8 @@ import React, { Component } from 'react';
 import cx from 'classnames';
 import { translate } from 'react-i18next';
 import DateRangeRoundedIcon from '@material-ui/icons/DateRangeRounded';
+import PrintRoundedIcon from '@material-ui/icons/PrintRounded';
 
-import printPng from './img/print-icon-2x.png';
 import Icon from '../elements/Icon';
 
 const Header = translate()(class Header extends Component {
@@ -115,7 +115,7 @@ const Header = translate()(class Header extends Component {
       'printview-print-icon': true,
       'patient-data-subnav-right': true,
       'patient-data-subnav-right-label': true,
-      'patient-data-subnav-active': showPrintLink,
+      'patient-data-subnav-active': false,
       'patient-data-subnav-hidden': !showPrintLink,
     });
 
@@ -139,6 +139,7 @@ const Header = translate()(class Header extends Component {
                   mt: -1,
                   color: 'white',
                   outline: 'none',
+                  '&:hover': { color: 'grays.6' },
                 }}
                 label="Choose custom date range"
                 icon={DateRangeRoundedIcon}
@@ -151,7 +152,18 @@ const Header = translate()(class Header extends Component {
         </div>
         <div className="app-no-print patient-data-subnav-right">
           <a href="" className={printLinkClass} onClick={this.props.onClickPrint}>
-            <img className="print-icon" src={printPng} alt="Print" />
+            <Icon
+              className="icon"
+              variant="default"
+              sx={{
+                mr: 1,
+                mt: '-2px',
+                color: 'white',
+                outline: 'none',
+              }}
+              label="Print PDF report"
+              icon={PrintRoundedIcon}
+            />
             {t('Print')}
           </a>
           <a href="" className={settingsLinkClass} onClick={this.props.onClickSettings}>{t('Device settings')}</a>

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -365,7 +365,7 @@ export let PatientData = translate()(createReactClass({
             if (!this.printWindowRef || this.printWindowRef.closed) {
               const waitMessage = this.props.t('Please wait while Tidepool generates your PDF report.');
               this.printWindowRef = window.open();
-              this.printWindowRef.document.write(`<p align="center" style="margin-top:20px;font-size:16px;">${waitMessage}</p>`);
+              this.printWindowRef.document.write(`<p align="center" style="margin-top:20px;font-size:16px;font-family:sans-serif">${waitMessage}</p>`);
             }
 
             this.setState({ printDialogPDFOpts: opts });

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -360,6 +360,14 @@ export let PatientData = translate()(createReactClass({
               startDate,
             });
 
+            // In cases where we need to fetch data via an async backend call, we need to pre-open
+            // the PDF tab ahead of time. Otherwise, it will be treated as a popup, and likely blocked.
+            if (!this.printWindowRef || this.printWindowRef.closed) {
+              const waitMessage = this.props.t('Please wait while Tidepool generates your PDF report.');
+              this.printWindowRef = window.open();
+              this.printWindowRef.document.write(`<p align="center" style="margin-top:20px;font-size:16px;">${waitMessage}</p>`);
+            }
+
             this.setState({ printDialogPDFOpts: opts });
           } else {
             this.generatePDF(this.props, this.state, opts);
@@ -1353,9 +1361,18 @@ export let PatientData = translate()(createReactClass({
       }
 
       if (nextProps.pdf.combined.url) {
-        const printWindow = window.open(nextProps.pdf.combined.url);
-        printWindow.focus();
-        printWindow.print();
+        if (this.printWindowRef && !this.printWindowRef.closed) {
+          // If we already have a ref to a PDF window, (re)use it
+          this.printWindowRef.location.href = nextProps.pdf.combined.url;
+        } else {
+          // Otherwise, we create and open a new PDF window ref.
+          this.printWindowRef = window.open(nextProps.pdf.combined.url);
+        }
+
+        setTimeout(() => {
+          this.printWindowRef.focus();
+          this.printWindowRef.print();
+        });
       }
     }
   },

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -44,7 +44,7 @@
 .patient-data-subnav-text {
   display: flex;
   align-items: center;
-  text-align: center;
+  justify-content: center;
 }
 
 .patient-data-subnav-dates-daily {
@@ -60,7 +60,7 @@
 }
 
 .patient-data-subnav a {
-  display: inline-block;
+  display: flex;
   padding: 0 @patient-data-subnav-horizontal-padding;
   &.patient-data-icon {
     padding: 0;
@@ -69,10 +69,16 @@
   color: #fff;
   text-decoration: none;
 
+  transition: all .2s ease-out;
+
   &:hover,
   &:focus {
     color: @gray-darkest;
     text-decoration: none;
+
+    .icon {
+      color: @gray-darkest;
+    }
   }
 
   &:active,
@@ -116,20 +122,6 @@
 
 .patient-data-subnav-right-label {
   float: right;
-}
-
-.patient-data-subnav .print-loading-spinner {
-  display: inline-block;
-  position: relative;
-  top: 2px;
-  margin-right: 5px;
-}
-
-.patient-data-subnav .printview-print-icon img {
-  padding-right: 5px;
-  height: 16px;
-  position: relative;
-  top: -2px;
 }
 
 // Content

--- a/test/unit/components/chart/settings.test.js
+++ b/test/unit/components/chart/settings.test.js
@@ -168,11 +168,9 @@ describe('Settings', function () {
 
       var settingsElem = React.createElement(Settings, props);
       var elem = TestUtils.renderIntoDocument(settingsElem);
-      var printLink = TestUtils.findRenderedDOMComponentWithClass(elem, ['patient-data-subnav-active', 'printview-print-icon']);
-      var printIcon = TestUtils.findRenderedDOMComponentWithClass(elem, 'print-icon');
+      var printLink = TestUtils.findRenderedDOMComponentWithClass(elem, 'printview-print-icon');
 
       expect(printLink).to.be.ok;
-      expect(printIcon).to.be.ok;
 
       expect(props.onClickPrint.callCount).to.equal(0);
       TestUtils.Simulate.click(printLink);


### PR DESCRIPTION
Small fix required for [WEB-981], where in scenarios that an async data fetch was required prior to generating a PDF report, the print window would be blocked by the browser's popup blocker.

The solution is to open the new window BEFORE sending the request for earlier data, and then updating the `location.href` of it once the data is received and the PDF is ready.  We show a short message in the new blank window while the user waits.

In cases where this pre-fetching is not required, the workflow has not been updated.  It will stay on the print modal until the processing is complete, and then open the new tab.

While implementing this fix, I also noticed some inconsistencies on hover states and flex positioning within the updated header bar, so I've cleaned up some styles as well.

[WEB-981]: https://tidepool.atlassian.net/browse/WEB-981