### PR TITLE
Travis: docker login before pull

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-cache madison docker-ce
   - sudo apt-get -y install docker-ce=5:19.03.5~3-0~ubuntu-xenial
+  - echo "$(DOCKER_PASSWORD)" | docker login --username "$(DOCKER_USERNAME)" --password-stdin
   - docker version
   - docker pull docker.io/docker/dockerfile:experimental
   - docker pull docker.io/library/node:10.14.2-alpine

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-cache madison docker-ce
   - sudo apt-get -y install docker-ce=5:19.03.5~3-0~ubuntu-xenial
-  - echo "$(DOCKER_PASSWORD)" | docker login --username "$(DOCKER_USERNAME)" --password-stdin
+  - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
   - docker version
   - docker pull docker.io/docker/dockerfile:experimental
   - docker pull docker.io/library/node:10.14.2-alpine


### PR DESCRIPTION
Docker pull rate limits are capped at 100 for unauthenticated requests.  Authenticating prior to pulling allows us to avoid these rate limit errors during high travis build usage.