### PR TITLE
[WEB-1209] Add logo link to a clinician's account settings and personal workspace pages

### DIFF
--- a/app/components/navbar/navbar.js
+++ b/app/components/navbar/navbar.js
@@ -91,8 +91,9 @@ export default translate()(class extends React.Component {
 
     if (this.props.clinicFlowActive) {
       const userClinics = _.filter(_.values(this.props.clinics), ({ clinicians }) => _.has(clinicians, _.get(this.props, 'user.userid')));
-      // Disable logo link if the clinician is only a member of a single clinic, or is not on a clinic workspace tab
-      linkDisabled = userClinics.length < 2 || !/^\/clinic-workspace.*/.test(this.props.currentPage);
+      // Disable logo link if the clinician is only a member of a single clinic,
+      // or is not on a clinic workspace tab, the personal workspace, or the account settings page
+      linkDisabled = userClinics.length < 2 || !/^(\/clinic-workspace.*|\/profile|\/patients)/.test(this.props.currentPage);
     }
 
     return (

--- a/app/routes.js
+++ b/app/routes.js
@@ -142,12 +142,12 @@ export const requireNoAuth = (api, cb = _.noop) => (dispatch, getState) => {
     const user = _.get(state.allUsersMap, state.loggedInUserId, {});
     const isClinicianAccount = personUtils.isClinicianAccount(user);
     const hasClinicProfile = !!_.get(user, ['profile', 'clinic'], false);
-    const firstEmptyClinic = _.find(state.clinics, clinic => _.isEmpty(clinic.clinic?.name) && !clinic.clinic?.canMigrate);
+    const firstEmptyClinic = _.find(state.clinics, clinic => _.isEmpty(clinic.name) && !clinic.canMigrate);
 
     // We don't want to navigate forward to a workspace if a clinician who needs to set up their
     // profile, or a clinician profile, navigates to the root url with the browser back button
     if (isClinicianAccount && (firstEmptyClinic || !hasClinicProfile)) {
-      if (firstEmptyClinic) dispatch(actions.sync.selectClinic(firstEmptyClinic.clinic?.id));
+      if (firstEmptyClinic) dispatch(actions.sync.selectClinic(firstEmptyClinic.id));
       dispatch(push(state.clinicFlowActive ? '/clinic-details' : '/clinician-details'));
     } else {
       dispatch(push(state.clinicFlowActive ? '/workspaces' : '/patients'));

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -530,7 +530,7 @@ describe('routes', () => {
               },
               clinicFlowActive: true,
               clinics: {
-                clinic123: { clinic: { id: 'clinic123', name: undefined } },
+                clinic123: { id: 'clinic123', name: undefined },
               },
               loggedInUserId: 'clinician123',
             },


### PR DESCRIPTION
Part of [WEB-1209]

Looking over the Figma spec, it seems that there were 2 locations where the logo should have been linked that were missed on the first pass (These were not part of the 'Done Criteria', which has now been updated to match the Figma spec).

As well, I noticed a property nesting error on the base route handling when checking for clinic properties, which is fixed here.

[WEB-1209]: https://tidepool.atlassian.net/browse/WEB-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ