### PR TITLE
[WEB-1210] Fix for missing and non-triggering patient removal metrics

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -235,16 +235,14 @@ export const ClinicPatients = (props) => {
 
   function handleRemove(patient) {
     return () => {
-      if (props.selectedClinicId) {
-        trackMetric('Clinic - Remove patient', { clinicId: props.selectedClinicId });
-      }
-
+      trackMetric('Clinic - Remove patient', { clinicId: selectedClinicId });
       setSelectedPatient(patient);
       setShowDeleteDialog(true);
     };
   }
 
   function handleRemovePatient() {
+    trackMetric('Clinic - Remove patient confirmed', { clinicId: selectedClinicId });
     dispatch(actions.async.deletePatientFromClinic(api, selectedClinicId, selectedPatient?.id));
   }
 

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -215,6 +215,7 @@ describe('ClinicPatients', () => {
     context('show names clicked', () => {
       beforeEach(() => {
         wrapper.find('button#patients-view-toggle').simulate('click');
+        defaultProps.trackMetric.resetHistory();
       });
 
       it('should render a list of patients', () => {
@@ -319,6 +320,9 @@ describe('ClinicPatients', () => {
         wrapper.update();
         expect(wrapper.find(Dialog).props().open).to.be.true;
 
+        expect(defaultProps.trackMetric.calledWith('Clinic - Remove patient')).to.be.true;
+        expect(defaultProps.trackMetric.callCount).to.equal(1);
+
         const confirmRemoveButton = wrapper.find(Dialog).find('Button#patientRemoveConfirm');
         expect(confirmRemoveButton.text()).to.equal('Remove');
 
@@ -330,6 +334,9 @@ describe('ClinicPatients', () => {
         ]);
 
         sinon.assert.calledWith(defaultProps.api.clinics.deletePatientFromClinic, 'clinicID123', 'patient1');
+
+        expect(defaultProps.trackMetric.calledWith('Clinic - Remove patient confirmed')).to.be.true;
+        expect(defaultProps.trackMetric.callCount).to.equal(2);
       });
 
       it('should refetch patients with updated sort parameter when name or birthday headers are clicked', () => {


### PR DESCRIPTION
Addresses some QA feedback for [WEB-1210]

[WEB-1210]: https://tidepool.atlassian.net/browse/WEB-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ