### PR TITLE
[WEB-1089] Catch pdf window focus errors caused by popup blocker

### DIFF
--- a/app/components/ChartDateRangeModal.js
+++ b/app/components/ChartDateRangeModal.js
@@ -214,9 +214,9 @@ export const ChartDateRangeModal = (props) => {
 };
 
 ChartDateRangeModal.propTypes = {
-  chartType: PropTypes.string.isRequired,
+  chartType: PropTypes.string,
   maxDays: PropTypes.number.isRequired,
-  mostRecentDatumDate: PropTypes.number.isRequired,
+  mostRecentDatumDate: PropTypes.number,
   onClose: PropTypes.func.isRequired,
   onDatesChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
@@ -224,8 +224,8 @@ ChartDateRangeModal.propTypes = {
   processing: PropTypes.bool,
   timePrefs: PropTypes.shape({
     timezoneAware: PropTypes.bool,
-    timezoneName: PropTypes.string.isRequired,
-  }).isRequired,
+    timezoneName: PropTypes.string,
+  }),
   trackMetric: PropTypes.func.isRequired,
 };
 

--- a/app/components/PrintDateRangeModal.js
+++ b/app/components/PrintDateRangeModal.js
@@ -340,9 +340,9 @@ export const PrintDateRangeModal = (props) => {
 PrintDateRangeModal.propTypes = {
   maxDays: PropTypes.number.isRequired,
   mostRecentDatumDates: PropTypes.shape({
-    basics: PropTypes.number.isRequired,
-    bgLog: PropTypes.number.isRequired,
-    daily: PropTypes.number.isRequired,
+    basics: PropTypes.number,
+    bgLog: PropTypes.number,
+    daily: PropTypes.number,
   }),
   onClickPrint: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
@@ -351,8 +351,8 @@ PrintDateRangeModal.propTypes = {
   processing: PropTypes.bool,
   timePrefs: PropTypes.shape({
     timezoneAware: PropTypes.bool,
-    timezoneName: PropTypes.string.isRequired,
-  }).isRequired,
+    timezoneName: PropTypes.string,
+  }),
   trackMetric: PropTypes.func.isRequired,
 };
 

--- a/app/components/elements/Toast.js
+++ b/app/components/elements/Toast.js
@@ -14,6 +14,7 @@ import baseTheme from '../../themes/baseTheme';
 
 export const Toast = props => {
   const {
+    action,
     message,
     onClose,
     open,
@@ -43,9 +44,10 @@ export const Toast = props => {
         theme={baseTheme}
         variant={`toasts.${variant}`}
       >
-        <Flex alignItems="center">
+        <Flex alignItems="center" pr={2}>
           <Icon className="feedback" label="feedback" icon={feedbackIcon[variant]} />
-          <Body1 pl={2} pr={4}>{message}</Body1>
+          <Body1 pl={2} pr={action ? 2 : 0}>{message}</Body1>
+          {action}
         </Flex>
         <Icon
           className="close"
@@ -70,6 +72,7 @@ Toast.propTypes = {
 };
 
 Toast.defaultProps = {
+  action: null,
   anchorOrigin: {
     horizontal: 'center',
     vertical: 'top',

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -55,7 +55,7 @@ const { Loader } = vizComponents;
 const { getLocalizedCeiling, getTimezoneFromTimePrefs } = vizUtils.datetime;
 const { commonStats, getStatDefinition } = vizUtils.stat;
 
-export let PatientData = createReactClass({
+export const PatientDataClass = createReactClass({
   displayName: 'PatientData',
 
   propTypes: {
@@ -1392,6 +1392,7 @@ export let PatientData = createReactClass({
                     this.printWindowRef = window.open(nextProps.pdf.combined.url);
                     this.printWindowRef.focus();
                     this.printWindowRef.print();
+                    setToast(null);
                   }}
                 >
                   {this.props.t('Open it anyway')}
@@ -1660,7 +1661,12 @@ export let PatientData = createReactClass({
   },
 });
 
-PatientData.contextType = ToastContext;
+PatientDataClass.contextType = ToastContext;
+
+// We need to apply the contextType prop to use the Toast provider with create-react-class.
+// This produces an issue with the current enzyme mounting and breaks unit tests.
+// Solution is to wrap the create-react-class component with a small HOC that gets the i18n context.
+export const PatientData = translate()(props => <PatientDataClass {...props}/>);
 
 /**
  * Expose "Smart" Component that is connect-ed to Redux
@@ -1789,4 +1795,4 @@ let mergeProps = (stateProps, dispatchProps, ownProps) => {
   });
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(translate()(PatientData));
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(PatientData);

--- a/app/providers/ToastProvider.js
+++ b/app/providers/ToastProvider.js
@@ -27,3 +27,5 @@ export function ToastProvider({ children }) {
 
 /* Consumer */
 export const useToasts = () => React.useContext(ToastContext);
+
+export default ToastContext;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.39.0",
+  "version": "1.39.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.39.1-rc.1",
+  "version": "1.39.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -28,7 +28,7 @@ const t = i18next.t.bind(i18next);
 
 // We must remember to require the base module when mocking dependencies,
 // otherwise dependencies mocked will be bound to the wrong scope!
-import PD, { PatientData, getFetchers, mapStateToProps } from '../../../app/pages/patientdata/patientdata.js';
+import PD, { PatientData, PatientDataClass, getFetchers, mapStateToProps } from '../../../app/pages/patientdata/patientdata.js';
 import { MGDL_UNITS } from '../../../app/core/constants';
 
 describe('PatientData', function () {
@@ -113,7 +113,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -193,7 +193,7 @@ describe('PatientData', function () {
       var props = defaultProps;
 
       console.error = sinon.spy();
-      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      var elem = shallow(<PatientDataClass {...props} />);
       expect(elem).to.be.ok;
       expect(console.error.callCount).to.equal(0);
     });
@@ -203,7 +203,7 @@ describe('PatientData', function () {
       let loader;
 
       beforeEach(() => {
-        wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+        wrapper = shallow(<PatientDataClass {...defaultProps} />);
         loader = () => wrapper.find(Loader);
       });
 
@@ -496,8 +496,8 @@ describe('PatientData', function () {
       });
 
       beforeEach(() => {
-        wrapper = mount(<PatientData {...props} />);
-        instance = wrapper.instance().getWrappedInstance();
+        wrapper = mount(<PatientDataClass {...props} />);
+        instance = wrapper.instance();
 
         sinon.spy(instance, 'deriveChartTypeFromLatestData');
 
@@ -941,8 +941,8 @@ describe('PatientData', function () {
       });
 
       beforeEach(() => {
-        wrapper = mount(<PatientData {...props} />);
-        instance = wrapper.instance().getWrappedInstance();
+        wrapper = mount(<PatientDataClass {...props} />);
+        instance = wrapper.instance();
 
         // Set data loaded and chart endpoints to hide loader and allow data views to render
         wrapper.setProps(_.assign({}, props, {
@@ -1055,7 +1055,7 @@ describe('PatientData', function () {
 
   describe('getInitialState', () => {
     it('should return the default `chartPrefs` state for each data view', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       expect(wrapper.state().chartPrefs).to.eql({
         basics: {
           sections: {},
@@ -1117,7 +1117,7 @@ describe('PatientData', function () {
     };
 
     it('should clear patient data upon refresh', function() {
-      const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
       const callCount = props.dataWorkerRemoveDataRequest.callCount;
       elem.handleRefresh();
 
@@ -1125,15 +1125,15 @@ describe('PatientData', function () {
     });
 
     it('should clear generated pdfs upon refresh', function() {
-      const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
       const callCount = props.removeGeneratedPDFS.callCount;
       elem.handleRefresh();
       expect(props.removeGeneratedPDFS.callCount).to.equal(callCount + 1);
     });
 
     it('should reset patient data processing state', function() {
-      const setStateSpy = sinon.spy(PatientData.WrappedComponent.prototype, 'setState');
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const setStateSpy = sinon.spy(PatientDataClass.prototype, 'setState');
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       instance.DEFAULT_TITLE = 'defaultTitle';
@@ -1156,7 +1156,7 @@ describe('PatientData', function () {
         refreshChartType: 'currentChartType',
       });
 
-      PatientData.WrappedComponent.prototype.setState.restore();
+      PatientDataClass.prototype.setState.restore();
     });
   });
 
@@ -1167,7 +1167,7 @@ describe('PatientData', function () {
     })
 
     it('should call `updateBasicsSettings` from props, but only if `canUpdateSettings` arg is true', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       const settings = { siteChangeSource: 'prime' };
@@ -1183,7 +1183,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `updatedSiteChangeSource` to state if `siteChangeSource` differs from user settings', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       expect(wrapper.state('updatedSiteChangeSource')).to.be.undefined;
@@ -1196,7 +1196,7 @@ describe('PatientData', function () {
     });
 
     it('should not set the `updatedSiteChangeSource` to state if `siteChangeSource` is unchanged from user settings', () => {
-      const setStateSpy = sinon.spy(PatientData.WrappedComponent.prototype, 'setState');
+      const setStateSpy = sinon.spy(PatientDataClass.prototype, 'setState');
 
       const settingsProps = _.assign({}, defaultProps, {
         patient: _.assign({}, defaultProps.patient, {
@@ -1206,7 +1206,7 @@ describe('PatientData', function () {
         }),
       });
 
-      const wrapper = shallow(<PatientData.WrappedComponent {...settingsProps} />);
+      const wrapper = shallow(<PatientDataClass {...settingsProps} />);
       const instance = wrapper.instance();
 
       setStateSpy.resetHistory();
@@ -1219,11 +1219,11 @@ describe('PatientData', function () {
       let canUpdateSettings = false;
       instance.updateBasicsSettings(defaultProps.currentPatientInViewId, settings, canUpdateSettings);
       sinon.assert.notCalled(setStateSpy);
-      PatientData.WrappedComponent.prototype.setState.restore();
+      PatientDataClass.prototype.setState.restore();
     });
 
     it('should callback with `props.removeGeneratedPDFS` if `siteChangeSource` is changed from user settings', () => {
-      const setStateSpy = sinon.spy(PatientData.WrappedComponent.prototype, 'setState');
+      const setStateSpy = sinon.spy(PatientDataClass.prototype, 'setState');
 
       const settingsProps = _.assign({}, defaultProps, {
         patient: _.assign({}, defaultProps.patient, {
@@ -1233,7 +1233,7 @@ describe('PatientData', function () {
         }),
       });
 
-      const wrapper = shallow(<PatientData.WrappedComponent {...settingsProps} />);
+      const wrapper = shallow(<PatientDataClass {...settingsProps} />);
       const instance = wrapper.instance();
 
       setStateSpy.resetHistory();
@@ -1251,7 +1251,7 @@ describe('PatientData', function () {
         updatedSiteChangeSource: settings.siteChangeSource
       }, defaultProps.removeGeneratedPDFS);
 
-      PatientData.WrappedComponent.prototype.setState.restore();
+      PatientDataClass.prototype.setState.restore();
     });
 
     describe('pdf removal', () => {
@@ -1264,7 +1264,7 @@ describe('PatientData', function () {
           }),
         });
 
-        const wrapper = shallow(<PatientData.WrappedComponent {...settingsProps} />);
+        const wrapper = shallow(<PatientDataClass {...settingsProps} />);
         const instance = wrapper.instance();
 
         sinon.assert.callCount(defaultProps.removeGeneratedPDFS, 0);
@@ -1287,7 +1287,7 @@ describe('PatientData', function () {
           }),
         });
 
-        const wrapper = shallow(<PatientData.WrappedComponent {...settingsProps} />);
+        const wrapper = shallow(<PatientDataClass {...settingsProps} />);
         const instance = wrapper.instance();
 
         sinon.assert.callCount(defaultProps.removeGeneratedPDFS, 0);
@@ -1307,7 +1307,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
       instance.queryData = sinon.stub();
       instance.getStatsByChartType = sinon.stub().returns('stats stub');
@@ -1372,7 +1372,7 @@ describe('PatientData', function () {
     };
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       wrapper.setState({
@@ -1539,7 +1539,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       wrapper.setProps({
@@ -1577,7 +1577,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       wrapper.setProps({
@@ -1613,7 +1613,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PD.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -1648,7 +1648,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -1799,7 +1799,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -1848,7 +1848,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       wrapper.setProps({
@@ -1903,7 +1903,7 @@ describe('PatientData', function () {
     const defaultOpts = { query: 'my query', updateChartEndpoints: true };
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       wrapper.setState({
@@ -2043,14 +2043,14 @@ describe('PatientData', function () {
     };
 
     it('should clear generated pdfs upon refresh', function() {
-    const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+    const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
       const callCount = props.removeGeneratedPDFS.callCount;
       elem.componentWillUnmount();
       expect(props.removeGeneratedPDFS.callCount).to.equal(callCount + 1);
     });
 
     it('should call `props.dataWorkerRemoveDataSuccess`', function() {
-    const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+    const elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
       const callCount = props.dataWorkerRemoveDataSuccess.callCount;
       elem.componentWillUnmount();
       expect(props.dataWorkerRemoveDataSuccess.callCount).to.equal(callCount + 1);
@@ -2083,7 +2083,7 @@ describe('PatientData', function () {
           queryParams: { timezone: 'US/Pacific' },
         });
 
-        wrapper = shallow(<PatientData.WrappedComponent {...props} />);
+        wrapper = shallow(<PatientDataClass {...props} />);
         instance = wrapper.instance();
 
         setStateSpy = sinon.spy(instance, 'setState');
@@ -2518,10 +2518,11 @@ describe('PatientData', function () {
             metaData: { size: 1 },
           },
           pdf: { combined: { url: 'pdfUrl' } },
+          t,
         };
 
-        const wrapper = mount(<PatientData {...props} />);
-        const instance = wrapper.instance().getWrappedInstance();
+        const wrapper = mount(<PatientDataClass {...props} />);
+        const instance = wrapper.instance();
         const setStateSpy = sinon.spy(instance, 'setState');
 
         instance.setState({ printDialogProcessing: true, printDialogOpen: true });
@@ -2545,7 +2546,7 @@ describe('PatientData', function () {
     beforeEach(() => {
       defaultProps.dataWorkerQueryDataRequest.reset();
 
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       instance.getDaysByType = sinon.stub().returns({ next: 'next stub', prev: 'prev stub' });
@@ -2796,7 +2797,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -2817,7 +2818,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -2837,7 +2838,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -2875,7 +2876,7 @@ describe('PatientData', function () {
     let instance;
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
     });
 
@@ -2930,7 +2931,7 @@ describe('PatientData', function () {
     ];
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       wrapper.setState({ bgPrefs, timePrefs });
       instance = wrapper.instance();
       defaultProps.generatePDFRequest.resetHistory();
@@ -3142,7 +3143,7 @@ describe('PatientData', function () {
     let dateTimeLocation = '2019-11-23T12:00:00.000Z';
 
     beforeEach(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       wrapper.setState({ chartEndpoints, mostRecentDatetimeLocation });
       instance = wrapper.instance();
 
@@ -3444,7 +3445,7 @@ describe('PatientData', function () {
     });
 
     it('should dispatch the track metric action', () => {
-      PatientData.WrappedComponent.prototype.handleMessageCreation.call(new BaseObject(), 'message');
+      PatientDataClass.prototype.handleMessageCreation.call(new BaseObject(), 'message');
       sinon.assert.calledOnce(props.trackMetric);
       sinon.assert.calledWith(props.trackMetric, 'Created New Message');
     });
@@ -3470,7 +3471,7 @@ describe('PatientData', function () {
     });
 
     it('should dispatch the track metric action', () => {
-      PatientData.WrappedComponent.prototype.handleEditMessage.call(new BaseObject(), 'message');
+      PatientDataClass.prototype.handleEditMessage.call(new BaseObject(), 'message');
       sinon.assert.calledOnce(props.trackMetric);
       sinon.assert.calledWith(props.trackMetric, 'Edit To Message');
     });
@@ -3488,7 +3489,7 @@ describe('PatientData', function () {
       });
 
 
-      wrapper = shallow(<PatientData.WrappedComponent {...props} />);
+      wrapper = shallow(<PatientDataClass {...props} />);
       instance = wrapper.instance();
 
       setStateSpy = sinon.spy(instance, 'setState');
@@ -3674,7 +3675,7 @@ describe('PatientData', function () {
     let setTimeoutSpy;
 
     before(() => {
-      wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      wrapper = shallow(<PatientDataClass {...defaultProps} />);
       instance = wrapper.instance();
 
       setStateSpy = sinon.spy(instance, 'setState');
@@ -3734,7 +3735,7 @@ describe('PatientData', function () {
         pdf: {},
       };
 
-      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
 
       var callCount = props.trackMetric.callCount;
       elem.handleSwitchToBasics();
@@ -3743,7 +3744,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `chartType` state to `basics`', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
       wrapper.setState({chartType: 'daily'});
 
@@ -3752,7 +3753,7 @@ describe('PatientData', function () {
     });
 
     it('should call `getMostRecentDatumTimeByChartType`, `getChartEndpoints`, and then call `updateChart` with appropriate args', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
       wrapper.setState({timePrefs: { timezoneAware: true, timezoneName: 'utc' } })
 
@@ -3789,7 +3790,7 @@ describe('PatientData', function () {
         pdf: {},
       };
 
-      var elem = TestUtils.renderIntoDocument(<PatientData.WrappedComponent {...props}/>);
+      var elem = TestUtils.renderIntoDocument(<PatientDataClass {...props}/>);
 
       var callCount = props.trackMetric.callCount;
       elem.handleSwitchToDaily('2016-08-19T01:51:55.000Z', 'testing');
@@ -3798,7 +3799,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `chartType` state to `daily`', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({chartType: 'basics'});
@@ -3808,7 +3809,7 @@ describe('PatientData', function () {
     });
 
     it('should call `getMostRecentDatumTimeByChartType`, `getChartEndpoints`, and then call `updateChart` with appropriate args', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
       wrapper.setState({timePrefs: { timezoneAware: true, timezoneName: 'utc' } })
 
@@ -3825,7 +3826,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to noon for the previous day of the provided datetime', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({datetimeLocation: '2018-03-03T00:00:00.000Z'});
@@ -3837,7 +3838,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to noon for the previous day of the latest applicable datum time if provided datetime is beyond it', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       instance.updateChart = sinon.stub();
@@ -3873,7 +3874,7 @@ describe('PatientData', function () {
         pdf: {},
       };
 
-      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
 
       var callCount = props.trackMetric.callCount;
       elem.handleSwitchToTrends('2016-08-19T01:51:55.000Z');
@@ -3882,7 +3883,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `chartType` state to `trends`', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({chartType: 'basics'});
@@ -3892,7 +3893,7 @@ describe('PatientData', function () {
     });
 
     it('should call `getMostRecentDatumTimeByChartType`, `getChartEndpoints`, and then call `updateChart` with appropriate args', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
       wrapper.setState({timePrefs: { timezoneAware: true, timezoneName: 'utc' } })
 
@@ -3909,7 +3910,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to the start of the next day for the provided datetime if it\'s after the very start of the day', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({datetimeLocation: '2018-03-03T12:00:00.000Z'});
@@ -3919,7 +3920,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to the provided datetime as is if it\'s at the very start of the day', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({datetimeLocation: '2018-03-03T00:00:00.000Z'});
@@ -3929,7 +3930,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to the end of day for the latest applicable datum time if provided datetime is beyond it', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       instance.updateChart = sinon.stub();
@@ -3965,7 +3966,7 @@ describe('PatientData', function () {
         pdf: {},
       };
 
-      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
 
       var callCount = props.trackMetric.callCount;
       elem.handleSwitchToBgLog('2016-08-19T01:51:55.000Z');
@@ -3974,7 +3975,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `chartType` state to `bgLog`', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({chartType: 'basics'});
@@ -3984,7 +3985,7 @@ describe('PatientData', function () {
     });
 
     it('should call `getMostRecentDatumTimeByChartType`, `getChartEndpoints`, and then call `updateChart` with appropriate args', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
       wrapper.setState({timePrefs: { timezoneAware: true, timezoneName: 'utc' } })
 
@@ -4001,7 +4002,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to noon for the previous day of the provided datetime', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({datetimeLocation: '2018-03-03T00:00:00.000Z'});
@@ -4013,7 +4014,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `datetimeLocation` state to noon for the previous day of the latest applicable datum time if provided datetime is beyond it', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       instance.updateChart = sinon.stub();
@@ -4049,7 +4050,7 @@ describe('PatientData', function () {
         pdf: {},
       };
 
-      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientData.WrappedComponent);
+      var elem = TestUtils.findRenderedComponentWithType(TestUtils.renderIntoDocument(<PatientData {...props} />), PatientDataClass);
 
       var callCount = props.trackMetric.callCount;
       elem.handleSwitchToSettings();
@@ -4058,7 +4059,7 @@ describe('PatientData', function () {
     });
 
     it('should set the `chartType` state to `settings`', () => {
-      const wrapper = shallow(<PatientData.WrappedComponent {...defaultProps} />);
+      const wrapper = shallow(<PatientDataClass {...defaultProps} />);
       const instance = wrapper.instance();
 
       wrapper.setState({chartType: 'daily'});


### PR DESCRIPTION
Hotfix. See [WEB-1089] for details.

Mainly, this PR will catch errors caused by the popup blocker being invoked when a request to generate a PDF takes too long, and display a notification to the user.

It also adds an action prop to the Toast component that can be used to render a CTA within a notification, and fixes a couple of warnings on the proptypes for the print and chart date range modals, since some of the props are not immediately available on first rendering.

The fix on this one was relatively easy.  Getting the patientdata unit tests working ended up being a rather large trial, due to a 'perfect storm' of sorts in the way the ToastProvider context had to be applied to the 'create-react-class' component, which didn't play nicely with i18n's context within the enzyme mounts.  I ended up having to export the `create-react-class` component separately, and pass it to the translate HOC wrapped in a minimal functional component.

[WEB-1089]: https://tidepool.atlassian.net/browse/WEB-1089