### PR TITLE
[WEB-1209] Logo link updates

### DIFF
--- a/app/components/navbar/navbar.js
+++ b/app/components/navbar/navbar.js
@@ -17,6 +17,7 @@ import logoSrc from './images/tidepool-logo-408x46.png';
 export default translate()(class extends React.Component {
   static propTypes = {
     clinicFlowActive: PropTypes.bool,
+    clinics: PropTypes.array,
     currentPage: PropTypes.string,
     user: PropTypes.object,
     fetchingUser: PropTypes.bool,
@@ -82,8 +83,17 @@ export default translate()(class extends React.Component {
       self.props.trackMetric('Clicked Navbar Logo');
     };
 
+    let linkDisabled = false;
+
+    if (this.props.clinicFlowActive) {
+      const userClinics = _.filter(_.values(this.props.clinics), ({ clinicians }) => _.has(clinicians, _.get(this.props, 'user.userid')));
+      // Disable logo link if the clinician is only a member of a single clinic, or is not on a clinic workspace tab
+      linkDisabled = userClinics.length < 2 || !/^\/clinic-workspace.*/.test(this.props.currentPage);
+    }
+
     return (
       <Link
+        disabled={linkDisabled}
         to="/"
         className="Navbar-logo"
         onClick={handleClick}>

--- a/app/core/less/nav.less
+++ b/app/core/less/nav.less
@@ -1,14 +1,14 @@
 /**
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  */
@@ -51,4 +51,8 @@
   float: right;
 
   margin-right: -@nav-item-horizontal-padding;
+}
+
+.Navbar-logo[disabled] {
+  pointer-events: none;
 }

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -173,7 +173,7 @@ export class AppComponent extends React.Component {
 
     if (!this.props.clinicFlowActive && nextProps.clinicFlowActive && !selectedClinicId && _.keys(clinics).length) {
       // We keep the selectedClinicId state at it's default 'null' if the app loads on the legacy
-      // patients page. Otherwise, we select teh first available clinic
+      // patients page. Otherwise, we select the first available clinic.
       if (location !== '/patients') nextProps.selectClinic(_.keys(clinics)[0]);
     }
 

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -172,7 +172,9 @@ export class AppComponent extends React.Component {
     }
 
     if (!this.props.clinicFlowActive && nextProps.clinicFlowActive && !selectedClinicId && _.keys(clinics).length) {
-      nextProps.selectClinic(_.keys(clinics)[0]);
+      // We keep the selectedClinicId state at it's default 'null' if the app loads on the legacy
+      // patients page. Otherwise, we select teh first available clinic
+      if (location !== '/patients') nextProps.selectClinic(_.keys(clinics)[0]);
     }
 
     const isBannerRoute = /^\/patients\/\S+\/data/.test(location);
@@ -310,6 +312,7 @@ export class AppComponent extends React.Component {
             fetchingPatient={this.props.fetchingPatient}
             currentPage={this.props.location}
             clinicFlowActive={this.props.clinicFlowActive}
+            clinics={this.props.clinics}
             getUploadUrl={getUploadUrl}
             onLogout={this.props.onLogout}
             trackMetric={this.props.context.trackMetric}
@@ -784,7 +787,7 @@ let mapDispatchToProps = dispatch => bindActionCreators({
 
 let mergeProps = (stateProps, dispatchProps, ownProps) => {
   var api = ownProps.api;
-  return Object.assign({}, _.pick(ownProps, ['children']), stateProps, {
+  return Object.assign({}, _.pick(ownProps, ['children', 'history']), stateProps, {
     context: {
       DEBUG: ownProps.DEBUG,
       api: ownProps.api,

--- a/app/routes.js
+++ b/app/routes.js
@@ -139,7 +139,7 @@ export const ensureNoAuth = (api, cb = _.noop) => () => {
 export const requireNoAuth = (api, cb = _.noop) => (dispatch, getState) => {
   const { blip: state } = getState();
   if (api.user.isAuthenticated()) {
-    dispatch(push(state.clinicFlowActive ? '/clinic-workspace/patients' : '/patients'));
+    dispatch(push(state.clinicFlowActive ? '/workspaces' : '/patients'));
   }
   cb();
 };

--- a/config/local.example.js
+++ b/config/local.example.js
@@ -41,4 +41,4 @@ module.exports = {
   linkedPackages,
   featureFlags,
   apiHost,
-}
+};


### PR DESCRIPTION
See [WEB-1209]
Sets the default root redirect to `/workspaces` when new clinic flow is active, and disables logo link in certain circumstances.

[WEB-1209]: https://tidepool.atlassian.net/browse/WEB-1209