### PR TITLE
Attempt to address max file watchers warnings that are clogging the travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - docker version
   - docker pull docker.io/docker/dockerfile:experimental
   - docker pull docker.io/library/node:10.14.2-alpine
+  - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
 install:
   - yarn install --frozen-lockfile


### PR DESCRIPTION
Seems to work.  Previously, Travis logs were getting inundated with error messages from `chokidar` along the lines of:
```
Error: ENOSPC: System limit for number of file watchers reached
```