### PR TITLE
[WEB-1295] Fix for conflicts between clinic invites and patients state

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -123,9 +123,7 @@ export const ClinicPatients = (props) => {
   }, [loggedInUserId, clinic?.id, patientFetchOptions]);
 
   function clinicPatients() {
-    const filteredPatients = filter(values(clinic?.patients), patient => !isEmpty(patient.id));
-
-    return map(filteredPatients, patient => ({
+    return map(values(clinic?.patients), patient => ({
         fullName: patient.fullName,
         link: `/patients/${patient.id}/data`,
         birthDate: patient.birthDate,

--- a/app/pages/clinicworkspace/clinicworkspace.js
+++ b/app/pages/clinicworkspace/clinicworkspace.js
@@ -28,7 +28,7 @@ export const ClinicWorkspace = (props) => {
   const { fetchingPatientInvites } = useSelector((state) => state.blip.working);
   const clinics = useSelector((state) => state.blip.clinics);
   const clinic = get(clinics, selectedClinicId);
-  const patientInvites = filter(values(clinic?.patients), patient => patient.status === 'pending');
+  const patientInvites = values(clinic?.patientInvites);
 
   const tabIndices = {
     patients: 0,

--- a/app/pages/share/PatientInvites.js
+++ b/app/pages/share/PatientInvites.js
@@ -115,16 +115,12 @@ export const PatientInvites = (props) => {
 
   useEffect(() => {
     if (clinic) {
-      const patientInvites = filter(values(clinic?.patients), patient => patient.status === 'pending');
-
-      const invites = map(patientInvites, invite => ({
+      setPendingInvites(map(values(clinic?.patientInvites), invite => ({
         key: invite.key,
         name: get(invite, 'creator.profile.fullName', ''),
         nameOrderable: get(invite, 'creator.profile.fullName', '').toLowerCase(),
         birthday: get(invite, 'creator.profile.patient.birthday', ''),
-      }));
-
-      setPendingInvites(invites);
+      })));
     }
   }, [clinic]);
 
@@ -184,7 +180,7 @@ export const PatientInvites = (props) => {
       <Button
         className="decline-invite"
         onClick={() => handleDecline(member)}
-        processing={deletingPatientInvitation.inProgress}
+        processing={deletingPatientInvitation.inProgress && member.key === selectedInvitation.key}
         variant="secondary"
       >
         {t('Decline')}
@@ -196,7 +192,7 @@ export const PatientInvites = (props) => {
           setSelectedInvitation(member);
           handleAccept(member);
         }}
-        processing={acceptingPatientInvitation.inProgress}
+        processing={acceptingPatientInvitation.inProgress && member.key === selectedInvitation.key}
         variant="primary"
         color="purpleMedium"
         bg="white"

--- a/app/pages/share/PatientInvites.js
+++ b/app/pages/share/PatientInvites.js
@@ -82,9 +82,6 @@ export const PatientInvites = (props) => {
     handleAsyncResult(acceptingPatientInvitation, t('Patient invitation for {{name}} has been accepted.', {
       name: selectedInvitation?.name,
     }));
-
-    // Refetch clinic patients to include newly-accepeted invitation
-    if (acceptingPatientInvitation.completed) dispatch(actions.async.fetchPatientsForClinic(api, clinic?.id));
   }, [acceptingPatientInvitation]);
 
   useEffect(() => {

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -2230,7 +2230,7 @@ export function fetchPatientInvites(api, clinicId) {
           createActionError(ErrorMessages.ERR_FETCHING_PATIENT_INVITES, err), err
         ));
       } else {
-        dispatch(sync.fetchPatientInvitesSuccess(invites));
+        dispatch(sync.fetchPatientInvitesSuccess(clinicId, invites));
       }
     });
   };

--- a/app/redux/actions/sync.js
+++ b/app/redux/actions/sync.js
@@ -1678,10 +1678,11 @@ export function fetchPatientInvitesRequest() {
   };
 }
 
-export function fetchPatientInvitesSuccess(invites) {
+export function fetchPatientInvitesSuccess(clinicId, invites) {
   return {
     type: ActionTypes.FETCH_PATIENT_INVITES_SUCCESS,
     payload: {
+      clinicId: clinicId,
       invites: invites,
     },
   };

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -666,21 +666,10 @@ export const clinics = (state = initialState.clinics, action) => {
   switch (action.type) {
     case types.GET_CLINICS_SUCCESS: {
       let clinics = _.get(action.payload, 'clinics', []);
-      const options = _.get(action.payload, 'options', {});
-      const clinicians = {
-        clinicians: !_.isUndefined(options.clinicianId)
-          ? { [options.clinicianId]: {} }
-          : {},
-      };
-      const patients = {
-        patients: !_.isUndefined(options.patientId)
-          ? { [options.patientId]: {} }
-          : {},
-      };
       const newClinics = _.reduce(
         clinics,
         (newSet, clinic) => {
-          newSet[clinic.id] = { ...clinicians, ...patients, ...clinic };
+          newSet[clinic.id] = { clinicians: {}, patients: {}, patientInvites: {}, ...clinic };
           return newSet;
         },
         {}
@@ -699,12 +688,12 @@ export const clinics = (state = initialState.clinics, action) => {
     }
     case types.FETCH_PATIENT_INVITES_SUCCESS: {
       const invites = _.get(action.payload, 'invites', []);
-      const clinicId = _.get(action.payload, 'invites.0.clinicId', '');
+      const clinicId = _.get(action.payload, 'clinicId');
       const newClinics = _.cloneDeep(state);
       _.forEach(invites, (invite) => {
         _.set(
           newClinics,
-          [clinicId, 'patients', invite.key],
+          [clinicId, 'patientInvites', invite.key],
           invite
         );
       });
@@ -714,26 +703,26 @@ export const clinics = (state = initialState.clinics, action) => {
       let inviteId = _.get(action.payload, 'inviteId');
       let clinicId = _.get(action.payload, 'clinicId');
       let newState = _.cloneDeep(state);
-      delete newState[clinicId]?.patients?.[inviteId];
+      delete newState[clinicId]?.patientInvites?.[inviteId];
       return newState;
     }
     case types.DELETE_PATIENT_INVITATION_SUCCESS: {
       let inviteId = _.get(action.payload, 'inviteId');
       let clinicId = _.get(action.payload, 'clinicId');
       let newState = _.cloneDeep(state);
-      delete newState[clinicId]?.patients?.[inviteId];
+      delete newState[clinicId]?.patientInvites?.[inviteId];
       return newState;
     }
     case types.CREATE_CLINIC_SUCCESS: {
       let clinic = _.get(action.payload, 'clinic', {});
       return update(state, {
-        [clinic.id]: { $set: { clinicians: {}, patients: {} } },
+        [clinic.id]: { $set: { clinicians: {}, patients: {}, patientInvites: {} } },
       });
     }
     case types.FETCH_CLINIC_SUCCESS: {
       let clinic = _.get(action.payload, 'clinic', {});
       return update(state, {
-        [clinic.id]: { $set: { clinicians: {}, patients: {}, ...clinic } },
+        [clinic.id]: { $set: { clinicians: {}, patients: {}, patientInvites: {}, ...clinic } },
       });
     }
     case types.FETCH_CLINICS_BY_IDS_SUCCESS: {

--- a/test/unit/pages/share/PatientInvites.test.js
+++ b/test/unit/pages/share/PatientInvites.test.js
@@ -120,7 +120,7 @@ describe('PatientInvites', () => {
           clinicians:{
             clinicianUserId123,
           },
-          patients: {
+          patientInvites: {
             invite1: {
               key: 'invite1',
               status: 'pending',

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -6001,7 +6001,7 @@ describe('Actions', () => {
 
         let expectedActions = [
           { type: 'FETCH_PATIENT_INVITES_REQUEST' },
-          { type: 'FETCH_PATIENT_INVITES_SUCCESS', payload: { invites } }
+          { type: 'FETCH_PATIENT_INVITES_SUCCESS', payload: { clinicId, invites } }
         ];
         _.each(expectedActions, (action) => {
           expect(isTSA(action)).to.be.true;

--- a/test/unit/redux/actions/sync.test.js
+++ b/test/unit/redux/actions/sync.test.js
@@ -3172,14 +3172,16 @@ describe('Actions', () => {
 
     describe('fetchPatientInvitesSuccess', () => {
       let invites = ['inviteid', 'inviteid2']
+      let clinicId = 'clinic123';
       it('should be a TSA', () => {
-        let action = sync.fetchPatientInvitesSuccess(invites);
+        let action = sync.fetchPatientInvitesSuccess(clinicId, invites);
         expect(isTSA(action)).to.be.true;
       });
 
       it('type should equal FETCH_PATIENT_INVITES_SUCCESS', () => {
-        let action = sync.fetchPatientInvitesSuccess(invites);
+        let action = sync.fetchPatientInvitesSuccess(clinicId, invites);
         expect(action.type).to.equal('FETCH_PATIENT_INVITES_SUCCESS');
+        expect(action.payload.clinicId).to.equal(clinicId);
         expect(action.payload.invites).to.equal(invites);
       });
     });

--- a/test/unit/redux/reducers/clinics.test.js
+++ b/test/unit/redux/reducers/clinics.test.js
@@ -16,16 +16,14 @@ describe('clinics', () => {
     it('should set clinics to state for clinician', () => {
       let initialStateForTest = {};
       let clinics = [{ id: 'clinicId123' }];
-      let options = { clinicianId: 'clinicianId' };
-      let action = actions.sync.getClinicsSuccess(clinics, options);
+      let action = actions.sync.getClinicsSuccess(clinics);
       let state = reducer(initialStateForTest, action);
       expect(state).to.eql({
         clinicId123: {
           id: 'clinicId123',
-          clinicians: {
-            clinicianId: {},
-          },
+          clinicians: {},
           patients: {},
+          patientInvites: {},
         },
       });
     });
@@ -33,16 +31,14 @@ describe('clinics', () => {
     it('should set clinics to state for patient', () => {
       let initialStateForTest = {};
       let clinics = [{ id: 'clinicId123' }];
-      let options = { patientId: 'patientId' };
-      let action = actions.sync.getClinicsSuccess(clinics, options);
+      let action = actions.sync.getClinicsSuccess(clinics);
       let state = reducer(initialStateForTest, action);
       expect(state).to.eql({
         clinicId123: {
           id: 'clinicId123',
           clinicians: {},
-          patients: {
-            patientId: {},
-          },
+          patients: {},
+          patientInvites: {},
         },
       });
     });
@@ -57,6 +53,58 @@ describe('clinics', () => {
       let action = actions.sync.fetchPatientsForClinicSuccess(clinicId, patients);
       let state = reducer(initialStateForTest, action);
       expect(state[clinic.id].patients.patientId123).to.eql({ id: 'patientId123' });
+    });
+  });
+
+  describe('fetchPatientInvitesSuccess', () => {
+    it('should add patient invites to a clinic', () => {
+      let initialStateForTest = {};
+      let clinicId = 'clinicId123';
+      let clinic = { id: clinicId };
+      let patientInvites = [{ key: 'patientId123' }];
+      let action = actions.sync.fetchPatientInvitesSuccess(clinicId, patientInvites);
+      let state = reducer(initialStateForTest, action);
+      expect(state[clinic.id].patientInvites.patientId123).to.eql({ key: 'patientId123' });
+    });
+  });
+
+  describe('acceptPatientInvitationSuccess', () => {
+    it('should remove the patient invites from a clinic', () => {
+      let initialStateForTest = {
+        clinicId123: {
+          patientInvites: {
+            patientId123: { key: 'patientId123' },
+            patientId456: { key: 'patientId456' },
+          },
+        },
+      };
+      let clinicId = 'clinicId123';
+      let clinic = { id: clinicId };
+      let inviteId = 'patientId123';
+      let action = actions.sync.acceptPatientInvitationSuccess(clinicId, inviteId);
+      let state = reducer(initialStateForTest, action);
+      expect(state[clinic.id].patientInvites.patientId123).to.be.undefined;
+      expect(state[clinic.id].patientInvites.patientId456).to.eql({ key: 'patientId456' });
+    });
+  });
+
+  describe('deletePatientInvitationSuccess', () => {
+    it('should remove the patient invites from a clinic', () => {
+      let initialStateForTest = {
+        clinicId123: {
+          patientInvites: {
+            patientId123: { key: 'patientId123' },
+            patientId456: { key: 'patientId456' },
+          },
+        },
+      };
+      let clinicId = 'clinicId123';
+      let clinic = { id: clinicId };
+      let inviteId = 'patientId123';
+      let action = actions.sync.deletePatientInvitationSuccess(clinicId, inviteId);
+      let state = reducer(initialStateForTest, action);
+      expect(state[clinic.id].patientInvites.patientId123).to.be.undefined;
+      expect(state[clinic.id].patientInvites.patientId456).to.eql({ key: 'patientId456' });
     });
   });
 


### PR DESCRIPTION
Fixes [WEB-1295].  

Not sure why, but originally , the clinic's accepted patients and invitations were stored in the same clinic property in redux state.  This was causing collisions with the updated API.

They are now stored in a `patientInvites` property of a clinic.

Added a few missing redux tests around clinic patient invites as well.

[WEB-1295]: https://tidepool.atlassian.net/browse/WEB-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ