### PR TITLE
[WEB-981] Address print dialog UI feedback

### DIFF
--- a/app/components/PrintDateRangeModal.js
+++ b/app/components/PrintDateRangeModal.js
@@ -232,7 +232,7 @@ export const PrintDateRangeModal = (props) => {
       <DialogTitle divider={false} onClose={handleClose}>
         <MediumTitle>{t('Print Report')}</MediumTitle>
       </DialogTitle>
-      <DialogContent divider={false} minWidth="400px" p={0}>
+      <DialogContent divider={false} minWidth="644px" p={0}>
         {map(panels, panel => (
           <Accordion {...accordionProps(panel.key, panel.header)}>
             <Box width="100%">
@@ -284,7 +284,6 @@ export const PrintDateRangeModal = (props) => {
                       )}
                       onFocusChange={input => setDatePickerOpen(!!input)}
                       themeProps={{
-                        minWidth: '580px',
                         minHeight: datePickerOpen ? '300px' : undefined,
                       }}
                     />

--- a/app/components/PrintDateRangeModal.js
+++ b/app/components/PrintDateRangeModal.js
@@ -79,6 +79,7 @@ export const PrintDateRangeModal = (props) => {
       basics: false,
       bgLog: false,
       daily: false,
+      general: false,
     },
     expandedPanel: 'basics',
     submitted: false,
@@ -108,14 +109,23 @@ export const PrintDateRangeModal = (props) => {
 
   const validateDates = ({ basics, bgLog, daily }) => {
     const validationErrors = {
-      basics: validateDatesSet(basics),
-      bgLog: validateDatesSet(bgLog),
-      daily: validateDatesSet(daily),
+      basics: enabled.basics && validateDatesSet(basics),
+      bgLog: enabled.bgLog && validateDatesSet(bgLog),
+      daily: enabled.daily && validateDatesSet(daily),
     };
 
-    setErrors(validationErrors);
     return validationErrors;
   };
+
+  const validateChartEnabled = () => {
+    const validationErrors = {
+      general: (!enabled.basics && !enabled.bgLog && !enabled.daily && !enabled.settings)
+        ? t('Please enable at least one chart to print')
+        : false,
+    };
+
+    return validationErrors;
+  }
 
   // Accordion Panels
   const handleAccordionChange = key => (event, isExpanded) => {
@@ -175,7 +185,14 @@ export const PrintDateRangeModal = (props) => {
   // Handlers
   const handleSubmit = () => {
     setSubmitted(true);
-    const validationErrors = validateDates(dates);
+
+    const validationErrors = {
+      ...validateDates(dates),
+      ...validateChartEnabled(),
+    };
+
+    setErrors(validationErrors);
+
     if (!isEqual(validationErrors, defaults.errors)) return;
 
     const printOpts = {
@@ -221,11 +238,15 @@ export const PrintDateRangeModal = (props) => {
     }
   }, [open]);
 
-  // Validate dates if submitted and call `onDatesChange` prop method when dates change
+  // Call `onDatesChange` prop method when dates change
   useEffect(() => {
-    if (submitted) validateDates(dates);
     onDatesChange(dates);
   }, [dates]);
+
+  // Validate dates and enabled statuses if submitted
+  useEffect(() => {
+    if (submitted) setErrors({ ...validateDates(dates), ...validateChartEnabled()});
+  }, [enabled, dates]);
 
   return (
     <Dialog id="printDateRangePicker" maxWidth="md" open={open} onClose={handleClose}>
@@ -298,12 +319,17 @@ export const PrintDateRangeModal = (props) => {
             )}
           </Accordion>
         ))}
+        {errors.general && (
+          <Caption mx={5} mt={2} color="feedback.danger" id="general-print-error">
+            {errors.general}
+          </Caption>
+        )}
       </DialogContent>
       <DialogActions justifyContent="space-between" py={2}>
         <Button variant="textSecondary" className="print-cancel" onClick={handleClose}>
           {t('Cancel')}
         </Button>
-        <Button variant="textPrimary" className="print-submit" processing={processing} onClick={handleSubmit}>
+        <Button variant="textPrimary" className="print-submit" disabled={!isEqual(errors, defaults.errors)} processing={processing} onClick={handleSubmit}>
           {t('Print')}
         </Button>
       </DialogActions>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.39.0-rc.2",
+  "version": "1.39.0-rc.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/components/printDateRangeModal.test.js
+++ b/test/unit/components/printDateRangeModal.test.js
@@ -250,6 +250,41 @@ describe('PrintDateRangeModal', function () {
       expect(basicsError().text()).to.equal('Please select a date range');
     });
 
+    it('should not call `onClickPrint` if there are no enabled charts and render error message', () => {
+      const basicsToggle = () => wrapper.find('button[name="enabled-basics"]').hostNodes();
+      expect(basicsToggle()).to.have.lengthOf(1);
+      expect(basicsToggle().prop('aria-checked')).to.be.true;
+
+      const bgLogToggle = () => wrapper.find('button[name="enabled-bgLog"]').hostNodes();
+      expect(bgLogToggle()).to.have.lengthOf(1);
+      expect(bgLogToggle().prop('aria-checked')).to.be.true;
+
+      const dailyToggle = () => wrapper.find('button[name="enabled-daily"]').hostNodes();
+      expect(dailyToggle()).to.have.lengthOf(1);
+      expect(dailyToggle().prop('aria-checked')).to.be.true;
+
+      const settingsToggle = () => wrapper.find('button[name="enabled-settings"]').hostNodes();
+      expect(settingsToggle()).to.have.lengthOf(1);
+      expect(settingsToggle().prop('aria-checked')).to.be.true;
+
+      basicsToggle().simulate('click');
+      bgLogToggle().simulate('click');
+      dailyToggle().simulate('click');
+      settingsToggle().simulate('click');
+
+      expect(basicsToggle().prop('aria-checked')).to.be.false;
+      expect(bgLogToggle().prop('aria-checked')).to.be.false;
+      expect(dailyToggle().prop('aria-checked')).to.be.false;
+      expect(settingsToggle().prop('aria-checked')).to.be.false;
+
+      submitButton().simulate('click');
+      sinon.assert.notCalled(props.onClickPrint);
+
+      const generalError = () => wrapper.find('#general-print-error').hostNodes();
+      expect(generalError()).to.have.lengthOf(1);
+      expect(generalError().text()).to.equal('Please enable at least one chart to print');
+    });
+
     it('should send metric for print options', () => {
       // Disable bgLog chart
       const bgLogToggle = () => wrapper.find('button[name="enabled-bgLog"]').hostNodes();


### PR DESCRIPTION
See Ginny's comments in [WEB-981]

This sets a better min-width for the modal for when only devices is enabled, adds validation to disable printing if no charts are enabled, and does not validate dates for a disabled chart.

[WEB-981]: https://tidepool.atlassian.net/browse/WEB-981