### PR TITLE
[WEB-1301] Fix for missing profile page custodial permissions

### DIFF
--- a/app/components/clinic/WorkspaceSwitcher.js
+++ b/app/components/clinic/WorkspaceSwitcher.js
@@ -72,7 +72,7 @@ export const WorkspaceSwitcher = props => {
 
       setMenuOptions(options);
     }
-  }, [clinics]);
+  }, [clinics, membershipInOtherCareTeams, hasPatientProfile]);
 
   const handleSelect = option => {
     trackMetric(...option.metric);

--- a/app/components/clinic/WorkspaceSwitcher.js
+++ b/app/components/clinic/WorkspaceSwitcher.js
@@ -103,7 +103,7 @@ export const WorkspaceSwitcher = props => {
           </Button>
 
           <Popover
-            width="15em"
+            minWidth="15em"
             anchorOrigin={{
               vertical: 'bottom',
               horizontal: 'center',

--- a/app/components/elements/Popover.js
+++ b/app/components/elements/Popover.js
@@ -14,6 +14,7 @@ const StyledPopover = styled(Base)`
     box-shadow: ${shadows.large};
     border-radius: ${radii.default}px;
     width: ${({ width }) => width};
+    min-width: ${({ minWidth }) => minWidth};
     max-width: calc(100% - ${space[5]}px);
   }
 `;

--- a/app/components/navbar/NavigationMenu.js
+++ b/app/components/navbar/NavigationMenu.js
@@ -135,7 +135,7 @@ export const NavigationMenu = props => {
       </Button>
 
       <Popover
-        width="15em"
+        minWwidth="15em"
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'center',

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1855,9 +1855,21 @@ export function mapStateToProps(state, props) {
       }
       // otherwise, we need to pull the perms of the loggedInUser wrt the patient in view from membershipPermissionsInOtherCareTeams
       else {
-        if (!_.isEmpty(state.blip.membershipPermissionsInOtherCareTeams)) {
-          permsOfLoggedInUser = state.blip.membershipPermissionsInOtherCareTeams[state.blip.currentPatientInViewId];
-        }
+        permsOfLoggedInUser = state.blip.selectedClinicId
+        ? _.get(
+          state.blip.clinics,
+          [
+            state.blip.selectedClinicId,
+            'patients',
+            state.blip.currentPatientInViewId,
+            'permissions',
+          ],
+          {}
+        ) : _.get(
+          state.blip.membershipPermissionsInOtherCareTeams,
+          state.blip.currentPatientInViewId,
+          {}
+        );
       }
     }
   }

--- a/app/pages/patientprofile/patientprofile.js
+++ b/app/pages/patientprofile/patientprofile.js
@@ -70,9 +70,21 @@ export function mapStateToProps(state) {
       }
       // otherwise, we need to pull the perms of the loggedInUser wrt the patient in view from membershipPermissionsInOtherCareTeams
       else {
-        if (!_.isEmpty(state.blip.membershipPermissionsInOtherCareTeams)) {
-          permsOfLoggedInUser = state.blip.membershipPermissionsInOtherCareTeams[state.blip.currentPatientInViewId];
-        }
+        permsOfLoggedInUser = state.blip.selectedClinicId
+        ? _.get(
+          state.blip.clinics,
+          [
+            state.blip.selectedClinicId,
+            'patients',
+            state.blip.currentPatientInViewId,
+            'permissions',
+          ],
+          {}
+        ) : _.get(
+          state.blip.membershipPermissionsInOtherCareTeams,
+          state.blip.currentPatientInViewId,
+          {}
+        );
       }
     }
   }

--- a/app/pages/patientprofile/patientprofile.js
+++ b/app/pages/patientprofile/patientprofile.js
@@ -22,9 +22,8 @@ export function getFetchers(dispatchProps, ownProps, stateProps, api) {
 
   if (!stateProps.fetchingAssociatedAccounts.inProgress && !stateProps.fetchingAssociatedAccounts.completed) {
     // Need fetchAssociatedAccounts here because the result includes of data donation accounts sharing info
-    if (_.get(stateProps, 'user.userid') === _.get(ownProps, 'match.params.id') ) {
-      fetchers.push(dispatchProps.fetchAssociatedAccounts.bind(null, api));
-    }
+    // and permissions for the patients in a care team
+    fetchers.push(dispatchProps.fetchAssociatedAccounts.bind(null, api));
   }
 
   return fetchers;

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -2061,7 +2061,7 @@ export function fetchPatientFromClinic(api, clinicId, patientId) {
           createActionError(ErrorMessages.ERR_FETCHING_PATIENT_FROM_CLINIC, err), err
         ));
       } else {
-        dispatch(sync.fetchPatientFromClinicSuccess(patient));
+        dispatch(sync.fetchPatientFromClinicSuccess(clinicId, patient));
       }
     });
   };

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -271,8 +271,8 @@ export function login(api, credentials, options, postLoginAction) {
                   } else if (values.clinics?.length) {
                     const clinicMigration = _.find(values.clinics, clinic => _.isEmpty(clinic.clinic?.name) || clinic.clinic?.canMigrate);
 
-                    if (!clinicMigration && values.clinics.length === 1 && !userHasPatientProfile && !values.associatedAccounts?.patients?.length) {
-                      // Go to the clinic workspace if only one clinic and no dsa/data-sharing
+                    if (!clinicMigration && values.clinics.length === 1) {
+                      // Go to the clinic workspace if only one clinic
                       setRedirectRoute(routes.clinicWorkspace);
                     } else {
                       // If we have an empty clinic object, go to clinic details, otherwise workspaces

--- a/app/redux/actions/sync.js
+++ b/app/redux/actions/sync.js
@@ -1522,10 +1522,11 @@ export function fetchPatientFromClinicRequest() {
   };
 }
 
-export function fetchPatientFromClinicSuccess(patient) {
+export function fetchPatientFromClinicSuccess(clinicId, patient) {
   return {
     type: ActionTypes.FETCH_PATIENT_FROM_CLINIC_SUCCESS,
     payload: {
+      clinicId: clinicId,
       patient: patient,
     },
   };

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -686,6 +686,15 @@ export const clinics = (state = initialState.clinics, action) => {
         [clinicId]: { $set: { ...state[clinicId], patients: newPatientSet, patientCount: count } },
       });
     }
+    case types.FETCH_PATIENT_FROM_CLINIC_SUCCESS: {
+      let { clinicId, patient } = action.payload;
+      return update(state, {
+        [clinicId]: { patients: { $set: {
+          ...state[clinicId].patients,
+          [patient.id]: patient
+        } } }
+      });
+    }
     case types.FETCH_PATIENT_INVITES_SUCCESS: {
       const invites = _.get(action.payload, 'invites', []);
       const clinicId = _.get(action.payload, 'clinicId');

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -5546,7 +5546,6 @@ describe('Actions', () => {
         let clinicId = '5f85fbe6686e6bb9170ab5d0';
         let patientId = 'patient_clinic_relationship_id';
         let patient = {
-          clinicId,
           id: patientId,
           patientId: patientUserId,
         }
@@ -5560,7 +5559,8 @@ describe('Actions', () => {
         let expectedActions = [
           { type: 'FETCH_PATIENT_FROM_CLINIC_REQUEST' },
           { type: 'FETCH_PATIENT_FROM_CLINIC_SUCCESS', payload: {
-            patient
+            patient,
+            clinicId,
           } }
         ];
         _.each(expectedActions, (action) => {

--- a/test/unit/redux/actions/sync.test.js
+++ b/test/unit/redux/actions/sync.test.js
@@ -2911,16 +2911,18 @@ describe('Actions', () => {
     });
 
     describe('fetchPatientFromClinicSuccess', () => {
-      let patient = {clinicId: 'clinicId', patientId: 'patientId', id: 'patientUserId'};
+      let patient = { id: 'patientUserId' };
+      let clinicId = { id: 'clinicId' };
 
       it('should be a TSA', () => {
-        let action = sync.fetchPatientFromClinicSuccess(patient);
+        let action = sync.fetchPatientFromClinicSuccess(clinicId, patient);
         expect(isTSA(action)).to.be.true;
       });
 
       it('type should equal FETCH_PATIENT_FROM_CLINIC_SUCCESS', () => {
-        let action = sync.fetchPatientFromClinicSuccess(patient);
+        let action = sync.fetchPatientFromClinicSuccess(clinicId, patient);
         expect(action.type).to.equal('FETCH_PATIENT_FROM_CLINIC_SUCCESS');
+        expect(action.payload.clinicId).to.equal(clinicId);
         expect(action.payload.patient).to.equal(patient);
       });
     });


### PR DESCRIPTION
See [WEB-1301] for details.

I also noticed a couple of small issues that I fixed at the same time:

1. Since we no longer show the private workspace option on the 'Workspaces' page, it no longer makes sense to redirect there when a clinician is a member of only 1 clinic - even if they have an active private workspace.
2. There was a bug where the workspace switcher was sometimes not showing the private workspace option when it should.  This is now fixed

[WEB-1301]: https://tidepool.atlassian.net/browse/WEB-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ