### PR TITLE
[WEB-1134] Add AACE calculator step to prescription form

### DIFF
--- a/app/components/elements/RadioGroup.js
+++ b/app/components/elements/RadioGroup.js
@@ -118,8 +118,8 @@ export const RadioGroup = (props) => {
             id={`${name}-${i}`}
             key={option.value}
             name={name}
-            value={option.value}
-            checked={value === option.value}
+            value={String(option.value)}
+            checked={String(value) === String(option.value)}
             onChange={onChange}
             label={option.label}
             error={error}
@@ -145,7 +145,10 @@ RadioGroup.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   disabled: PropTypes.bool,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   onChange: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['horizontal', 'vertical', 'verticalBordered']),
   options: PropTypes.arrayOf(

--- a/app/components/elements/Select.js
+++ b/app/components/elements/Select.js
@@ -41,6 +41,7 @@ const StyledSelect = styled(Flex)`
 export const Select = props => {
   const {
     disabled,
+    innerRef,
     name,
     label,
     value,
@@ -74,6 +75,7 @@ export const Select = props => {
           disabled={disabled}
           value={value}
           onChange={onChange}
+          ref={innerRef}
         >
           {map(options, option => (
             <option
@@ -98,6 +100,10 @@ export const Select = props => {
 
 Select.propTypes = {
   ...SelectProps,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   disabled: PropTypes.bool,

--- a/app/components/elements/Stepper.js
+++ b/app/components/elements/Stepper.js
@@ -300,7 +300,18 @@ export const Stepper = props => {
   };
 
   const handleSkip = () => {
+    if (stepHasSubSteps(activeStep)) {
+      if (isFunction(steps[activeStep].subSteps[activeSubStep].onSkip)) {
+        steps[activeStep].subSteps[activeSubStep].onSkip();
+      }
+    }
+
+    if (isFunction(steps[activeStep].onSkip)) {
+      steps[activeStep].onSkip();
+    }
+
     if (!disableDefaultStepHandlers) advanceActiveStep();
+
     setSkipped((prevSkipped) => {
       const newSkipped = new Set(prevSkipped.values());
       newSkipped.add(activeStep);
@@ -445,6 +456,7 @@ const StepPropTypes = {
   label: PropTypes.string,
   onBack: PropTypes.func,
   onComplete: PropTypes.func,
+  onSkip: PropTypes.func,
   optional: PropTypes.bool,
   panelContent: PropTypes.node,
 };

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -73,3 +73,5 @@ export const MGDL_PER_MMOLL = 18.01559;
 export const MS_IN_DAY = 864e5;
 export const MS_IN_HOUR = 864e5 / 24;
 export const MS_IN_MIN = MS_IN_HOUR / 60;
+
+export const LBS_PER_KG = 2.2046226218;

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -404,7 +404,7 @@ export const PrescriptionForm = props => {
 
   const accountFormStepsProps = accountFormSteps(schema, initialFocusedInput, values);
   const profileFormStepsProps = profileFormSteps(schema, devices, values);
-  const settingsCalculatorFormStepsProps = settingsCalculatorFormSteps(schema, values, handlers);
+  const settingsCalculatorFormStepsProps = settingsCalculatorFormSteps(schema, handlers, values);
   const therapySettingsFormStepProps = therapySettingsFormStep(schema, pump, values);
   const reviewFormStepProps = reviewFormStep(schema, pump, handlers, values);
 

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -105,14 +105,13 @@ export const prescriptionForm = (bgUnits = defaultUnits.bloodGlucose) => ({
         bloodGlucoseTargetPhysicalActivity: get(props, 'prescription.latestRevision.attributes.initialSettings.bloodGlucoseTargetPhysicalActivity'),
         bloodGlucoseTargetPreprandial: get(props, 'prescription.latestRevision.attributes.initialSettings.bloodGlucoseTargetPreprandial'),
         basalRateSchedule: get(props, 'prescription.latestRevision.attributes.initialSettings.basalRateSchedule', [{
-          rate: getPumpGuardrail(pump, 'basalRates.defaultValue', 0.05), // TODO: calculator defaults here???
           start: 0,
         }]),
         carbohydrateRatioSchedule: get(props, 'prescription.latestRevision.attributes.initialSettings.carbohydrateRatioSchedule', [{
-          start: 0, // TODO: calculator defaults here???
+          start: 0,
         }]),
         insulinSensitivitySchedule: get(props, 'prescription.latestRevision.attributes.initialSettings.insulinSensitivitySchedule', [{
-          start: 0, // TODO: calculator defaults here???
+          start: 0,
         }]),
       },
       training: get(props, 'prescription.latestRevision.attributes.training'),

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -105,14 +105,14 @@ export const prescriptionForm = (bgUnits = defaultUnits.bloodGlucose) => ({
         bloodGlucoseTargetPhysicalActivity: get(props, 'prescription.latestRevision.attributes.initialSettings.bloodGlucoseTargetPhysicalActivity'),
         bloodGlucoseTargetPreprandial: get(props, 'prescription.latestRevision.attributes.initialSettings.bloodGlucoseTargetPreprandial'),
         basalRateSchedule: get(props, 'prescription.latestRevision.attributes.initialSettings.basalRateSchedule', [{
-          rate: getPumpGuardrail(pump, 'basalRates.defaultValue', 0.05),
+          rate: getPumpGuardrail(pump, 'basalRates.defaultValue', 0.05), // TODO: calculator defaults here???
           start: 0,
         }]),
         carbohydrateRatioSchedule: get(props, 'prescription.latestRevision.attributes.initialSettings.carbohydrateRatioSchedule', [{
-          start: 0,
+          start: 0, // TODO: calculator defaults here???
         }]),
         insulinSensitivitySchedule: get(props, 'prescription.latestRevision.attributes.initialSettings.insulinSensitivitySchedule', [{
-          start: 0,
+          start: 0, // TODO: calculator defaults here???
         }]),
       },
       training: get(props, 'prescription.latestRevision.attributes.training'),
@@ -320,6 +320,17 @@ export const PrescriptionForm = props => {
       setInitialFocusedInput(initialFocusedInput);
     },
 
+    clearCalculator: () => {
+      setFieldValue('calculator.method', undefined, false)
+      setFieldValue('calculator.totalDailyDose', undefined, false)
+      setFieldValue('calculator.totalDailyDoseScaleFactor', undefined, false)
+      setFieldValue('calculator.weight', undefined, false)
+      setFieldValue('calculator.weightUnits', undefined, false)
+      setFieldValue('calculator.recommendedBasalRate', undefined, false)
+      setFieldValue('calculator.recommendedInsulinSensitivity', undefined, false)
+      setFieldValue('calculator.recommendedCarbohydrateRatio', undefined, false)
+    },
+
     generateTherapySettingsOrderText,
 
     handleCopyTherapySettingsClicked: () => {
@@ -394,7 +405,7 @@ export const PrescriptionForm = props => {
 
   const accountFormStepsProps = accountFormSteps(schema, initialFocusedInput, values);
   const profileFormStepsProps = profileFormSteps(schema, devices, values);
-  const settingsCalculatorFormStepsProps = settingsCalculatorFormSteps(schema, values);
+  const settingsCalculatorFormStepsProps = settingsCalculatorFormSteps(schema, values, handlers);
   const therapySettingsFormStepProps = therapySettingsFormStep(schema, pump, values);
   const reviewFormStepProps = reviewFormStep(schema, pump, handlers, values);
 

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -159,6 +159,17 @@ export const generateTherapySettingsOrderText = (patientRows = [], therapySettin
   return textString;
 };
 
+export const clearCalculator = setFieldValue => {
+  setFieldValue('calculator.method', undefined, false)
+  setFieldValue('calculator.totalDailyDose', undefined, false)
+  setFieldValue('calculator.totalDailyDoseScaleFactor', undefined, false)
+  setFieldValue('calculator.weight', undefined, false)
+  setFieldValue('calculator.weightUnits', undefined, false)
+  setFieldValue('calculator.recommendedBasalRate', undefined, false)
+  setFieldValue('calculator.recommendedInsulinSensitivity', undefined, false)
+  setFieldValue('calculator.recommendedCarbohydrateRatio', undefined, false)
+};
+
 export const PrescriptionForm = props => {
   const {
     t,
@@ -319,16 +330,7 @@ export const PrescriptionForm = props => {
       setInitialFocusedInput(initialFocusedInput);
     },
 
-    clearCalculator: () => {
-      setFieldValue('calculator.method', undefined, false)
-      setFieldValue('calculator.totalDailyDose', undefined, false)
-      setFieldValue('calculator.totalDailyDoseScaleFactor', undefined, false)
-      setFieldValue('calculator.weight', undefined, false)
-      setFieldValue('calculator.weightUnits', undefined, false)
-      setFieldValue('calculator.recommendedBasalRate', undefined, false)
-      setFieldValue('calculator.recommendedInsulinSensitivity', undefined, false)
-      setFieldValue('calculator.recommendedCarbohydrateRatio', undefined, false)
-    },
+    clearCalculator: clearCalculator.bind(null, setFieldValue),
 
     generateTherapySettingsOrderText,
 

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -28,6 +28,7 @@ import { fieldsAreValid } from '../../core/forms';
 import prescriptionSchema from './prescriptionSchema';
 import accountFormSteps from './accountFormSteps';
 import profileFormSteps from './profileFormSteps';
+import settingsCalculatorFormSteps from './settingsCalculatorFormSteps';
 import therapySettingsFormStep from './therapySettingsFormStep';
 import reviewFormStep from './reviewFormStep';
 import withPrescriptions from './withPrescriptions';
@@ -77,6 +78,13 @@ export const prescriptionForm = (bgUnits = defaultUnits.bloodGlucose) => ({
       },
       mrn: get(props, 'prescription.latestRevision.attributes.mrn'),
       sex: get(props, 'prescription.latestRevision.attributes.sex'),
+      calculator: {
+        method: get(props, 'prescription.latestRevision.attributes.calculator.method'),
+        weight: get(props, 'prescription.latestRevision.attributes.calculator.weight'),
+        weightUnits: get(props, 'prescription.latestRevision.attributes.calculator.weightUnits', defaultUnits.weight),
+        totalDailyDose: get(props, 'prescription.latestRevision.attributes.calculator.totalDailyDose'),
+        totalDailyDoseScaleFactor: get(props, 'prescription.latestRevision.attributes.calculator.totalDailyDoseScaleFactor', 1),
+      },
       initialSettings: {
         bloodGlucoseUnits: get(props, 'prescription.latestRevision.attributes.initialSettings.bloodGlucoseUnits', defaultUnits.bloodGlucose),
         pumpId: selectedPumpId,
@@ -386,6 +394,7 @@ export const PrescriptionForm = props => {
 
   const accountFormStepsProps = accountFormSteps(schema, initialFocusedInput, values);
   const profileFormStepsProps = profileFormSteps(schema, devices, values);
+  const settingsCalculatorFormStepsProps = settingsCalculatorFormSteps(schema, values);
   const therapySettingsFormStepProps = therapySettingsFormStep(schema, pump, values);
   const reviewFormStepProps = reviewFormStep(schema, pump, handlers, values);
 
@@ -432,6 +441,12 @@ export const PrescriptionForm = props => {
         onComplete: isSingleStepEdit ? noop : handlers.stepSubmit,
         asyncState: isSingleStepEdit ? null : stepAsyncState,
         subSteps: subStepProps(profileFormStepsProps.subSteps),
+      },
+      {
+        ...settingsCalculatorFormStepsProps,
+        onComplete: handlers.stepSubmit,
+        asyncState: stepAsyncState,
+        subSteps: subStepProps(settingsCalculatorFormStepsProps.subSteps),
       },
       {
         ...stepProps(therapySettingsFormStepProps),

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -284,13 +284,13 @@ export const warningThresholds = (pump, bgUnits = defaultUnits.bloodGlucose, val
  * @param {Object} values form values provided by formik context
  * @returns {Object} default values keyed by setting
  */
-export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
+export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values = {}) => {
   const {
     calculator: {
       recommendedBasalRate,
       recommendedInsulinSensitivity,
       recommendedCarbohydrateRatio,
-    },
+    } = {},
   } = values;
 
   const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -72,7 +72,6 @@ export const defaultUnits = {
   basalRate: 'Units/hour',
   bloodGlucose: MGDL_UNITS,
   bolusAmount: 'Units',
-  glucoseSafetyLimit: MGDL_UNITS,
   insulinCarbRatio: 'g/U',
   weight: 'kg',
 };

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -332,8 +332,10 @@ export const calculateRecommendedTherapySettings = values => {
       weightUnits,
       totalDailyDose,
       totalDailyDoseScaleFactor,
-    },
-    initialSettings: { bloodGlucoseUnits: bgUnits = defaultUnits.bloodGlucose }
+    } = {},
+    initialSettings: {
+      bloodGlucoseUnits: bgUnits = defaultUnits.bloodGlucose
+    } = {},
   } = values;
 
   const baseTotalDailyDoseInputs = [];

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -285,11 +285,20 @@ export const warningThresholds = (pump, bgUnits = defaultUnits.bloodGlucose, val
  * @returns {Object} default values keyed by setting
  */
 export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
+  const {
+    calculator: {
+      recommendedBasalRate,
+      recommendedInsulinSensitivity,
+      recommendedCarbohydrateRatio,
+    },
+  } = values;
+
   const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
   const patientAge = moment().diff(moment(get(values, 'birthday'), dateFormat), 'years', true);
   const isPediatric = patientAge < 18;
 
   return {
+    basalRate: recommendedBasalRate || 0.05,
     basalRateMaximum: isFinite(maxBasalRate)
       ? parseFloat((maxBasalRate * (isPediatric ? 3 : 3.5)).toFixed(2))
       : getPumpGuardrail(pump, 'basalRateMaximum.defaultValue', 0.05),
@@ -305,6 +314,8 @@ export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values)
       low: getBgInTargetUnits(80, MGDL_UNITS, bgUnits),
       high: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
     },
+    carbohydrateRatio: recommendedCarbohydrateRatio,
+    insulinSensitivity: recommendedInsulinSensitivity,
     glucoseSafetyLimit: getBgInTargetUnits(isPediatric ? 80 : 75, MGDL_UNITS, bgUnits),
   };
 };

--- a/app/pages/prescription/profileFormSteps.js
+++ b/app/pages/prescription/profileFormSteps.js
@@ -31,7 +31,7 @@ import {
 } from './prescriptionFormConstants';
 
 const t = i18next.t.bind(i18next);
-const log = bows('PrescriptionAccount');
+const log = bows('PrescriptionProfile');
 
 export const PatientPhone = translate()(props => {
   const { t } = props;

--- a/app/pages/prescription/reviewFormStep.js
+++ b/app/pages/prescription/reviewFormStep.js
@@ -300,7 +300,7 @@ export const PatientInfo = props => {
   const initialFocusedInputRef = useInitialFocusedInput();
 
   const nameStep = [0, 1];
-  const currentStep = [3, 0];
+  const currentStep = [4, 0];
 
   const { values } = useFormikContext();
 
@@ -358,8 +358,8 @@ export const TherapySettings = props => {
     ...themeProps
   } = props;
 
-  const therapySettingsStep = [2, 0];
-  const currentStep = [3, 0];
+  const therapySettingsStep = [3, 0];
+  const currentStep = [4, 0];
 
   const { values } = useFormikContext();
 

--- a/app/pages/prescription/settingsCalculatorFormSteps.js
+++ b/app/pages/prescription/settingsCalculatorFormSteps.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import { translate } from 'react-i18next';
+import { FastField, useFormikContext } from 'formik';
+import { Box, Flex } from 'rebass/styled-components';
+import bows from 'bows';
+import get from 'lodash/get';
+import includes from 'lodash/includes';
+import isEmpty from 'lodash/isEmpty';
+import map from 'lodash/map';
+
+import { fieldsAreValid, getFieldError } from '../../core/forms';
+import { useInitialFocusedInput } from '../../core/hooks';
+import i18next from '../../core/language';
+import Button from '../../components/elements/Button';
+import RadioGroup from '../../components/elements/RadioGroup';
+import Select from '../../components/elements/Select';
+import TextInput from '../../components/elements/TextInput';
+import { Paragraph1, Headline } from '../../components/elements/FontStyles';
+
+import {
+  condensedInputStyles,
+  fieldsetStyles,
+  inputStyles,
+} from './prescriptionFormStyles';
+
+import {
+  calculateRecommendedTherapySettings,
+  calculatorMethodOptions,
+  roundValueToIncrement,
+  stepValidationFields,
+  totalDailyDoseScaleFactorOptions,
+  weightUnitOptions,
+} from './prescriptionFormConstants';
+
+const t = i18next.t.bind(i18next);
+const log = bows('PrescriptionAccount');
+
+export const CalculatorMethod = translate()(props => {
+  const { t } = props;
+  const formikContext = useFormikContext();
+  const initialFocusedInputRef = useInitialFocusedInput();
+
+  const options = !isEmpty(get(formikContext.values, 'calculator.method', ''))
+    ? calculatorMethodOptions
+    : [ { label: t('Select method'), value: '' }, ...calculatorMethodOptions ];
+
+  return (
+    <Box {...fieldsetStyles}>
+      <Headline mb={4}>{t('Optional Therapy Settings Calculator')}</Headline>
+      <Box mb={4}>
+        <Paragraph1>
+          {t('Allows for guided entry of total daily dose, weight, or both to generate basal rates, carbohydrate to insulin ratio, and insulin sensitivity factor.')}
+        </Paragraph1>
+        <Paragraph1>
+          {t('All calculations must be confirmed by the provider before use. The suggested results are not a substitute for clinical judgment.')}
+        </Paragraph1>
+      </Box>
+      <FastField
+        as={Select}
+        themeProps={inputStyles}
+        id="calculator.method"
+        name="calculator.method"
+        options={options}
+        error={getFieldError('calculator.method', formikContext)}
+        innerRef={initialFocusedInputRef}
+      />
+    </Box>
+  );
+});
+
+export const CalculatorInputs = translate()(props => {
+  const { t, schema } = props;
+  const formikContext = useFormikContext();
+  const [results, setResults] = React.useState();
+
+  const {
+    setFieldTouched,
+    setFieldValue,
+    values,
+  } = formikContext;
+
+  React.useEffect(() => {
+    if (results) {
+      setFieldValue('calculator.recommendedBasalRate', results.recommendedBasalRate, true);
+      setFieldValue('calculator.recommendedInsulinSensitivity', results.recommendedInsulinSensitivity, true);
+      setFieldValue('calculator.recommendedCarbohydrateRatio', results.recommendedCarbohydrateRatio, true);
+    }
+  }, [results])
+
+  const initialFocusedInputRef = useInitialFocusedInput();
+  const method = get(values, 'calculator.method');
+  const showTotalDailyDose = includes(['totalDailyDose', 'totalDailyDoseAndWeight'], method);
+  const showWeight = includes(['weight', 'totalDailyDoseAndWeight'], method);
+  const bgUnits = values.initialSettings.bloodGlucoseUnits;
+
+  return (
+    <Box {...fieldsetStyles}>
+      <Headline mb={4}>{t('Optional Therapy Settings Calculator')}</Headline>
+
+      <Box mb={4}>
+        <Paragraph1>
+          {t('All calculations must be confirmed by the provider before use. The suggested results are not a substitute for clinical judgment.')}
+        </Paragraph1>
+      </Box>
+
+      {showTotalDailyDose && (
+        <Box mb={3}>
+          <FastField
+            as={TextInput}
+            label={t('Total Daily Dose')}
+            placeholder={t('Enter Patient\'s Total Daily Dose')}
+            type="number"
+            id="calculator.totalDailyDose"
+            name="calculator.totalDailyDose"
+            onBlur={e => {
+              setFieldTouched('calculator.totalDailyDose');
+              setFieldValue('calculator.totalDailyDose', roundValueToIncrement(e.target.value, 0.1));
+            }}
+            step={1}
+            min={0}
+            error={getFieldError('calculator.totalDailyDose', formikContext)}
+            innerRef={initialFocusedInputRef}
+            {...condensedInputStyles}
+          />
+          <FastField
+            as={RadioGroup}
+            variant="vertical"
+            id="calculator.totalDailyDoseScaleFactor"
+            name="calculator.totalDailyDoseScaleFactor"
+            onChange={e => {
+              setFieldValue('calculator.totalDailyDoseScaleFactor', parseFloat(e.target.value));
+            }}
+            options={totalDailyDoseScaleFactorOptions}
+            error={getFieldError('calculator.totalDailyDoseScaleFactor', formikContext)}
+            innerRef={initialFocusedInputRef}
+          />
+      </Box>
+      )}
+
+      {showWeight && (
+        <Flex mb={5} alignItems="flex-start">
+          <Box flexGrow={6}>
+            <FastField
+              as={TextInput}
+              label={t('Weight')}
+              placeholder={t('Enter Patient\'s Weight')}
+              type="number"
+              id="calculator.weight"
+              name="calculator.weight"
+              onBlur={e => {
+                setFieldTouched('calculator.weight');
+                setFieldValue('calculator.weight', roundValueToIncrement(e.target.value, 0.1));
+              }}
+              step={1}
+              min={0}
+              themeProps={inputStyles}
+              error={getFieldError('calculator.weight', formikContext)}
+              innerRef={!showTotalDailyDose ? initialFocusedInputRef : undefined}
+            />
+          </Box>
+
+          <Box ml={2} mt="1.5em" flexGrow={1}>
+            <FastField
+              as={Select}
+              themeProps={{
+                ...inputStyles,
+                borderLeft: 'none',
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+              }}
+              id="calculator.weightUnits"
+              name="calculator.weightUnits"
+              options={weightUnitOptions}
+              error={getFieldError('calculator.weightUnits', formikContext)}
+            />
+          </Box>
+        </Flex>
+      )}
+
+      <Button
+        variant="primary"
+        disabled={!fieldsAreValid([
+          'calculator.totalDailyDose',
+          'calculator.totalDailyDoseScaleFactor',
+          'calculator.weight',
+          'calculator.weightUnits',
+        ], schema, values)}
+        onClick={() => setResults(calculateRecommendedTherapySettings(values))}
+      >
+        {t('Calculate')}
+      </Button>
+
+      {results && (
+        <Box
+          mt={4}
+          sx={{ borderLeft: '3px solid', borderLeftColor: 'purpleMedium' }}
+          bg="purpleLight"
+          p={3}
+        >
+          <Paragraph1>
+            <strong>{t('Basal Rate: ')}</strong>{results.recommendedBasalRate} U/hr
+          </Paragraph1>
+          <Paragraph1>
+            <strong>{t('Insulin Sensitivity: ')}</strong>{results.recommendedInsulinSensitivity} {`${bgUnits}/U`}
+          </Paragraph1>
+          <Paragraph1>
+            <strong>{t('Carbohydrate Ratio: ')}</strong>{results.recommendedCarbohydrateRatio} g/U
+          </Paragraph1>
+        </Box>
+      )}
+    </Box>
+  );
+});
+
+const settingsCalculatorFormSteps = (schema, values) => ({
+  label: t('Therapy Settings Calculator'),
+  optional: true,
+  subSteps: [
+    {
+      disableComplete: isEmpty(get(values, stepValidationFields[2][0][0])) || !fieldsAreValid(stepValidationFields[2][0], schema, values),
+      onComplete: () => log('Calculator Method Complete'),
+      panelContent: <CalculatorMethod />
+    },
+    {
+      disableComplete: !fieldsAreValid(stepValidationFields[2][1], schema, values),
+      onComplete: () => log('Calculator Inputs Complete'),
+      // completeText: t('Use Defaults'),
+      // skipText: t('Discard Defaults'),
+      panelContent: <CalculatorInputs schema={schema} />
+    },
+  ],
+});
+
+export default settingsCalculatorFormSteps;

--- a/app/pages/prescription/settingsCalculatorFormSteps.js
+++ b/app/pages/prescription/settingsCalculatorFormSteps.js
@@ -211,7 +211,7 @@ export const CalculatorInputs = translate()(props => {
   );
 });
 
-const settingsCalculatorFormSteps = (schema, values, handlers) => ({
+const settingsCalculatorFormSteps = (schema, handlers, values ) => ({
   label: t('Therapy Settings Calculator'),
   optional: true,
   onSkip: handlers.clearCalculator,

--- a/app/pages/prescription/settingsCalculatorFormSteps.js
+++ b/app/pages/prescription/settingsCalculatorFormSteps.js
@@ -132,7 +132,6 @@ export const CalculatorInputs = translate()(props => {
             }}
             options={totalDailyDoseScaleFactorOptions}
             error={getFieldError('calculator.totalDailyDoseScaleFactor', formikContext)}
-            innerRef={initialFocusedInputRef}
           />
       </Box>
       )}

--- a/app/pages/prescription/settingsCalculatorFormSteps.js
+++ b/app/pages/prescription/settingsCalculatorFormSteps.js
@@ -6,7 +6,6 @@ import bows from 'bows';
 import get from 'lodash/get';
 import includes from 'lodash/includes';
 import isEmpty from 'lodash/isEmpty';
-import map from 'lodash/map';
 
 import { fieldsAreValid, getFieldError } from '../../core/forms';
 import { useInitialFocusedInput } from '../../core/hooks';

--- a/app/pages/prescription/settingsCalculatorFormSteps.js
+++ b/app/pages/prescription/settingsCalculatorFormSteps.js
@@ -32,7 +32,7 @@ import {
 } from './prescriptionFormConstants';
 
 const t = i18next.t.bind(i18next);
-const log = bows('PrescriptionAccount');
+const log = bows('PrescriptionCalculator');
 
 export const CalculatorMethod = translate()(props => {
   const { t } = props;

--- a/app/pages/prescription/settingsCalculatorFormSteps.js
+++ b/app/pages/prescription/settingsCalculatorFormSteps.js
@@ -212,9 +212,10 @@ export const CalculatorInputs = translate()(props => {
   );
 });
 
-const settingsCalculatorFormSteps = (schema, values) => ({
+const settingsCalculatorFormSteps = (schema, values, handlers) => ({
   label: t('Therapy Settings Calculator'),
   optional: true,
+  onSkip: handlers.clearCalculator,
   subSteps: [
     {
       disableComplete: isEmpty(get(values, stepValidationFields[2][0][0])) || !fieldsAreValid(stepValidationFields[2][0], schema, values),
@@ -224,8 +225,6 @@ const settingsCalculatorFormSteps = (schema, values) => ({
     {
       disableComplete: !fieldsAreValid(stepValidationFields[2][1], schema, values),
       onComplete: () => log('Calculator Inputs Complete'),
-      // completeText: t('Use Defaults'),
-      // skipText: t('Discard Defaults'),
       panelContent: <CalculatorInputs schema={schema} />
     },
   ],

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -113,7 +113,7 @@ export const InModuleTrainingNotification = props => {
 InModuleTrainingNotification.propTypes = fieldsetPropTypes;
 
 export const GlucoseSettings = props => {
-  const { t, pump, ...themeProps } = props;
+  const { t, pump, ranges, thresholds, ...themeProps } = props;
   const formikContext = useFormikContext();
 
   const {
@@ -123,8 +123,6 @@ export const GlucoseSettings = props => {
   } = formikContext;
 
   const bgUnits = values.initialSettings.bloodGlucoseUnits;
-  const ranges = pumpRanges(pump, bgUnits, values);
-  const thresholds = warningThresholds(pump, bgUnits, values);
 
   return (
     <Box {...fieldsetStyles} {...wideFieldsetStyles} {...borderedFieldsetStyles} {...themeProps}>
@@ -307,7 +305,7 @@ export const GlucoseSettings = props => {
 GlucoseSettings.propTypes = fieldsetPropTypes;
 
 export const InsulinSettings = props => {
-  const { t, pump, ...themeProps } = props;
+  const { t, pump, ranges, thresholds, ...themeProps } = props;
   const formikContext = useFormikContext();
 
   const {
@@ -317,8 +315,6 @@ export const InsulinSettings = props => {
   } = formikContext;
 
   const bgUnits = values.initialSettings.bloodGlucoseUnits;
-  const ranges = pumpRanges(pump, bgUnits, values);
-  const thresholds = warningThresholds(pump, bgUnits, values);
 
   return (
     <Box {...fieldsetStyles} {...wideFieldsetStyles} {...borderedFieldsetStyles} {...themeProps}>
@@ -531,9 +527,31 @@ export const TherapySettings = translate()(props => {
   } = formikContext;
 
   const bgUnits = values.initialSettings.bloodGlucoseUnits;
-  const ranges = pumpRanges(props.pump, bgUnits, values);
-  const defaults = defaultValues(props.pump, bgUnits, values);
   const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
+  const bloodGlucoseTargetSchedules = get(values, 'initialSettings.bloodGlucoseTargetSchedule');
+  const carbohydrateRatioSchedules = get(values, 'initialSettings.carbohydrateRatioSchedule');
+  const glucoseSafetyLimit = get(values, 'initialSettings.glucoseSafetyLimit');
+  const bloodGlucoseTargetPhysicalActivityLow = get(values, 'initialSettings.bloodGlucoseTargetPhysicalActivity.low');
+  const bloodGlucoseTargetPreprandialLow = get(values, 'initialSettings.bloodGlucoseTargetPreprandial.low');
+
+  // Only re-calculate thresholds, ranges, and defaults when relevant dependancy values change
+  const thresholds = React.useMemo(() => warningThresholds(props.pump, bgUnits, values), [
+    maxBasalRate,
+    bloodGlucoseTargetSchedules,
+  ]);
+
+  const ranges = React.useMemo(() => pumpRanges(props.pump, bgUnits, values), [
+    maxBasalRate,
+    carbohydrateRatioSchedules,
+    bloodGlucoseTargetSchedules,
+    bloodGlucoseTargetPhysicalActivityLow,
+    bloodGlucoseTargetPreprandialLow,
+    glucoseSafetyLimit,
+  ]);
+
+  const defaults = React.useMemo(() => defaultValues(props.pump, bgUnits, values), [
+    maxBasalRate,
+  ]);
 
   const fieldsWithDefaults = [
     {
@@ -592,8 +610,8 @@ export const TherapySettings = translate()(props => {
       <PatientInfo mb={4} {...props} />
       <PatientTraining mt={0} mb={4} {...props} />
       {values.training === 'inModule' && <InModuleTrainingNotification mt={0} mb={4} {...props} />}
-      <GlucoseSettings mt={0} mb={4} {...props} />
-      <InsulinSettings mt={0} {...props} />
+      <GlucoseSettings mt={0} mb={4} {...{ ranges, thresholds, ...props }} />
+      <InsulinSettings mt={0} {...{ ranges, thresholds, ...props }} />
     </Box>
   );
 });

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -600,7 +600,7 @@ export const TherapySettings = translate()(props => {
 
 const therapySettingsFormStep = (schema, pump, values) => ({
   label: t('Enter Therapy Settings'),
-  disableComplete: !fieldsAreValid(stepValidationFields[2][0], schema, values),
+  disableComplete: !fieldsAreValid(stepValidationFields[3][0], schema, values),
   panelContent: <TherapySettings pump={pump} />
 });
 

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -551,6 +551,7 @@ export const TherapySettings = translate()(props => {
 
   const defaults = React.useMemo(() => defaultValues(props.pump, bgUnits, values), [
     maxBasalRate,
+    values.calculator,
   ]);
 
   const fieldsWithDefaults = [
@@ -595,6 +596,21 @@ export const TherapySettings = translate()(props => {
       increment: ranges.basalRateMaximum.increment,
       dependancies: [maxBasalRate],
     },
+    {
+      path: 'initialSettings.basalRateSchedule[0].rate',
+      defaultValue: defaults.basalRate,
+      increment: ranges.basalRate.increment,
+    },
+    {
+      path: 'initialSettings.carbohydrateRatioSchedule[0].amount',
+      defaultValue: defaults.carbohydrateRatio,
+      increment: ranges.carbRatio.increment,
+    },
+    {
+      path: 'initialSettings.insulinSensitivitySchedule[0].amount',
+      defaultValue: defaults.insulinSensitivity,
+      increment: ranges.insulinSensitivityFactor.increment,
+    },
   ];
 
   each(fieldsWithDefaults, field => {
@@ -602,7 +618,7 @@ export const TherapySettings = translate()(props => {
       if (shouldUpdateDefaultValue(field.path, formikContext)) {
         setFieldValue(field.path, roundValueToIncrement(field.defaultValue, field.increment));
       }
-    }, field.dependancies || []);
+    }, field.dependancies || [field.defaultValue]);
   });
 
   return (

--- a/app/themes/base/inputs.js
+++ b/app/themes/base/inputs.js
@@ -30,10 +30,10 @@ export default ({ borders, colors, fonts, radii, fontSizes, fontWeights, space }
 
     input: {
       '&::placeholder': {
-        color: colors.text.primaryTextSubdued,
+        color: colors.text.primarySubdued,
       },
       '&.active': {
-        color: colors.text.primaryTextSubdued,
+        color: colors.text.primarySubdued,
         boxShadow: 'none',
       },
       '&:focus': {

--- a/test/unit/app/core/constants.test.js
+++ b/test/unit/app/core/constants.test.js
@@ -43,6 +43,10 @@ describe('constants', function() {
     expect(Constants.MGDL_PER_MMOLL).to.equal(18.01559);
   });
 
+  it('should define the lbs per kg conversion factor as 2.2046226218', function() {
+    expect(Constants.LBS_PER_KG).to.equal(2.2046226218);
+  });
+
   it('should define the tidepool big data donation account email', function() {
     expect(Constants.TIDEPOOL_DATA_DONATION_ACCOUNT_EMAIL).to.equal('bigdata@tidepool.org');
   });

--- a/test/unit/pages/prescription/PrescriptionForm.test.js
+++ b/test/unit/pages/prescription/PrescriptionForm.test.js
@@ -81,6 +81,10 @@ describe('PrescriptionForm', () => {
     expect(backButton).to.have.length(0);
   });
 
+  describe('clearCalculator', () => {
+
+  });
+
   describe('generateTherapySettingsOrderText', () => {
     it('should generate the therapy settings order text', () => {
       const patientRows = [

--- a/test/unit/pages/prescription/PrescriptionForm.test.js
+++ b/test/unit/pages/prescription/PrescriptionForm.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import moment from 'moment';
 
 import {
+  clearCalculator,
   generateTherapySettingsOrderText,
   prescriptionForm,
   PrescriptionForm,
@@ -11,6 +12,7 @@ import {
 import { ToastProvider } from '../../../../app/providers/ToastProvider';
 
 import { withFormik } from 'formik';
+import { set } from 'lodash';
 
 /* global chai */
 /* global sinon */
@@ -82,7 +84,19 @@ describe('PrescriptionForm', () => {
   });
 
   describe('clearCalculator', () => {
+    const setFieldValue = sinon.stub();
 
+    it('should clear all calculator values', () => {
+      clearCalculator(setFieldValue);
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.method', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.totalDailyDose', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.totalDailyDoseScaleFactor', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.weight', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.weightUnits', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.recommendedBasalRate', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.recommendedInsulinSensitivity', undefined, false)
+      sinon.assert.calledWithExactly(setFieldValue, 'calculator.recommendedCarbohydrateRatio', undefined, false)
+    });
   });
 
   describe('generateTherapySettingsOrderText', () => {

--- a/test/unit/pages/prescription/PrescriptionForm.test.js
+++ b/test/unit/pages/prescription/PrescriptionForm.test.js
@@ -59,14 +59,15 @@ describe('PrescriptionForm', () => {
     expect(stepper).to.have.length(1);
 
     const steps = stepper.find('.MuiStep-root');
-    expect(steps).to.have.length(4);
+    expect(steps).to.have.length(5);
 
     expect(steps.at(0).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Create Patient Account');
     expect(steps.at(0).hasClass('active')).to.be.true;
 
     expect(steps.at(1).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Complete Patient Profile');
-    expect(steps.at(2).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Enter Therapy Settings');
-    expect(steps.at(3).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Review and Save Prescription');
+    expect(steps.at(2).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Therapy Settings Calculator');
+    expect(steps.at(3).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Enter Therapy Settings');
+    expect(steps.at(4).find('.MuiStepLabel-label').hostNodes().text()).to.equal('Review and Save Prescription');
   });
 
   it('should render the form actions, with only the `next` button on the first step', () => {
@@ -142,7 +143,7 @@ describe('PrescriptionForm', () => {
     let wrapper;
     let reviewStepProps = {
       ...defaultProps,
-      location: { search: '?prescription-form-steps-step=3,0' },
+      location: { search: '?prescription-form-steps-step=4,0' },
     };
 
     beforeEach(() => {

--- a/test/unit/pages/prescription/accountFormSteps.test.js
+++ b/test/unit/pages/prescription/accountFormSteps.test.js
@@ -20,14 +20,11 @@ const values = {
   emailConfirm: 'goodField',
 };
 
-const validateSyncAt = sinon.stub();
-validateSyncAt
-  .withArgs('goodField')
-  .returns(true);
-
-validateSyncAt
-  .withArgs('badField')
-  .throws();
+const validateSyncAt = sinon.stub().callsFake((fieldKey, values) => {
+  if (_.get(values, fieldKey) === 'badField') {
+    throw('error');
+  }
+});
 
 const schema = { validateSyncAt };
 
@@ -59,14 +56,14 @@ describe('accountFormSteps', function() {
     expect(subSteps[1].disableComplete).to.be.false;
     expect(subSteps[2].disableComplete).to.be.false;
 
-    expect(accountFormSteps(invalidateValue('accountType')).subSteps[0].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('firstName')).subSteps[1].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('lastName')).subSteps[1].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('birthday')).subSteps[1].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('caregiverFirstName')).subSteps[2].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('caregiverLastName')).subSteps[2].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('email')).subSteps[2].disableComplete).to.be.true;
-    expect(accountFormSteps(invalidateValue('emailConfirm')).subSteps[2].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('accountType')).subSteps[0].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('firstName')).subSteps[1].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('lastName')).subSteps[1].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('birthday')).subSteps[1].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('caregiverFirstName')).subSteps[2].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('caregiverLastName')).subSteps[2].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('email')).subSteps[2].disableComplete).to.be.true;
+    expect(accountFormSteps(schema, null, invalidateValue('emailConfirm')).subSteps[2].disableComplete).to.be.true;
   });
 
   it('should hide the back button for the first subStep', () => {

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -91,7 +91,6 @@ describe('prescriptionFormConstants', function() {
     expect(prescriptionFormConstants.defaultUnits).to.eql({
       basalRate: 'Units/hour',
       bloodGlucose: 'mg/dL',
-      glucoseSafetyLimit: MGDL_UNITS,
       bolusAmount: 'Units',
       insulinCarbRatio: 'g/U',
       weight: 'kg',

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -94,6 +94,7 @@ describe('prescriptionFormConstants', function() {
       glucoseSafetyLimit: MGDL_UNITS,
       bolusAmount: 'Units',
       insulinCarbRatio: 'g/U',
+      weight: 'kg',
     });
   });
 

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -59,7 +59,7 @@ describe('prescriptionFormConstants', function() {
     });
   });
 
-  it('should export the list pump device options', function() {
+  it('should export the list of the pump device options', function() {
     const pumpDeviceOptions = prescriptionFormConstants.pumpDeviceOptions(devices);
     expect(pumpDeviceOptions).to.be.an('array');
     expect(_.map(pumpDeviceOptions, 'value')).to.eql([
@@ -73,7 +73,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list cgm device options', function() {
+  it('should export the list of the cgm device options', function() {
     const cgmDeviceOptions = prescriptionFormConstants.cgmDeviceOptions(devices);
     expect(cgmDeviceOptions).to.be.an('array');
     expect(_.map(cgmDeviceOptions, 'value')).to.eql([
@@ -1006,7 +1006,7 @@ describe('prescriptionFormConstants', function() {
     });
   });
 
-  it('should export the list the prescription account type options', function() {
+  it('should export the list of the prescription account type options', function() {
     expect(prescriptionFormConstants.typeOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.typeOptions, 'value')).to.eql([
       'patient',
@@ -1018,7 +1018,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list the prescription patient sex options', function() {
+  it('should export the list of the prescription patient sex options', function() {
     expect(prescriptionFormConstants.sexOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.sexOptions, 'value')).to.eql([
       'female',
@@ -1031,7 +1031,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list the prescription training options', function() {
+  it('should export the list of the prescription training options', function() {
     expect(prescriptionFormConstants.trainingOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.trainingOptions, 'value')).to.eql([
       'inPerson',
@@ -1043,7 +1043,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list the prescription insulin type options', function() {
+  it('should export the list of the prescription insulin type options', function() {
     expect(prescriptionFormConstants.insulinModelOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.insulinModelOptions, 'value')).to.eql([
       'rapidAdult',
@@ -1055,7 +1055,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list the calculator method options', function() {
+  it('should export the list of the calculator method options', function() {
     expect(prescriptionFormConstants.calculatorMethodOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.calculatorMethodOptions, 'value')).to.eql([
       'totalDailyDose',
@@ -1068,7 +1068,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list the calculator tdd scale factor options', function() {
+  it('should export the list of the calculator tdd scale factor options', function() {
     expect(prescriptionFormConstants.totalDailyDoseScaleFactorOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.totalDailyDoseScaleFactorOptions, 'value')).to.eql([
       1,
@@ -1080,7 +1080,7 @@ describe('prescriptionFormConstants', function() {
     })
   });
 
-  it('should export the list the calculator weight unit options', function() {
+  it('should export the list of the calculator weight unit options', function() {
     expect(prescriptionFormConstants.weightUnitOptions).to.be.an('array');
     expect(_.map(prescriptionFormConstants.weightUnitOptions, 'value')).to.eql([
       'kg',

--- a/test/unit/pages/prescription/prescriptionSchema.test.js
+++ b/test/unit/pages/prescription/prescriptionSchema.test.js
@@ -27,6 +27,7 @@ describe('prescriptionSchema', function() {
       'phoneNumber',
       'mrn',
       'sex',
+      'calculator',
       'initialSettings',
       'training',
       'therapySettingsReviewed',
@@ -98,6 +99,17 @@ describe('prescriptionSchema', function() {
     expect(schema.fields.initialSettings.fields.insulinSensitivitySchedule._subType._nodes).to.be.an('array').and.have.members([
       'amount',
       'start',
+    ]);
+
+    expect(schema.fields.calculator._nodes).to.be.an('array').and.have.members([
+      'method',
+      'totalDailyDose',
+      'totalDailyDoseScaleFactor',
+      'weight',
+      'weightUnits',
+      'recommendedBasalRate',
+      'recommendedInsulinSensitivity',
+      'recommendedCarbohydrateRatio',
     ]);
   });
 });

--- a/test/unit/pages/prescription/profileFormSteps.test.js
+++ b/test/unit/pages/prescription/profileFormSteps.test.js
@@ -21,14 +21,11 @@ const values = {
   },
 };
 
-const validateSyncAt = sinon.stub();
-validateSyncAt
-  .withArgs('goodField')
-  .returns(true);
-
-validateSyncAt
-  .withArgs('badField')
-  .throws();
+const validateSyncAt = sinon.stub().callsFake((fieldKey, values) => {
+  if (_.get(values, fieldKey) === 'badField') {
+    throw('error');
+  }
+});
 
 const schema = { validateSyncAt };
 
@@ -61,11 +58,11 @@ describe('profileFormSteps', function() {
     expect(subSteps[2].disableComplete).to.be.false;
     expect(subSteps[3].disableComplete).to.be.false;
 
-    expect(profileFormSteps(invalidateValue('phoneNumber.number')).subSteps[0].disableComplete).to.be.true;
-    expect(profileFormSteps(invalidateValue('mrn')).subSteps[1].disableComplete).to.be.true;
-    expect(profileFormSteps(invalidateValue('sex')).subSteps[2].disableComplete).to.be.true;
-    expect(profileFormSteps(invalidateValue('initialSettings.pumpId')).subSteps[3].disableComplete).to.be.true;
-    expect(profileFormSteps(invalidateValue('initialSettings.cgmId')).subSteps[3].disableComplete).to.be.true;
+    expect(profileFormSteps(schema, null, invalidateValue('phoneNumber.number')).subSteps[0].disableComplete).to.be.true;
+    expect(profileFormSteps(schema, null, invalidateValue('mrn')).subSteps[1].disableComplete).to.be.true;
+    expect(profileFormSteps(schema, null, invalidateValue('sex')).subSteps[2].disableComplete).to.be.true;
+    expect(profileFormSteps(schema, null, invalidateValue('initialSettings.pumpId')).subSteps[3].disableComplete).to.be.true;
+    expect(profileFormSteps(schema, null, invalidateValue('initialSettings.cgmId')).subSteps[3].disableComplete).to.be.true;
   });
 
   it('should not hide the back button for the any subSteps', () => {

--- a/test/unit/pages/prescription/reviewFormStep.test.js
+++ b/test/unit/pages/prescription/reviewFormStep.test.js
@@ -26,6 +26,16 @@ const values = {
   mrn: 'goodField',
   sex: 'goodField',
   training: 'goodField',
+  calculator: {
+    method: 'goodField',
+    totalDailyDose: 'goodField',
+    totalDailyDoseScaleFactor: 'goodField',
+    weight: 'goodField',
+    weightUnits: 'goodField',
+    recommendedBasalRate: 'goodField',
+    recommendedInsulinSensitivity: 'goodField',
+    recommendedCarbohydrateRatio: 'goodField',
+  },
   initialSettings: {
     pumpId: 'goodField',
     cgmId: 'goodField',
@@ -43,14 +53,11 @@ const values = {
   therapySettingsReviewed: 'goodField',
 };
 
-const validateSyncAt = sinon.stub();
-validateSyncAt
-  .withArgs('goodField')
-  .returns(true);
-
-validateSyncAt
-  .withArgs('badField')
-  .throws();
+const validateSyncAt = sinon.stub().callsFake((fieldKey, values) => {
+  if (_.get(values, fieldKey) === 'badField') {
+    throw('error');
+  }
+});
 
 const schema = { validateSyncAt };
 
@@ -88,31 +95,39 @@ describe('reviewFormStep', function() {
 
   it('should disable the complete button if the any of the prescriptions fields are invalid', () => {
     expect(reviewFormStep(schema, pump, handlers, values).disableComplete).to.be.false;
-    expect(reviewFormStep(invalidateValue('accountType')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('firstName')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('lastName')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('birthday')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('caregiverFirstName')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('caregiverLastName')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('email')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('emailConfirm')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('phoneNumber.number')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('mrn')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('sex')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('training')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.pumpId')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.cgmId')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.glucoseSafetyLimit')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.insulinModel')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.basalRateMaximum')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.bolusAmountMaximum')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.bloodGlucoseTargetSchedule')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.bloodGlucoseTargetPhysicalActivity')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.bloodGlucoseTargetPreprandial')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.basalRateSchedule')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.carbohydrateRatioSchedule')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('initialSettings.insulinSensitivitySchedule')).disableComplete).to.be.true;
-    expect(reviewFormStep(invalidateValue('therapySettingsReviewed')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('accountType')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('firstName')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('lastName')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('birthday')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('caregiverFirstName')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('caregiverLastName')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('email')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('emailConfirm')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('phoneNumber.number')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('mrn')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('sex')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.method')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.totalDailyDose')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.totalDailyDoseScaleFactor')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.weight')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.weightUnits')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.recommendedBasalRate')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.recommendedInsulinSensitivity')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('calculator.recommendedCarbohydrateRatio')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('training')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.pumpId')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.cgmId')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.glucoseSafetyLimit')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.insulinModel')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.basalRateMaximum')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.bolusAmountMaximum')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.bloodGlucoseTargetSchedule')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.bloodGlucoseTargetPhysicalActivity')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.bloodGlucoseTargetPreprandial')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.basalRateSchedule')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.carbohydrateRatioSchedule')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('initialSettings.insulinSensitivitySchedule')).disableComplete).to.be.true;
+    expect(reviewFormStep(schema, pump, handlers, invalidateValue('therapySettingsReviewed')).disableComplete).to.be.true;
   });
 
   it('should not hide the back button', () => {

--- a/test/unit/pages/prescription/settingsCalculatorFormSteps.test.js
+++ b/test/unit/pages/prescription/settingsCalculatorFormSteps.test.js
@@ -1,0 +1,76 @@
+import _ from 'lodash';
+
+import settingsCalculatorFormSteps from '../../../../app/pages/prescription/settingsCalculatorFormSteps';
+
+/* global chai */
+/* global describe */
+/* global it */
+/* global sinon */
+
+const expect = chai.expect;
+
+const values = {
+  calculator: {
+    method: 'goodField',
+    totalDailyDose: 'goodField',
+    totalDailyDoseScaleFactor: 'goodField',
+    weight: 'goodField',
+    weightUnits: 'goodField',
+    recommendedBasalRate: 'goodField',
+    recommendedInsulinSensitivity: 'goodField',
+    recommendedCarbohydrateRatio: 'goodField',
+  },
+};
+
+const validateSyncAt = sinon.stub().callsFake((fieldKey, values) => {
+  if (_.get(values, fieldKey) === 'badField') {
+    throw('error');
+  }
+});
+
+const schema = { validateSyncAt };
+
+const handlers = {
+  clearCalculator: sinon.stub(),
+};
+
+const invalidateValue = fieldPath => _.set({ ...values }, fieldPath, 'badField');
+
+describe('settingsCalculatorFormSteps', function() {
+  it('should export a settingsCalculatorFormSteps function', function() {
+    expect(settingsCalculatorFormSteps).to.be.a('function');
+  });
+
+  it('should include the step label', () => {
+    expect(settingsCalculatorFormSteps(schema, handlers, values).label).to.equal('Therapy Settings Calculator');
+  });
+
+  it('should set the onSkip handler', () => {
+    expect(settingsCalculatorFormSteps(schema, handlers, values).onSkip).to.equal(handlers.clearCalculator);
+  });
+
+  it('should include the step subSteps', () => {
+    const subSteps = settingsCalculatorFormSteps(schema, handlers, values).subSteps;
+    expect(subSteps).to.be.an('array').and.have.lengthOf(2);
+  });
+
+  it('should disable the complete button for any invalid fields within a subStep', () => {
+    const subSteps = settingsCalculatorFormSteps(schema, handlers, values).subSteps;
+    expect(subSteps[0].disableComplete).to.be.false;
+    expect(subSteps[1].disableComplete).to.be.false;
+
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.method')).subSteps[0].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.totalDailyDose')).subSteps[1].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.totalDailyDoseScaleFactor')).subSteps[1].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.weight')).subSteps[1].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.weightUnits')).subSteps[1].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.recommendedBasalRate')).subSteps[1].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.recommendedInsulinSensitivity')).subSteps[1].disableComplete).to.be.true;
+    expect(settingsCalculatorFormSteps(schema, handlers, invalidateValue('calculator.recommendedCarbohydrateRatio')).subSteps[1].disableComplete).to.be.true;
+  });
+
+  it('should not hide the back button for the any subSteps', () => {
+    expect(settingsCalculatorFormSteps(schema, handlers, values).subSteps[0].hideBack).to.be.undefined;
+    expect(settingsCalculatorFormSteps(schema, handlers, values).subSteps[1].hideBack).to.be.undefined;
+  });
+});

--- a/test/unit/pages/prescription/therapySettingsFormStep.test.js
+++ b/test/unit/pages/prescription/therapySettingsFormStep.test.js
@@ -25,14 +25,11 @@ const values = {
   },
 };
 
-const validateSyncAt = sinon.stub();
-validateSyncAt
-  .withArgs('goodField')
-  .returns(true);
-
-validateSyncAt
-  .withArgs('badField')
-  .throws();
+const validateSyncAt = sinon.stub().callsFake((fieldKey, values) => {
+  if (_.get(values, fieldKey) === 'badField') {
+    throw('error');
+  }
+});
 
 const schema = { validateSyncAt };
 
@@ -57,17 +54,17 @@ describe('therapySettingsFormStep', function() {
 
   it('should disable the complete button for any invalid fields', () => {
     expect(therapySettingsFormStep(schema, pump, values).disableComplete).to.be.false;
-    expect(therapySettingsFormStep(invalidateValue('training')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.glucoseSafetyLimit')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.insulinModel')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.basalRateMaximum.value')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.bolusAmountMaximum.value')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.bloodGlucoseTargetSchedule')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.bloodGlucoseTargetPhysicalActivity')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.bloodGlucoseTargetPreprandial')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.basalRateSchedule')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.carbohydrateRatioSchedule')).disableComplete).to.be.true;
-    expect(therapySettingsFormStep(invalidateValue('initialSettings.insulinSensitivitySchedule')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('training')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.glucoseSafetyLimit')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.insulinModel')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.basalRateMaximum.value')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.bolusAmountMaximum.value')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.bloodGlucoseTargetSchedule')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.bloodGlucoseTargetPhysicalActivity')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.bloodGlucoseTargetPreprandial')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.basalRateSchedule')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.carbohydrateRatioSchedule')).disableComplete).to.be.true;
+    expect(therapySettingsFormStep(schema, pump, invalidateValue('initialSettings.insulinSensitivitySchedule')).disableComplete).to.be.true;
   });
 
   it('should not hide the back button', () => {


### PR DESCRIPTION
See [WEB-1134] for details

Some small things to note:

- Small changes to the Radio and Select components (for handling number values and refs for focus reasons, respectively)
- Added an `onSkip` handler to the Stepper to flush all calculator form values when step is skipped at any time
- Memoized some functions on the therapy settings step that were being called way more often than needed (the ones for determining input ranges, thresholds, and default values) 
- Fixed an invalid color reference for some input styles
- FIxed some unit tests for the validation of the existing form steps that were not really testing what I thought they were

[WEB-1134]: https://tidepool.atlassian.net/browse/WEB-1134