### PR TITLE
[WEB-1291] Remove private workspace link

### DIFF
--- a/app/components/navbar/NavigationMenu.js
+++ b/app/components/navbar/NavigationMenu.js
@@ -84,8 +84,6 @@ export const NavigationMenu = props => {
     if (isClinicProfileFormPath) {
       setMenuOptions([logoutOption]);
     } else if (userClinics.length) {
-      const hidePrivateWorkspaceOption = !hasPatientProfile && !membershipInOtherCareTeams.length;
-
       const options = [
         ...map(userClinics, clinic => ({
           action: handleSelectWorkspace.bind(null, clinic.id),
@@ -94,14 +92,10 @@ export const NavigationMenu = props => {
           metric: ['Clinic - Menu - Go to clinic workspace', { clinicId: clinic.id }],
         })),
         manageWorkspacesOption,
-      ];
-
-      if (!hidePrivateWorkspaceOption) options.push(privateWorkspaceOption);
-
-      options.push(...[
+        privateWorkspaceOption,
         accountSettingsOption,
         logoutOption,
-      ]);
+      ];
 
       setMenuOptions(options);
     }

--- a/app/pages/workspaces/workspaces.js
+++ b/app/pages/workspaces/workspaces.js
@@ -327,25 +327,6 @@ export const Workspaces = (props) => {
               {map(workspaces, RenderClinicWorkspace)}
             </Box>
           </Box>
-
-          <Flex id="private-workspace" justifyContent={['center', 'left']} flexWrap={['wrap']}>
-            <Body1
-              width={['100%', '100%', 'auto']}
-              textAlign={['center', 'center', 'auto']}
-              pb={[2, 3, 0]}
-            >
-              {t('Want to use Tidepool for your private data?')}
-            </Body1>
-            <Button
-              width={['100%', '100%', 'auto']}
-              variant='textPrimary'
-              fontSize={'1'}
-              py={0}
-              onClick={handleGoToWorkspace}
-            >
-              {t('Go To Private Workspace')}
-            </Button>
-          </Flex>
         </Box>
       </Box>
       <Dialog

--- a/test/unit/components/navbar/NavigationMenu.test.js
+++ b/test/unit/components/navbar/NavigationMenu.test.js
@@ -244,11 +244,12 @@ describe('NavigationMenu', () => {
       expect(menuTrigger.text()).to.equal('Example Clinic');
 
       const menuOptions = wrapper.find('Button.navigation-menu-option');
-      expect(menuOptions).to.have.lengthOf(4);
+      expect(menuOptions).to.have.lengthOf(5);
       expect(menuOptions.at(0).text()).to.equal('new_clinic_name Workspace');
       expect(menuOptions.at(1).text()).to.equal('Manage Workspaces');
-      expect(menuOptions.at(2).text()).to.equal('Account Settings');
-      expect(menuOptions.at(3).text()).to.equal('Logout');
+      expect(menuOptions.at(2).text()).to.equal('Private Workspace');
+      expect(menuOptions.at(3).text()).to.equal('Account Settings');
+      expect(menuOptions.at(4).text()).to.equal('Logout');
 
       // Click clinic workspace option
       store.clearActions();
@@ -284,9 +285,29 @@ describe('NavigationMenu', () => {
         },
       ]);
 
-      // Click account settings option
+      // Click private workspace option
       store.clearActions();
       menuOptions.at(2).simulate('click');
+
+      expect(store.getActions()).to.eql([
+        {
+          type: 'SELECT_CLINIC',
+          payload: {
+            clinicId: null,
+          },
+        },
+        {
+          type: '@@router/CALL_HISTORY_METHOD',
+          payload: {
+            args: ['/patients'],
+            method: 'push',
+          },
+        },
+      ]);
+
+      // Click account settings option
+      store.clearActions();
+      menuOptions.at(3).simulate('click');
 
       expect(store.getActions()).to.eql([
         {
@@ -300,7 +321,7 @@ describe('NavigationMenu', () => {
 
       // Click logout option
       store.clearActions();
-      menuOptions.at(3).simulate('click');
+      menuOptions.at(4).simulate('click');
 
       expect(store.getActions()).to.eql([
         {

--- a/test/unit/pages/workspaces/workspaces.test.js
+++ b/test/unit/pages/workspaces/workspaces.test.js
@@ -339,32 +339,5 @@ describe('Workspaces', () => {
         },
       ]);
     });
-
-    it('should render a button to navigate to a private workspace', () => {
-      const privateWorkspace = wrapper.find('#private-workspace').hostNodes();
-      expect(privateWorkspace).to.have.lengthOf(1);
-      const privateWorkspaceCTA = privateWorkspace.find('button');
-      expect(privateWorkspaceCTA).to.have.lengthOf(1);
-      expect(privateWorkspaceCTA.text()).to.equal('Go To Private Workspace');
-
-      store.clearActions();
-      privateWorkspaceCTA.simulate('click');
-
-      expect(store.getActions()).to.eql([
-        {
-          type: 'SELECT_CLINIC',
-          payload: {
-            clinicId: null,
-          },
-        },
-        {
-          type: '@@router/CALL_HISTORY_METHOD',
-          payload: {
-            args: ['/patients'],
-            method: 'push',
-          },
-        },
-      ]);
-    });
   });
 });


### PR DESCRIPTION
See [WEB-1291].  Since this removes the link from the workspaces page, we need a way to still access the private workspace, the link now always shows in the top navigation menu

As well, this includes a small fix for the fallback routing based on whether or not a user is in a clinic workflow.

[WEB-1291]: https://tidepool.atlassian.net/browse/WEB-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ