### PR TITLE
[WEB-1129] Basics date selection fix

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -332,8 +332,9 @@ export const PatientDataClass = createReactClass({
             this.setState({ datesDialogFetchingData: true });
 
             this.fetchEarlierData({
+              returnData: false,
               showLoading: true,
-              returnData: false
+              startDate,
             });
           } else {
             this.closeDatesDialog();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.42.0",
+  "version": "1.43.0-web-1129-basics-date-selection-fix.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
See [WEB-1129] for details.

Basically the wrong date was being used for requests for earlier data due to a missing `startDate` option being set when requesting a range for the basics view that required earlier data to be fetched.

[WEB-1129]: https://tidepool.atlassian.net/browse/WEB-1129