### PR TITLE
[WEB-1238] notify on resend invite

### DIFF
--- a/app/pages/share/AccessManagement.js
+++ b/app/pages/share/AccessManagement.js
@@ -17,6 +17,7 @@ import InputIcon from '@material-ui/icons/Input';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import PublishRoundedIcon from '@material-ui/icons/PublishRounded';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import sundial from 'sundial';
 
 import {
   Title,
@@ -50,6 +51,7 @@ export const AccessManagement = (props) => {
   const dispatch = useDispatch();
   const { set: setToast } = useToasts();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showResendInviteDialog, setShowResendInviteDialog] = useState(false);
   const [sharedAccounts, setSharedAccounts] = useState([]);
   const [pendingClinicInvites, setPendingClinicInvites] = useState([]);
   const [selectedSharedAccount, setSelectedSharedAccount] = useState(null);
@@ -69,6 +71,7 @@ export const AccessManagement = (props) => {
   const membersOfTargetCareTeam = useSelector((state) => state.blip.membersOfTargetCareTeam);
   const pendingSentInvites = useSelector((state) => state.blip.pendingSentInvites);
   const permissionsOfMembersInTargetCareTeam = useSelector((state) => state.blip.permissionsOfMembersInTargetCareTeam);
+  const timePrefs = useSelector((state) => state.timePrefs);
 
   const {
     cancellingSentInvite,
@@ -248,6 +251,7 @@ export const AccessManagement = (props) => {
         status: invite.status,
         type: invite.type,
         uploadPermission: !!get(invite, ['context', 'upload']),
+        created: invite.created,
       }))),
       ...(map(clinicInvites, invite => ({
         id: invite.clinicId,
@@ -454,9 +458,9 @@ export const AccessManagement = (props) => {
         iconPosition: 'left',
         id: `resendInvite-${member.inviteId}`,
         onClick: _popupState => {
-          setPopupState(_popupState);
+          _popupState.close();
           setSelectedSharedAccount(member);
-          handleResendInvite(member);
+          setShowResendInviteDialog(true);
         },
         processing: resendingInvite.inProgress,
         text: t('Resend invitation'),
@@ -532,6 +536,15 @@ export const AccessManagement = (props) => {
       align: 'left',
     },
   ];
+
+  const formattedInviteDate =
+    selectedSharedAccount?.created &&
+    sundial.formatInTimezone(
+      selectedSharedAccount?.created,
+      timePrefs?.timezoneName ||
+        new Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'MM/DD/YYYY [at] h:mm a'
+    );
 
   return (
     <>
@@ -620,6 +633,42 @@ export const AccessManagement = (props) => {
             }}
           >
             {deleteDialogContent?.submitText}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        id="resendInvite"
+        aria-labelledBy="dialog-title"
+        open={showResendInviteDialog}
+        onClose={() => setShowResendInviteDialog(false)}
+      >
+        <DialogTitle onClose={() => setShowResendInviteDialog(false)}>
+          <MediumTitle id="dialog-title">{t('Confirm Resending Invitation')}</MediumTitle>
+        </DialogTitle>
+        <DialogContent>
+          <Body1>
+            {t(
+              'You invited {{inviteName}} to view your data on {{inviteDate}}. Are you sure you want to resend this invitation?',
+              {
+                inviteName: selectedSharedAccount?.name || selectedSharedAccount?.email,
+                inviteDate: formattedInviteDate,
+              }
+            )}
+          </Body1>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="secondary" onClick={() => setShowResendInviteDialog(false)}>
+            {t('Cancel')}
+          </Button>
+          <Button
+            className="resend-invitation"
+            variant="primary"
+            processing={resendingInvite.inProgress}
+            onClick={() => {
+              handleResendInvite(selectedSharedAccount);
+            }}
+          >
+            {t('Resend Invitation')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/test/unit/pages/share/AccessManagement.test.js
+++ b/test/unit/pages/share/AccessManagement.test.js
@@ -324,10 +324,10 @@ describe('AccessManagement', () => {
 
       // Click remove account button to open confirmation modal
       expect(popoverActionButtons.at(1).text()).contains('Remove account');
-      expect(wrapper.find(Dialog).props().open).to.be.false;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.false;
       popoverActionButtons.at(1).props().onClick();
       wrapper.update();
-      expect(wrapper.find(Dialog).props().open).to.be.true;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.true;
 
       // Confirm delete in modal
       const deleteButton = wrapper.find('button.remove-account-access');
@@ -363,9 +363,17 @@ describe('AccessManagement', () => {
 
       const actions = () => store.getActions();
 
-      // Click resent invitation button
+      // Click resent invitation button to open confirmation modal
       expect(popoverActionButtons.at(0).text()).contains('Resend invitation');
+      expect(wrapper.find(Dialog).at(1).props().open).to.be.false;
       popoverActionButtons.at(0).props().onClick();
+      wrapper.update()
+      expect(wrapper.find(Dialog).at(1).props().open).to.be.true;
+
+      // Confirm resend invitation in modal
+      const resendButton = wrapper.find('button.resend-invitation');
+      expect(resendButton).to.have.length(1);
+      resendButton.props().onClick();
       expect(actions()[0]).to.eql(expectedActions[0]);
 
       sinon.assert.calledWith(
@@ -375,10 +383,10 @@ describe('AccessManagement', () => {
 
       // Click revoke invitation button to open confirmation modal
       expect(popoverActionButtons.at(1).text()).contains('Revoke invitation');
-      expect(wrapper.find(Dialog).props().open).to.be.false;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.false;
       popoverActionButtons.at(1).props().onClick();
       wrapper.update();
-      expect(wrapper.find(Dialog).props().open).to.be.true;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.true;
 
       // Confirm delete in modal
       const deleteButton = wrapper.find('button.remove-account-access');
@@ -428,10 +436,10 @@ describe('AccessManagement', () => {
 
       // Click remove account button to open confirmation modal
       expect(popoverActionButtons.at(1).text()).contains('Remove clinic');
-      expect(wrapper.find(Dialog).props().open).to.be.false;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.false;
       popoverActionButtons.at(1).props().onClick();
       wrapper.update();
-      expect(wrapper.find(Dialog).props().open).to.be.true;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.true;
 
       // Confirm delete in modal
       const deleteButton = wrapper.find('button.remove-account-access');
@@ -467,10 +475,10 @@ describe('AccessManagement', () => {
 
       // Click revoke invitation button to open confirmation modal
       expect(popoverActionButtons.at(0).text()).contains('Revoke invitation');
-      expect(wrapper.find(Dialog).props().open).to.be.false;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.false;
       popoverActionButtons.at(0).props().onClick();
       wrapper.update();
-      expect(wrapper.find(Dialog).props().open).to.be.true;
+      expect(wrapper.find(Dialog).at(0).props().open).to.be.true;
 
       // Confirm delete in modal
       const deleteButton = wrapper.find('button.remove-account-access');


### PR DESCRIPTION
[WEB-1238] - moving the resend invitation action behind a modal confirmation to avoid accidental spam