### PR TITLE
[WEB-1094] accomodate default therapy settings

### DIFF
--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -200,7 +200,7 @@ export const warningThresholds = (pump, bgUnits = defaultUnits.bloodGlucose, val
     },
     bloodGlucoseTarget: {
       low: {
-        value: getBgInTargetUnits(getPumpGuardrail(pump, 'correctionRange.recommendedBounds.minimum', 101), MGDL_UNITS, bgUnits),
+        value: getBgInTargetUnits(getPumpGuardrail(pump, 'correctionRange.recommendedBounds.minimum', 100), MGDL_UNITS, bgUnits),
         message: lowWarning,
       },
       high: {
@@ -292,8 +292,16 @@ export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values)
       ? parseFloat((maxBasalRate * (isPediatric ? 3 : 3.5)).toFixed(2))
       : getPumpGuardrail(pump, 'basalRateMaximum.defaultValue', 0.05),
     bloodGlucoseTarget: {
-      low: getBgInTargetUnits(101, MGDL_UNITS, bgUnits),
+      low: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
       high: getBgInTargetUnits(isPediatric ? 115 : 105, MGDL_UNITS, bgUnits),
+    },
+    bloodGlucoseTargetPhysicalActivity: {
+      low: getBgInTargetUnits(150, MGDL_UNITS, bgUnits),
+      high: getBgInTargetUnits(170, MGDL_UNITS, bgUnits),
+    },
+    bloodGlucoseTargetPreprandial: {
+      low: getBgInTargetUnits(80, MGDL_UNITS, bgUnits),
+      high: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
     },
     glucoseSafetyLimit: getBgInTargetUnits(isPediatric ? 80 : 75, MGDL_UNITS, bgUnits),
   };

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -8,6 +8,7 @@ import max from 'lodash/max';
 import min from 'lodash/min';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
+import moment from 'moment';
 
 import i18next from '../../core/language';
 import { MGDL_UNITS } from '../../core/constants';
@@ -272,6 +273,18 @@ export const warningThresholds = (pump, bgUnits = defaultUnits.bloodGlucose, val
   };
 
   return thresholds;
+};
+
+export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
+  const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
+  const patientAge = moment().diff(moment(get(values, 'birthday'), dateFormat), 'years', true);
+  const isPaed = patientAge < 18;
+
+  return {
+    basalRateMaximum: isFinite(maxBasalRate)
+      ? parseFloat((maxBasalRate * (isPaed ? 3 : 3.5)).toFixed(2))
+      : getPumpGuardrail(pump, 'basalRateMaximum.defaultValue', 0.05),
+  };
 };
 
 export const typeOptions = [

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -335,7 +335,7 @@ export const shouldUpdateDefaultValue = (fieldPath, formikContext) => {
 
   return (
     !status.isSingleStepEdit
-    && !isFinite(get(initialValuesSource, fieldPath))&& !get(touched, fieldPath)
+    && !isFinite(get(initialValuesSource, fieldPath)) && !get(touched, fieldPath)
   );
 };
 

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -275,6 +275,13 @@ export const warningThresholds = (pump, bgUnits = defaultUnits.bloodGlucose, val
   return thresholds;
 };
 
+/**
+ * Determine dynamic default values for therapy settings as needed
+ * @param {Object} pump object as provided by the devices api
+ * @param {String} bgUnits one of mg/dL | mmol/L
+ * @param {Object} values form values provided by formik context
+ * @returns {Object} default values keyed by setting
+ */
 export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
   const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
   const patientAge = moment().diff(moment(get(values, 'birthday'), dateFormat), 'years', true);
@@ -285,10 +292,10 @@ export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values)
       ? parseFloat((maxBasalRate * (isPediatric ? 3 : 3.5)).toFixed(2))
       : getPumpGuardrail(pump, 'basalRateMaximum.defaultValue', 0.05),
     bloodGlucoseTarget: {
-      low: 101,
-      high: isPediatric ? 115 : 105,
+      low: getBgInTargetUnits(101, MGDL_UNITS, bgUnits),
+      high: getBgInTargetUnits(isPediatric ? 115 : 105, MGDL_UNITS, bgUnits),
     },
-    glucoseSafetyLimit: isPediatric ? 80 : 75,
+    glucoseSafetyLimit: getBgInTargetUnits(isPediatric ? 80 : 75, MGDL_UNITS, bgUnits),
   };
 };
 

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -5,6 +5,10 @@ import { FastField, Field, useFormikContext } from 'formik';
 import { Box, Flex, Text, BoxProps } from 'rebass/styled-components';
 import bows from 'bows';
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import isFinite from 'lodash/isFinite';
+import map from 'lodash/map';
+import max from 'lodash/max';
 
 import { fieldsAreValid, getFieldError, getThresholdWarning } from '../../core/forms';
 import { useInitialFocusedInput } from '../../core/hooks';
@@ -16,6 +20,11 @@ import TextInput from '../../components/elements/TextInput';
 import ScheduleForm from './ScheduleForm';
 
 import {
+  useParams,
+} from 'react-router-dom';
+
+import {
+  defaultValues,
   insulinModelOptions,
   pumpRanges,
   roundValueToIncrement,
@@ -303,18 +312,70 @@ export const GlucoseSettings = props => {
 GlucoseSettings.propTypes = fieldsetPropTypes;
 
 export const InsulinSettings = props => {
-  const { t, pump, ...themeProps } = props;
+  const { t, pump, isSingleStepEdit, ...themeProps } = props;
   const formikContext = useFormikContext();
+  const params = useParams();
 
   const {
+    initialValues,
     setFieldTouched,
     setFieldValue,
+    status,
+    touched,
     values,
   } = formikContext;
 
   const bgUnits = values.initialSettings.bloodGlucoseUnits;
   const ranges = pumpRanges(pump, bgUnits, values);
   const thresholds = warningThresholds(pump, bgUnits, values);
+
+  /** Scenarios when we want to update the basalRateMaximum default when max basal rate changes
+   * New prescription flow
+   * - hydrated upon reload of settings step and no value and not touched (if a finite value is hydrated from localStorage, we don't change it)
+   * - not just hydrated and not touched and not a single step edit from the review page (such as when navigating freshly to the page from the previous step. value can be set or unset)
+   *
+   * Edit prescription flow
+   * - no initial value and not touched (can't say never since a new prescription may be created up to the previous step, abandonned, and returned to later as an edit with a blank settings step)
+   *
+   * Single step edit from review page
+   * - Never, but perhaps the 'no (initial?) value and not touched' is also safe, though I can't see it actually occurring.
+   *   Would eliminate the need to detect if it's a single step edit - unless it conflicts with new prescription flow conditions....
+   *   Theoretically, the settings form should always be completed for a user to be at that stage, but who knows if a user will
+   *   just get to an incomplete review page by pasting the url / or refreshing a review page from a different prescription after
+   *   a new one has started and a different prescription is in localStorage.  Getting complicated.  Thinking never is the best route.
+   */
+
+  // Update default basalRateMaximum when max basal rate changes
+  const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
+  React.useEffect(() => {
+    const isPrescriptionEditFlow = !!get(params, 'id');
+    let updateDefaultBasalRateMaximum = false;
+
+    if (!isSingleStepEdit) {
+      if (isPrescriptionEditFlow) {
+        updateDefaultBasalRateMaximum = (
+          !isFinite(get(initialValues, 'initialSettings.basalRateMaximum.value'))
+          && !get(touched, 'initialSettings.basalRateMaximum.value')
+        );
+      } else { // new prescription flow
+        updateDefaultBasalRateMaximum = isEmpty(status.hydratedValues)
+          ? !get(touched, 'initialSettings.basalRateMaximum.value')
+          : (
+            !get(touched, 'initialSettings.basalRateMaximum.value')
+            && !isFinite(get(status.hydratedValues, 'initialSettings.basalRateMaximum.value'))
+          );
+      }
+    }
+
+    if (updateDefaultBasalRateMaximum) {
+      const defaults = defaultValues(pump, bgUnits, values);
+      console.log('defaults.basalRateMaximum', defaults.basalRateMaximum);
+      setFieldValue(
+        'initialSettings.basalRateMaximum.value',
+        roundValueToIncrement(defaults.basalRateMaximum, ranges.basalRateMaximum.increment)
+      );
+    }
+  }, [maxBasalRate]);
 
   return (
     <Box {...fieldsetStyles} {...wideFieldsetStyles} {...borderedFieldsetStyles} {...themeProps}>
@@ -532,10 +593,10 @@ export const TherapySettings = translate()(props => {
   );
 });
 
-const therapySettingsFormStep = (schema, pump, values) => ({
+const therapySettingsFormStep = (schema, pump, values, isSingleStepEdit) => ({
   label: t('Enter Therapy Settings'),
   disableComplete: !fieldsAreValid(stepValidationFields[2][0], schema, values),
-  panelContent: <TherapySettings pump={pump} />
+  panelContent: <TherapySettings pump={pump} isSingleStepEdit={isSingleStepEdit} />
 });
 
 export default therapySettingsFormStep;

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -552,6 +552,26 @@ export const TherapySettings = translate()(props => {
       increment: ranges.bloodGlucoseTarget.increment,
     },
     {
+      path: 'initialSettings.bloodGlucoseTargetPhysicalActivity.low',
+      defaultValue: defaults.bloodGlucoseTargetPhysicalActivity.low,
+      increment: ranges.bloodGlucoseTarget.increment,
+    },
+    {
+      path: 'initialSettings.bloodGlucoseTargetPhysicalActivity.high',
+      defaultValue: defaults.bloodGlucoseTargetPhysicalActivity.high,
+      increment: ranges.bloodGlucoseTarget.increment,
+    },
+    {
+      path: 'initialSettings.bloodGlucoseTargetPreprandial.low',
+      defaultValue: defaults.bloodGlucoseTargetPreprandial.low,
+      increment: ranges.bloodGlucoseTarget.increment,
+    },
+    {
+      path: 'initialSettings.bloodGlucoseTargetPreprandial.high',
+      defaultValue: defaults.bloodGlucoseTargetPreprandial.high,
+      increment: ranges.bloodGlucoseTarget.increment,
+    },
+    {
       path: 'initialSettings.basalRateMaximum.value',
       defaultValue: defaults.basalRateMaximum,
       increment: ranges.basalRateMaximum.increment,

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import moment from 'moment';
 import * as prescriptionFormConstants from '../../../../app/pages/prescription/prescriptionFormConstants';
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../../app/core/constants';
 
@@ -563,6 +564,256 @@ describe('prescriptionFormConstants', function() {
             },
           }).glucoseSafetyLimit.max).to.equal(85);
         });
+      });
+    });
+  });
+
+  describe('defaultValues', () => {
+    const pump = {
+      guardRails: {
+        basalRateMaximum: {
+          defaultValue: {
+            units: 0,
+            nanos: 100000000,
+          },
+        },
+      },
+    };
+
+    context('pediatric patient', () => {
+      const birthday = moment().subtract(18, 'years').add(1, 'day').toISOString();
+
+      context('max basal rate is not set', () => {
+        it('should return a default value from pump guardrails for basalRateMaximum', () => {
+          const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+            birthday,
+          });
+
+          expect(result.basalRateMaximum).to.equal(0.1);
+        });
+      });
+
+      context('max basal rate is set', () => {
+        it('should return a default value of 3x the max basal rate for basalRateMaximum', () => {
+          const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+            birthday,
+            initialSettings: { basalRateSchedule: [
+              { rate: 0.05 },
+              { rate: 0.15 },
+              { rate: 0.1 },
+            ] },
+          });
+
+          expect(result.basalRateMaximum).to.equal(0.45);
+        });
+      });
+
+      it('should return a default value for bloodGlucoseTarget in mg/dL units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+          birthday,
+        });
+
+        expect(result.bloodGlucoseTarget.low).to.equal(101);
+        expect(result.bloodGlucoseTarget.high).to.equal(115);
+      });
+
+      it('should return a default value for bloodGlucoseTarget in mmol/L units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MMOLL_UNITS, {
+          birthday,
+        });
+
+        expect(result.bloodGlucoseTarget.low).to.equal(5.6);
+        expect(result.bloodGlucoseTarget.high).to.equal(6.4);
+      });
+
+      it('should return a default value for glucoseSafetyLimit in mg/dL units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+          birthday,
+        });
+
+        expect(result.glucoseSafetyLimit).to.equal(80);
+      });
+
+      it('should return a default value for glucoseSafetyLimit in mmol/L units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MMOLL_UNITS, {
+          birthday,
+        });
+
+        expect(result.glucoseSafetyLimit).to.equal(4.4);
+      });
+    });
+
+    context('adult patient', () => {
+      const birthday = moment().subtract(18, 'years').toISOString();
+
+      context('max basal rate is not set', () => {
+        it('should return a default value from pump guardrails for basalRateMaximum', () => {
+          const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+            birthday,
+          });
+
+          expect(result.basalRateMaximum).to.equal(0.1);
+        });
+      });
+
+      context('max basal rate is set', () => {
+        it('should return a default value of 3.5x the max basal rate for basalRateMaximum', () => {
+          const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+            birthday,
+            initialSettings: { basalRateSchedule: [
+              { rate: 0.05 },
+              { rate: 0.15 },
+              { rate: 0.1 },
+            ] },
+          });
+
+          expect(result.basalRateMaximum).to.equal(0.53);
+        });
+      });
+
+      it('should return a default value for bloodGlucoseTarget in mg/dL units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+          birthday,
+        });
+
+        expect(result.bloodGlucoseTarget.low).to.equal(101);
+        expect(result.bloodGlucoseTarget.high).to.equal(105);
+      });
+
+      it('should return a default value for bloodGlucoseTarget in mmol/L units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MMOLL_UNITS, {
+          birthday,
+        });
+
+        expect(result.bloodGlucoseTarget.low).to.equal(5.6);
+        expect(result.bloodGlucoseTarget.high).to.equal(5.8);
+      });
+
+      it('should return a default value for glucoseSafetyLimit in mg/dL units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS, {
+          birthday,
+        });
+
+        expect(result.glucoseSafetyLimit).to.equal(75);
+      });
+
+      it('should return a default value for glucoseSafetyLimit in mmol/L units', () => {
+        const result = prescriptionFormConstants.defaultValues(pump, MMOLL_UNITS, {
+          birthday,
+        });
+
+        expect(result.glucoseSafetyLimit).to.equal(4.2);
+      });
+    });
+  });
+
+  describe('shouldUpdateDefaultValue', () => {
+    const initialValue = {
+      initialValues: { field: { path: 30 } },
+    };
+
+    const noInitialValue = {
+      initialValues: { field: { path: undefined } },
+    };
+
+    const touched = {
+      touched: { field: { path: true } },
+    };
+
+    const notTouched = {
+      touched: { field: { path: false } },
+    };
+
+    const hydratedValue = {
+      hydratedValues: { field: { path: 20 } },
+    };
+
+    const noHydratedValue = {
+      hydratedValues: { field: { path: undefined } },
+    };
+
+    const singleStepEdit = {
+      isSingleStepEdit: true,
+    };
+
+    const prescriptionEditFlow = {
+      isPrescriptionEditFlow: true,
+    };
+
+    context('new prescription flow', () => {
+      it('should return `true` if field in hydrated localStorage values is non-finite and field is untouched', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          status: { ...noHydratedValue },
+          ...notTouched,
+        })).to.equal(true);
+      });
+
+      it('should return `false` if field in hydrated localStorage values is finite and field is untouched but is in single step edit mode', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          status: { ...noHydratedValue, ...singleStepEdit },
+          ...notTouched,
+        })).to.equal(false);
+      });
+
+      it('should return `false` if field in hydrated localStorage values is finite and field is untouched', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          status: { ...hydratedValue },
+          ...notTouched,
+        })).to.equal(false);
+      });
+
+      it('should return `false` if field in hydrated localStorage values is non-finite and field is touched', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          status: { ...noHydratedValue },
+          ...touched,
+        })).to.equal(false);
+      });
+    });
+
+    context('edit prescription flow', () => {
+      const prescriptionEditFlowContext = {
+        status: {
+          ...prescriptionEditFlow,
+        },
+      };
+
+      const prescriptionEditFlowSingleStepContext = {
+        status: {
+          ...prescriptionEditFlow,
+          ...singleStepEdit,
+        },
+      };
+
+      it('should return `true` if field in initial values is non-finite and field is untouched', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          ...prescriptionEditFlowContext,
+          ...noInitialValue,
+          ...notTouched,
+        })).to.equal(true);
+      });
+
+      it('should return `false` if field in initial values is non-finite and field is untouched but is in single step edit mode', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          ...prescriptionEditFlowSingleStepContext,
+          ...noInitialValue,
+          ...notTouched,
+        })).to.equal(false);
+      });
+
+      it('should return `false` if field in initial values is finite and field is untouched', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          ...prescriptionEditFlowContext,
+          ...initialValue,
+          ...notTouched,
+        })).to.equal(false);
+      });
+
+      it('should return `false` if field in initial values is non-finite and field is touched', () => {
+        expect(prescriptionFormConstants.shouldUpdateDefaultValue('field.path', {
+          ...prescriptionEditFlowContext,
+          ...noInitialValue,
+          ...touched,
+        })).to.equal(false);
       });
     });
   });

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -251,7 +251,7 @@ describe('prescriptionFormConstants', function() {
           low: undefined,
         },
         bloodGlucoseTarget: {
-          low: { value: 101, message: lowWarning },
+          low: { value: 100, message: lowWarning },
           high: { value: 115, message: highWarning },
         },
         bloodGlucoseTargetPhysicalActivity: {
@@ -613,7 +613,7 @@ describe('prescriptionFormConstants', function() {
           birthday,
         });
 
-        expect(result.bloodGlucoseTarget.low).to.equal(101);
+        expect(result.bloodGlucoseTarget.low).to.equal(100);
         expect(result.bloodGlucoseTarget.high).to.equal(115);
       });
 
@@ -676,7 +676,7 @@ describe('prescriptionFormConstants', function() {
           birthday,
         });
 
-        expect(result.bloodGlucoseTarget.low).to.equal(101);
+        expect(result.bloodGlucoseTarget.low).to.equal(100);
         expect(result.bloodGlucoseTarget.high).to.equal(105);
       });
 
@@ -704,6 +704,34 @@ describe('prescriptionFormConstants', function() {
 
         expect(result.glucoseSafetyLimit).to.equal(4.2);
       });
+    });
+
+    it('should return a default value for bloodGlucoseTargetPhysicalActivity in mg/dL units', () => {
+      const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS);
+
+      expect(result.bloodGlucoseTargetPhysicalActivity.low).to.equal(150);
+      expect(result.bloodGlucoseTargetPhysicalActivity.high).to.equal(170);
+    });
+
+    it('should return a default value for bloodGlucoseTargetPhysicalActivity in mmol/L units', () => {
+      const result = prescriptionFormConstants.defaultValues(pump, MMOLL_UNITS);
+
+      expect(result.bloodGlucoseTargetPhysicalActivity.low).to.equal(8.3);
+      expect(result.bloodGlucoseTargetPhysicalActivity.high).to.equal(9.4);
+    });
+
+    it('should return a default value for bloodGlucoseTargetPreprandial in mg/dL units', () => {
+      const result = prescriptionFormConstants.defaultValues(pump, MGDL_UNITS);
+
+      expect(result.bloodGlucoseTargetPreprandial.low).to.equal(80);
+      expect(result.bloodGlucoseTargetPreprandial.high).to.equal(100);
+    });
+
+    it('should return a default value for bloodGlucoseTargetPreprandial in mmol/L units', () => {
+      const result = prescriptionFormConstants.defaultValues(pump, MMOLL_UNITS);
+
+      expect(result.bloodGlucoseTargetPreprandial.low).to.equal(4.4);
+      expect(result.bloodGlucoseTargetPreprandial.high).to.equal(5.6);
     });
   });
 


### PR DESCRIPTION
See [WEB-1094]

Also includes a small update to the blood glucose target low warning to be consistent with an updates to Loop.  (now <100, was <101)

[WEB-1094]: https://tidepool.atlassian.net/browse/WEB-1094