### PR TITLE
[WEB-1204, WEB-1182] Stat updates

### DIFF
--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -128,8 +128,9 @@ class Basics extends Component {
                   chartPrefs={this.props.chartPrefs}
                   chartType={this.chartType}
                   devices={_.get(this.props, 'data.metaData.devices', [])}
-                  updateChartPrefs={this.props.updateChartPrefs}
                   removeGeneratedPDFS={this.props.removeGeneratedPDFS}
+                  trackMetric={this.props.trackMetric}
+                  updateChartPrefs={this.props.updateChartPrefs}
                 />
               </div>
             </div>

--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -120,6 +120,7 @@ class Basics extends Component {
                 <Stats
                   bgPrefs={_.get(this.props, 'data.bgPrefs', {})}
                   chartPrefs={this.props.chartPrefs}
+                  chartType={this.chartType}
                   stats={statsToRender}
                 />
                 <DeviceSelection

--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -122,6 +122,7 @@ class Basics extends Component {
                   chartPrefs={this.props.chartPrefs}
                   chartType={this.chartType}
                   stats={statsToRender}
+                  trackMetric={this.props.trackMetric}
                 />
                 <DeviceSelection
                   chartPrefs={this.props.chartPrefs}

--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -261,8 +261,9 @@ class BgLog extends Component {
                 chartPrefs={this.props.chartPrefs}
                 chartType={this.chartType}
                 devices={_.get(this.props, 'data.metaData.devices', [])}
-                updateChartPrefs={this.props.updateChartPrefs}
                 removeGeneratedPDFS={this.props.removeGeneratedPDFS}
+                trackMetric={this.props.trackMetric}
+                updateChartPrefs={this.props.updateChartPrefs}
               />
             </div>
           </div>

--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -255,6 +255,7 @@ class BgLog extends Component {
                 chartPrefs={this.props.chartPrefs}
                 chartType={this.chartType}
                 stats={this.props.stats}
+                trackMetric={this.props.trackMetric}
               />
               <DeviceSelection
                 chartPrefs={this.props.chartPrefs}

--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -253,6 +253,7 @@ class BgLog extends Component {
               <Stats
                 bgPrefs={_.get(this.props, 'data.bgPrefs', {})}
                 chartPrefs={this.props.chartPrefs}
+                chartType={this.chartType}
                 stats={this.props.stats}
               />
               <DeviceSelection

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -328,8 +328,9 @@ class Daily extends Component {
                 chartPrefs={this.props.chartPrefs}
                 chartType={this.chartType}
                 devices={_.get(this.props, 'data.metaData.devices', [])}
-                updateChartPrefs={this.props.updateChartPrefs}
                 removeGeneratedPDFS={this.props.removeGeneratedPDFS}
+                trackMetric={this.props.trackMetric}
+                updateChartPrefs={this.props.updateChartPrefs}
               />
             </div>
           </div>

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -320,6 +320,7 @@ class Daily extends Component {
               <Stats
                 bgPrefs={bgPrefs}
                 chartPrefs={this.props.chartPrefs}
+                chartType={this.chartType}
                 stats={this.props.stats}
               />
               <DeviceSelection

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -322,6 +322,7 @@ class Daily extends Component {
                 chartPrefs={this.props.chartPrefs}
                 chartType={this.chartType}
                 stats={this.props.stats}
+                trackMetric={this.props.trackMetric}
               />
               <DeviceSelection
                 chartPrefs={this.props.chartPrefs}

--- a/app/components/chart/deviceSelection.js
+++ b/app/components/chart/deviceSelection.js
@@ -48,15 +48,17 @@ export const DeviceSelection = (props) => {
         </Flex>
       }
       children={map(devices, ({id, label}) => (
-        <Checkbox
-          checked={!includes(excludedDevices, id)}
-          onChange={toggleDevice}
-          label={label || id}
-          name={`${id}-toggle`}
-          value={id}
-          key={id}
-          themeProps={{ color: colors.stat.text }}
-        />
+        <Box mb={1}>
+          <Checkbox
+            checked={!includes(excludedDevices, id)}
+            onChange={toggleDevice}
+            label={label || id}
+            name={`${id}-toggle`}
+            value={id}
+            key={id}
+            themeProps={{ color: colors.stat.text }}
+          />
+        </Box>
       ))}
       onChange={handleCollapse}
       square={false}
@@ -106,6 +108,8 @@ export const DeviceSelection = (props) => {
         panel: {
           style: {
             flexDirection: 'column',
+            paddingTop: '8px',
+            paddingBottom: '4px',
           },
         },
       }}

--- a/app/components/chart/deviceSelection.js
+++ b/app/components/chart/deviceSelection.js
@@ -6,9 +6,18 @@ import Checkbox from '../elements/Checkbox';
 import { Box, Flex } from 'rebass/styled-components';
 
 import { colors, fontSizes } from '../../themes/baseTheme';
+import utils from '../../core/utils';
 
 export const DeviceSelection = (props) => {
-  const { chartPrefs,  devices = [], updateChartPrefs, removeGeneratedPDFS } = props;
+  const {
+    chartPrefs,
+    chartType,
+    devices = [],
+    removeGeneratedPDFS,
+    trackMetric,
+    updateChartPrefs,
+  } = props;
+
   const excludedDevices = get(chartPrefs, 'excludedDevices', []);
 
   const toggleDevice = (e) => {
@@ -20,9 +29,14 @@ export const DeviceSelection = (props) => {
       prefs.excludedDevices = union(prefs.excludedDevices, [e.target.value]);
     }
 
+    trackMetric(`Clicked ${utils.readableChartName(chartType)} filter device ${e.target.checked ? 'on' : 'off'}`);
     updateChartPrefs(prefs, true, true);
     removeGeneratedPDFS();
   };
+
+  const handleCollapse = (e, expanded) => {
+    trackMetric(`Click ${expanded ? 'expanded' : 'collapsed'} - ${utils.readableChartName(chartType)} - Filter devices`);
+  }
 
   return (
     <Accordion
@@ -44,6 +58,7 @@ export const DeviceSelection = (props) => {
           themeProps={{ color: colors.stat.text }}
         />
       ))}
+      onChange={handleCollapse}
       square={false}
       themeProps={{
         wrapper: {
@@ -102,6 +117,7 @@ DeviceSelection.propTypes = {
   chartPrefs: PropTypes.shape({
     excludedDevices: PropTypes.array,
   }),
+  chartType: PropTypes.string.isRequired,
   devices: PropTypes.arrayOf(
     PropTypes.shape({
       bgm: PropTypes.bool,
@@ -113,6 +129,7 @@ DeviceSelection.propTypes = {
     }
   )),
   removeGeneratedPDFS: PropTypes.func.isRequired,
+  trackMetric: PropTypes.func.isRequired,
   updateChartPrefs: PropTypes.func.isRequired,
 };
 

--- a/app/components/chart/stats.js
+++ b/app/components/chart/stats.js
@@ -4,23 +4,9 @@ import get from 'lodash/get';
 import map from 'lodash/map';
 import { components as vizComponents } from '@tidepool/viz';
 import { useLocalStorage } from '../../core/hooks';
+import utils from '../../core/utils';
 
 const { Stat } = vizComponents;
-
-export const readableStatName = statId => ({
-  readingsInRange: 'Readings in range',
-  timeInAuto: 'Time in automation',
-  timeInOverride: 'Time in activity',
-  timeInRange: 'Time in range',
-  totalInsulin: 'Insulin ratio',
-}[statId] || statId);
-
-export const readableChartName = chartType => ({
-  basics: 'Basics',
-  bgLog: 'BG log',
-  daily: 'Daily',
-  trends: 'Trends',
-}[chartType] || chartType);
 
 const Stats = (props) => {
   const {
@@ -44,7 +30,7 @@ const Stats = (props) => {
         }
       });
 
-      trackMetric(`Click ${collapsed ? 'collapsed' : 'expanded'} - ${readableChartName(chartType)} - ${readableStatName(id)}`);
+      trackMetric(`Click ${collapsed ? 'collapsed' : 'expanded'} - ${utils.readableChartName(chartType)} - ${utils.readableStatName(id)}`);
     }
   }
 

--- a/app/components/chart/stats.js
+++ b/app/components/chart/stats.js
@@ -1,35 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import get from 'lodash/get';
+import map from 'lodash/map';
 import { components as vizComponents } from '@tidepool/viz';
 import { useLocalStorage } from '../../core/hooks';
 
 const { Stat } = vizComponents;
+
+export const readableStatName = statId => ({
+  readingsInRange: 'Readings in range',
+  timeInAuto: 'Time in automation',
+  timeInOverride: 'Time in activity',
+  timeInRange: 'Time in range',
+  totalInsulin: 'Insulin ratio',
+}[statId] || statId);
+
+export const readableChartName = chartType => ({
+  basics: 'Basics',
+  bgLog: 'BG log',
+  daily: 'Daily',
+  trends: 'Trends',
+}[chartType] || chartType);
 
 const Stats = (props) => {
   const {
     bgPrefs,
     chartPrefs,
     chartType,
-    stats,
     persistState,
+    stats,
+    trackMetric,
   } = props;
 
   const [statsCollapsedState, setStatsCollapsedState] = useLocalStorage('statsCollapsedState', {});
 
   function handleCollapse (id, collapsed) {
-    if (persistState) setStatsCollapsedState({
-      ...statsCollapsedState,
-      [chartType]: {
-        ...statsCollapsedState[chartType],
-        [id]: collapsed,
-      }
-    });
+    if (persistState) {
+      setStatsCollapsedState({
+        ...statsCollapsedState,
+        [chartType]: {
+          ...statsCollapsedState[chartType],
+          [id]: collapsed,
+        }
+      });
+
+      trackMetric(`Click ${collapsed ? 'collapsed' : 'expanded'} - ${readableChartName(chartType)} - ${readableStatName(id)}`);
+    }
   }
 
   return (
     <div className="Stats">
-      {_.map(stats, stat => (
+      {map(stats, stat => (
         <div id={`Stat--${stat.id}`} key={stat.id}>
           <Stat
             animate={chartPrefs.animateStats}
@@ -38,7 +59,7 @@ const Stats = (props) => {
             isOpened={stat.collapsible ? !statsCollapsedState[chartType]?.[stat.id] : true}
             {...stat}
             title={stat.collapsible && statsCollapsedState[chartType]?.[stat.id]
-              ? _.get(stat, 'collapsedTitle', stat.title)
+              ? get(stat, 'collapsedTitle', stat.title)
               : stat.title
             }
           />
@@ -54,6 +75,7 @@ Stats.propTypes = {
   chartType: PropTypes.string,
   persistState: PropTypes.bool,
   stats: PropTypes.array.isRequired,
+  trackMetric: PropTypes.func.isRequired,
 };
 
 Stats.defaultProps = {

--- a/app/components/chart/stats.js
+++ b/app/components/chart/stats.js
@@ -27,25 +27,23 @@ const Stats = (props) => {
     });
   }
 
-  const renderStats = (stats, animate) => (_.map(stats, stat => (
-    <div id={`Stat--${stat.id}`} key={stat.id}>
-      <Stat
-        animate={animate}
-        bgPrefs={bgPrefs}
-        onCollapse={handleCollapse.bind(null, stat.id)}
-        isOpened={stat.collapsible ? !statsCollapsedState[chartType]?.[stat.id] : true}
-        {...stat}
-        title={stat.collapsible && statsCollapsedState[chartType]?.[stat.id]
-          ? _.get(stat, 'collapsedTitle', stat.title)
-          : stat.title
-        }
-      />
-    </div>
-  )));
-
   return (
     <div className="Stats">
-      {renderStats(stats, chartPrefs.animateStats)}
+      {_.map(stats, stat => (
+        <div id={`Stat--${stat.id}`} key={stat.id}>
+          <Stat
+            animate={chartPrefs.animateStats}
+            bgPrefs={bgPrefs}
+            onCollapse={handleCollapse.bind(null, stat.id)}
+            isOpened={stat.collapsible ? !statsCollapsedState[chartType]?.[stat.id] : true}
+            {...stat}
+            title={stat.collapsible && statsCollapsedState[chartType]?.[stat.id]
+              ? _.get(stat, 'collapsedTitle', stat.title)
+              : stat.title
+            }
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/app/components/chart/stats.js
+++ b/app/components/chart/stats.js
@@ -2,25 +2,46 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { components as vizComponents } from '@tidepool/viz';
+import { useLocalStorage } from '../../core/hooks';
 
 const { Stat } = vizComponents;
 
 const Stats = (props) => {
   const {
     bgPrefs,
-    chartPrefs: { animateStats },
+    chartPrefs,
+    chartType,
     stats,
+    persistState,
   } = props;
+
+  const [statsCollapsedState, setStatsCollapsedState] = useLocalStorage('statsCollapsedState', {});
+
+  function handleCollapse (id, collapsed) {
+    if (persistState) setStatsCollapsedState({
+      ...statsCollapsedState,
+      [chartType]: {
+        ...statsCollapsedState[chartType],
+        [id]: collapsed,
+      }
+    });
+  }
 
   const renderStats = (stats, animate) => (_.map(stats, stat => (
     <div id={`Stat--${stat.id}`} key={stat.id}>
-      <Stat animate={animate} bgPrefs={bgPrefs} {...stat} />
+      <Stat
+        animate={animate}
+        bgPrefs={bgPrefs}
+        onCollapse={handleCollapse.bind(null, stat.id)}
+        isOpened={stat.collapsible ? !statsCollapsedState[chartType]?.[stat.id] : true}
+        {...stat}
+      />
     </div>
   )));
 
   return (
     <div className="Stats">
-      {renderStats(stats, animateStats)}
+      {renderStats(stats, chartPrefs.animateStats)}
     </div>
   );
 }
@@ -28,7 +49,13 @@ const Stats = (props) => {
 Stats.propTypes = {
   bgPrefs: PropTypes.object.isRequired,
   chartPrefs: PropTypes.object.isRequired,
+  chartType: PropTypes.string,
+  persistState: PropTypes.bool,
   stats: PropTypes.array.isRequired,
+};
+
+Stats.defaultProps = {
+  persistState: true,
 };
 
 export default Stats;

--- a/app/components/chart/stats.js
+++ b/app/components/chart/stats.js
@@ -35,6 +35,10 @@ const Stats = (props) => {
         onCollapse={handleCollapse.bind(null, stat.id)}
         isOpened={stat.collapsible ? !statsCollapsedState[chartType]?.[stat.id] : true}
         {...stat}
+        title={stat.collapsible && statsCollapsedState[chartType]?.[stat.id]
+          ? _.get(stat, 'collapsedTitle', stat.title)
+          : stat.title
+        }
       />
     </div>
   )));

--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -464,6 +464,7 @@ const Trends = translate()(class Trends extends PureComponent {
                 chartPrefs={this.props.chartPrefs}
                 chartType={this.chartType}
                 stats={statsToRender}
+                trackMetric={this.props.trackMetric}
               />
               <DeviceSelection
                 chartPrefs={this.props.chartPrefs}

--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -470,8 +470,9 @@ const Trends = translate()(class Trends extends PureComponent {
                 chartPrefs={this.props.chartPrefs}
                 chartType={this.chartType}
                 devices={_.get(this.props, 'data.metaData.devices', [])}
-                updateChartPrefs={this.props.updateChartPrefs}
                 removeGeneratedPDFS={this.props.removeGeneratedPDFS}
+                trackMetric={this.props.trackMetric}
+                updateChartPrefs={this.props.updateChartPrefs}
               />
             </div>
           </div>

--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -462,6 +462,7 @@ const Trends = translate()(class Trends extends PureComponent {
               <Stats
                 bgPrefs={_.get(this.props, 'data.bgPrefs', {})}
                 chartPrefs={this.props.chartPrefs}
+                chartType={this.chartType}
                 stats={statsToRender}
               />
               <DeviceSelection

--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -367,6 +367,7 @@ const Trends = translate()(class Trends extends PureComponent {
     const prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.trends.smbgRangeOverlay = prefs.trends.smbgRangeOverlay ? false : true;
     this.props.updateChartPrefs(prefs, false);
+    this.props.trackMetric(`clicked Trends range and average ${prefs.trends.smbgRangeOverlay ? 'on' : 'off'}`);
   }
 
   toggleDay(day) {
@@ -383,18 +384,29 @@ const Trends = translate()(class Trends extends PureComponent {
     const prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.trends.smbgGrouped = prefs.trends.smbgGrouped ? false : true;
     this.props.updateChartPrefs(prefs, false);
+    this.props.trackMetric(`clicked Trends group ${prefs.trends.smbgGrouped ? 'on' : 'off'}`);
   }
 
   toggleLines() {
     const prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.trends.smbgLines = prefs.trends.smbgLines ? false : true;
     this.props.updateChartPrefs(prefs, false);
+    this.props.trackMetric(`clicked Trends lines ${prefs.trends.smbgLines ? 'on' : 'off'}`);
   }
 
   toggleDisplayFlags(flag, value) {
     const prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.trends.cbgFlags[flag] = value;
     this.props.updateChartPrefs(prefs, false);
+
+    const flagMetrics = {
+      cbg100Enabled: encodeURIComponent('100% readings'),
+      cbg80Enabled: encodeURIComponent('80% readings'),
+      cbg50Enabled: encodeURIComponent('50% readings'),
+      cbgMedianEnabled: 'median',
+    }
+
+    this.props.trackMetric(`clicked Trends ${flagMetrics[flag]} ${value ? 'on' : 'off'}`);
   }
 
   toggleWeekdays(allActive) {

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -445,4 +445,19 @@ utils.initializePendo = (user, location, window) => {
   }
 };
 
+utils.readableStatName = statId => ({
+  readingsInRange: 'Readings in range',
+  timeInAuto: 'Time in automation',
+  timeInOverride: 'Time in activity',
+  timeInRange: 'Time in range',
+  totalInsulin: 'Insulin ratio',
+}[statId] || statId);
+
+utils.readableChartName = chartType => ({
+  basics: 'Basics',
+  bgLog: 'BG log',
+  daily: 'Daily',
+  trends: 'Trends',
+}[chartType] || chartType);
+
 export default utils;

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -679,7 +679,6 @@ export const PatientDataClass = createReactClass({
     const bgSource = this.getMetaData('bgSources.current');
     const endpoints = this.getCurrentData('endpoints');
     const { averageDailyDose, ...statsData } = this.getCurrentData('stats');
-
     const stats = [];
 
     _.forOwn(statsData, (data, statType) => {
@@ -694,6 +693,8 @@ export const PatientDataClass = createReactClass({
       if (statType === 'totalInsulin' && _.includes(['basics', 'trends'], chartType)) {
         // We nest the averageDailyDose stat within the totalInsulin stat
         stat.title = props.t('Avg. Daily Insulin Ratio');
+        stat.collapsedTitle = props.t('Avg. Daily Insulin');
+
         delete stat.dataFormat.title;
         delete stat.data.dataPaths.title;
 
@@ -733,9 +734,6 @@ export const PatientDataClass = createReactClass({
             />
           </Box>
         );
-
-        console.log('daysWithBoluses', daysWithBoluses);
-        console.log('activeDays', activeDays);
 
         if (daysWithBoluses > 0 && daysWithBoluses < activeDays) {
           // If any of the calendar dates within the range are missing boluses,
@@ -1167,8 +1165,6 @@ export const PatientDataClass = createReactClass({
 
   getAggregationsByChartType: function(chartType = this.state.chartType) {
     let aggregations;
-
-    console.log('chartType', chartType);
 
     switch (chartType) {
       case 'basics':

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -722,7 +722,12 @@ export const PatientDataClass = createReactClass({
               }
             }}
           >
-            <Stats stats={[ averageDailyDoseStat ]} chartPrefs={state.chartPrefs} bgPrefs={bgPrefs} />
+            <Stats
+              stats={[ averageDailyDoseStat ]}
+              chartPrefs={state.chartPrefs}
+              bgPrefs={bgPrefs}
+              persistState={false}
+            />
           </Box>
         );
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -682,6 +682,7 @@ export const PatientDataClass = createReactClass({
     _.forOwn(statsData, (data, statType) => {
       const stat = getStatDefinition(data, statType, {
         bgSource,
+        collapsible: !_.includes(['averageGlucose', 'standardDev'], statType),
         days: endpoints.activeDays || endpoints.days,
         bgPrefs,
         manufacturer,

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1231,9 +1231,9 @@ export const PatientDataClass = createReactClass({
         cbgSelected && stats.push(commonStats.timeInRange);
         smbgSelected && stats.push(commonStats.readingsInRange);
         stats.push(commonStats.averageGlucose);
+        cbgSelected && stats.push(commonStats.sensorUsage);
         stats.push(commonStats.totalInsulin);
         stats.push(commonStats.averageDailyDose);
-        cbgSelected && stats.push(commonStats.sensorUsage);
         isAutomatedBasalDevice && stats.push(commonStats.timeInAuto);
         isSettingsOverrideDevice && stats.push(commonStats.timeInOverride);
         cbgSelected && stats.push(commonStats.glucoseManagementIndicator);

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -727,10 +727,11 @@ export const PatientDataClass = createReactClass({
             }}
           >
             <Stats
-              stats={[ averageDailyDoseStat ]}
-              chartPrefs={state.chartPrefs}
               bgPrefs={bgPrefs}
+              chartPrefs={state.chartPrefs}
               persistState={false}
+              stats={[ averageDailyDoseStat ]}
+              trackMetric={this.props.trackMetric}
             />
           </Box>
         );

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.23.0-web-1204-collapsible-stats.2",
+    "@tidepool/viz": "1.23.0-web-1204-collapsible-stats.3",
     "async": "2.6.1",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.22.0-web-1240-square-bolus-pdf-fix.2",
+    "@tidepool/viz": "1.23.0-web-1204-collapsible-stats.1",
     "async": "2.6.1",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.22.0",
+    "@tidepool/viz": "1.23.0-web-1204-collapsible-stats.2",
     "async": "2.6.1",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/test/unit/components/chart/deviceSelection.test.js
+++ b/test/unit/components/chart/deviceSelection.test.js
@@ -169,7 +169,6 @@ describe('DeviceSelection', () => {
 
   it('should track a metric when device selection accordion is collapsed or expanded', () => {
     const collapseIcon = wrapper.find('.MuiExpansionPanelSummary-expandIcon').hostNodes();
-    console.log('collapseIcon.debug()', collapseIcon.debug());
     expect(collapseIcon).to.have.lengthOf(1);
 
     sinon.assert.callCount(props.trackMetric, 0);

--- a/test/unit/components/chart/deviceSelection.test.js
+++ b/test/unit/components/chart/deviceSelection.test.js
@@ -17,6 +17,7 @@ const expect = chai.expect;
 
 describe('DeviceSelection', () => {
   const props = {
+    chartType: 'basics',
     devices: [
       { id: 'device1' },
       { id: 'device2' }
@@ -26,6 +27,7 @@ describe('DeviceSelection', () => {
     },
     updateChartPrefs: sinon.stub(),
     removeGeneratedPDFS: sinon.stub(),
+    trackMetric: sinon.stub(),
   };
 
   let wrapper;
@@ -35,6 +37,7 @@ describe('DeviceSelection', () => {
 
   afterEach(() => {
     props.updateChartPrefs.reset();
+    props.trackMetric.resetHistory();
   });
 
   it('should render without errors when provided all required props', () => {
@@ -98,13 +101,14 @@ describe('DeviceSelection', () => {
     expect(wrapper.find('Checkbox').length).to.equal(3);
   });
 
-  it('should call updateChartPrefs and removeGeneratedPDFS on Checkbox change adding or removing devices', () => {
+  it('should call updateChartPrefs and removeGeneratedPDFS and trackMetric on Checkbox change adding or removing devices', () => {
     const checkboxes = wrapper.find('Checkbox');
     const checkbox1 = checkboxes.at(0).find('input');
     const checkbox2 = checkboxes.at(1).find('input');
 
     sinon.assert.callCount(props.updateChartPrefs, 0);
     sinon.assert.callCount(props.removeGeneratedPDFS, 0);
+    sinon.assert.callCount(props.trackMetric, 0);
 
     checkbox1.simulate('change', {
       target: { value: 'device1', checked: false },
@@ -116,6 +120,7 @@ describe('DeviceSelection', () => {
       sinon.match({ excludedDevices: ['device1'] })
     );
     sinon.assert.callCount(props.removeGeneratedPDFS, 1);
+    sinon.assert.calledWith(props.trackMetric, 'Clicked Basics filter device off');
 
     wrapper.setProps({ chartPrefs: { excludedDevices: ['device1'] } });
 
@@ -144,6 +149,7 @@ describe('DeviceSelection', () => {
       sinon.match({ excludedDevices: ['device2'] })
     );
     sinon.assert.callCount(props.removeGeneratedPDFS, 3);
+    sinon.assert.calledWith(props.trackMetric, 'Clicked Basics filter device on');
 
     wrapper.setProps({
       chartPrefs: { excludedDevices: ['device2'] },
@@ -159,5 +165,18 @@ describe('DeviceSelection', () => {
       sinon.match({ excludedDevices: [] })
     );
     sinon.assert.callCount(props.removeGeneratedPDFS, 4);
+  });
+
+  it('should track a metric when device selection accordion is collapsed or expanded', () => {
+    const collapseIcon = wrapper.find('.MuiExpansionPanelSummary-expandIcon').hostNodes();
+    console.log('collapseIcon.debug()', collapseIcon.debug());
+    expect(collapseIcon).to.have.lengthOf(1);
+
+    sinon.assert.callCount(props.trackMetric, 0);
+    collapseIcon.simulate('click');
+    sinon.assert.calledWith(props.trackMetric, 'Click expanded - Basics - Filter devices');
+
+    collapseIcon.simulate('click');
+    sinon.assert.calledWith(props.trackMetric, 'Click collapsed - Basics - Filter devices');
   });
 });

--- a/test/unit/components/chart/stats.test.js
+++ b/test/unit/components/chart/stats.test.js
@@ -171,6 +171,9 @@ describe('Stats', () => {
 
         expect(dailyDoseStat().props().isOpened).to.be.false;
         expect(dailyDoseStat().props().title).to.equal('Daily Dose Collapsed');
+
+        expect(carbStat.props().isOpened).to.be.true;
+        expect(carbStat.props().title).to.equal('Carbs');
       });
 
       it('should track metrics for collapse and expand clicks', () => {

--- a/test/unit/components/chart/stats.test.js
+++ b/test/unit/components/chart/stats.test.js
@@ -58,14 +58,14 @@ describe('Stats', () => {
     chartPrefs: {
       animateStats: true
     },
+    chartType: 'basics',
     stats: [],
   };
 
   let wrapper;
-  let instance;
+
   beforeEach(() => {
     wrapper = shallow(<Stats {...baseProps} />);
-    instance = wrapper.instance();
   });
 
   describe('render', () => {
@@ -104,6 +104,71 @@ describe('Stats', () => {
 
       _.each(expectedStats, statId => {
         expect(wrapper.find(`#Stat--${statId}`)).to.have.length(1);
+      });
+    });
+
+    describe('collapse state', () => {
+      after(() => {
+        Stats.__ResetDependency__('useLocalStorage');
+      });
+
+      it('should render the stats with correct `isOpened` and `title` props', () => {
+        Stats.__Rewire__('useLocalStorage', sinon.stub().returns([
+          {
+            basics: {
+              // collapsed state of stats
+              averageDailyDose: false,
+              carbs: true,
+            },
+          },
+          sinon.stub()
+        ]));
+
+        wrapper.setProps({
+          ...wrapper.props(),
+          stats: [
+            {
+              id: 'carbs',
+              collapsible: false,
+              title: 'Carbs',
+              collapsedTitle: 'Carbs Collapsed',
+            },
+            {
+              id: 'averageDailyDose',
+              collapsible: true,
+              title: 'Daily Dose',
+              collapsedTitle: 'Daily Dose Collapsed',
+            },
+          ],
+        });
+
+        // non-collapsible stats should always be open and use the standard title prop,
+        // even if collapsed state in local storage is `true`
+        const carbStat = wrapper.find('#Stat--carbs').childAt(0);
+        expect(carbStat.props().isOpened).to.be.true;
+        expect(carbStat.props().title).to.equal('Carbs');
+
+        // collapsible stat should follow the collapsed state
+        const dailyDoseStat = () => wrapper.find('#Stat--averageDailyDose').childAt(0);
+        expect(dailyDoseStat().props().isOpened).to.be.true;
+        expect(dailyDoseStat().props().title).to.equal('Daily Dose');
+
+        // Update collapsed state to true
+        Stats.__Rewire__('useLocalStorage', sinon.stub().returns([
+          {
+            basics: {
+              // collapsed state of stats
+              averageDailyDose: true,
+              carbs: true,
+            },
+          },
+          sinon.stub()
+        ]));
+
+        wrapper.setProps();
+
+        expect(dailyDoseStat().props().isOpened).to.be.false;
+        expect(dailyDoseStat().props().title).to.equal('Daily Dose Collapsed');
       });
     });
   });

--- a/test/unit/components/chart/stats.test.js
+++ b/test/unit/components/chart/stats.test.js
@@ -60,6 +60,7 @@ describe('Stats', () => {
     },
     chartType: 'basics',
     stats: [],
+    trackMetric: sinon.stub(),
   };
 
   let wrapper;

--- a/test/unit/components/chart/stats.test.js
+++ b/test/unit/components/chart/stats.test.js
@@ -146,9 +146,9 @@ describe('Stats', () => {
 
         // non-collapsible stats should always be open and use the standard title prop,
         // even if collapsed state in local storage is `true`
-        const carbStat = wrapper.find('#Stat--carbs').childAt(0);
-        expect(carbStat.props().isOpened).to.be.true;
-        expect(carbStat.props().title).to.equal('Carbs');
+        const carbStat = () => wrapper.find('#Stat--carbs').childAt(0);
+        expect(carbStat().props().isOpened).to.be.true;
+        expect(carbStat().props().title).to.equal('Carbs');
 
         // collapsible stat should follow the collapsed state
         const dailyDoseStat = () => wrapper.find('#Stat--averageDailyDose').childAt(0);
@@ -172,8 +172,8 @@ describe('Stats', () => {
         expect(dailyDoseStat().props().isOpened).to.be.false;
         expect(dailyDoseStat().props().title).to.equal('Daily Dose Collapsed');
 
-        expect(carbStat.props().isOpened).to.be.true;
-        expect(carbStat.props().title).to.equal('Carbs');
+        expect(carbStat().props().isOpened).to.be.true;
+        expect(carbStat().props().title).to.equal('Carbs');
       });
 
       it('should track metrics for collapse and expand clicks', () => {

--- a/test/unit/components/chart/trends.test.js
+++ b/test/unit/components/chart/trends.test.js
@@ -398,14 +398,54 @@ describe('Trends', () => {
 
   describe('toggleDisplayFlags', () => {
     it('should set the provided the trends `cbgFlags` chartPrefs state to the provided value', () => {
-      instance.toggleDisplayFlags('cbg100', true);
+      instance.toggleDisplayFlags('cbg100Enabled', true);
       sinon.assert.callCount(baseProps.updateChartPrefs, 1);
       sinon.assert.calledWith(baseProps.updateChartPrefs, {
         trends: {
           ...baseProps.chartPrefs.trends,
-          cbgFlags: { cbg100: true },
+          cbgFlags: { cbg100Enabled: true },
         },
       }, false);
+    });
+  });
+
+  describe('metrics on display toggle events', () => {
+    it('should send metrics for toggleBoxOverlay changes', () => {
+      wrapper.setProps({chartPrefs: { trends: { smbgRangeOverlay: false } } });
+      sinon.assert.callCount(baseProps.trackMetric, 0);
+      instance.toggleBoxOverlay();
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends range and average on');
+      wrapper.setProps({chartPrefs: { trends: { smbgRangeOverlay: true } } });
+      instance.toggleBoxOverlay();
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends range and average off');
+    });
+
+    it('should send metrics for toggleGrouping changes', () => {
+      wrapper.setProps({chartPrefs: { trends: { smbgGrouped: false } } });
+      sinon.assert.callCount(baseProps.trackMetric, 0);
+      instance.toggleGrouping();
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends group on');
+      wrapper.setProps({chartPrefs: { trends: { smbgGrouped: true } } });
+      instance.toggleGrouping();
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends group off');
+    });
+
+    it('should send metrics for toggleLines changes', () => {
+      wrapper.setProps({chartPrefs: { trends: { smbgLines: false } } });
+      sinon.assert.callCount(baseProps.trackMetric, 0);
+      instance.toggleLines();
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends lines on');
+      wrapper.setProps({chartPrefs: { trends: { smbgLines: true } } });
+      instance.toggleLines();
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends lines off');
+    });
+
+    it('should send metrics for toggleDisplayFlags changes', () => {
+      sinon.assert.callCount(baseProps.trackMetric, 0);
+      instance.toggleDisplayFlags('cbg100Enabled', true);
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends 100%25%20readings on');
+      instance.toggleDisplayFlags('cbg100Enabled', false);
+      sinon.assert.calledWith(baseProps.trackMetric, 'clicked Trends 100%25%20readings off');
     });
   });
 });

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -1863,9 +1863,9 @@ describe('PatientData', function () {
         expect(instance.getStatsByChartType()).to.eql([
           'timeInRange',
           'averageGlucose',
+          'sensorUsage',
           'totalInsulin',
           'averageDailyDose',
-          'sensorUsage',
           'glucoseManagementIndicator',
           'standardDev',
           'coefficientOfVariation',

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -1098,6 +1098,9 @@ describe('PatientData', function () {
           focusedSmbg: null,
           focusedSmbgRangeAvg: null,
           showingCbgDateTraces: false,
+          stats: {
+            excludeDaysWithoutBolus: false
+          },
           touched: false,
         },
         bgLog: {
@@ -1860,6 +1863,8 @@ describe('PatientData', function () {
         expect(instance.getStatsByChartType()).to.eql([
           'timeInRange',
           'averageGlucose',
+          'totalInsulin',
+          'averageDailyDose',
           'sensorUsage',
           'glucoseManagementIndicator',
           'standardDev',
@@ -1873,6 +1878,8 @@ describe('PatientData', function () {
         expect(instance.getStatsByChartType()).to.eql([
           'readingsInRange',
           'averageGlucose',
+          'totalInsulin',
+          'averageDailyDose',
           'standardDev',
           'coefficientOfVariation',
           'bgExtents',
@@ -1885,6 +1892,8 @@ describe('PatientData', function () {
         expect(instance.getStatsByChartType()).to.eql([
           'readingsInRange',
           'averageGlucose',
+          'totalInsulin',
+          'averageDailyDose',
           'timeInAuto',
           'standardDev',
           'coefficientOfVariation',
@@ -1898,6 +1907,8 @@ describe('PatientData', function () {
         expect(instance.getStatsByChartType()).to.eql([
           'readingsInRange',
           'averageGlucose',
+          'totalInsulin',
+          'averageDailyDose',
           'timeInOverride',
           'standardDev',
           'coefficientOfVariation',
@@ -2927,6 +2938,7 @@ describe('PatientData', function () {
     });
 
     it('should call `updateChartPrefs` with the `excludeDaysWithoutBolus` chartPrefs state toggled', () => {
+      instance.setState({ chartType: 'basics' });
       const updateChartPrefsSpy = sinon.spy(instance, 'updateChartPrefs');
       instance.toggleDaysWithoutBoluses();
 
@@ -2943,11 +2955,17 @@ describe('PatientData', function () {
       });
     });
 
-    it('should track a metric when `excludeDaysWithoutBolus` set to true', () => {
+    it('should track a metric when `excludeDaysWithoutBolus` set to true on basics view', () => {
+      instance.setState({ chartType: 'basics' });
       instance.toggleDaysWithoutBoluses();
       sinon.assert.calledWith(defaultProps.trackMetric, 'Basics exclude days without boluses');
     });
 
+    it('should track a metric when `excludeDaysWithoutBolus` set to true on trends view', () => {
+      instance.setState({ chartType: 'trends' });
+      instance.toggleDaysWithoutBoluses();
+      sinon.assert.calledWith(defaultProps.trackMetric, 'Trends exclude days without boluses');
+    });
   });
 
   describe('closeDatesDialog', () => {

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -581,4 +581,24 @@ describe('utils', () => {
     });
   });
 
+  describe('readableStatName', function() {
+    it('should return a readable name for stats, and fall back to the argument provided if no readable name exists', function() {
+      expect(utils.readableStatName('readingsInRange')).to.equal('Readings in range');
+      expect(utils.readableStatName('timeInAuto')).to.equal('Time in automation');
+      expect(utils.readableStatName('timeInOverride')).to.equal('Time in activity');
+      expect(utils.readableStatName('timeInRange')).to.equal('Time in range');
+      expect(utils.readableStatName('totalInsulin')).to.equal('Insulin ratio');
+      expect(utils.readableStatName('foo')).to.equal('foo');
+    });
+  });
+
+  describe('readableChartName', function() {
+    it('should return a readable name for charts, and fall back to the argument provided if no readable name exists', function() {
+      expect(utils.readableChartName('basics')).to.equal('Basics');
+      expect(utils.readableChartName('bgLog')).to.equal('BG log');
+      expect(utils.readableChartName('daily')).to.equal('Daily');
+      expect(utils.readableChartName('trends')).to.equal('Trends');
+      expect(utils.readableChartName('bar')).to.equal('bar');
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,10 +3009,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.23.0-web-1204-collapsible-stats.2":
-  version "1.23.0-web-1204-collapsible-stats.2"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.23.0-web-1204-collapsible-stats.2.tgz#dccc324f8a734b833cda6ac3223dd71eb06e50c4"
-  integrity sha512-difASASjlb/7fUFRgCDnCcGdCz2PLH1ee8pnNM25PvYWhUSt7bmV19oa2oGXQ6ndUiPdUG2zh8lNw5gZnakvBw==
+"@tidepool/viz@1.23.0-web-1204-collapsible-stats.3":
+  version "1.23.0-web-1204-collapsible-stats.3"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.23.0-web-1204-collapsible-stats.3.tgz#dea534e2ca077d29ef3127caf5be9f9095af8e4f"
+  integrity sha512-n8HB1IQb2ihEKmD9k1zP18OLCM0xpW6H6hVXf6/cIJ7a1kgF4m/4Px6SY162ZW0Hn5XSvh+AJiTW/rw6LJrdNQ==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,10 +3009,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.23.0-web-1204-collapsible-stats.1":
-  version "1.23.0-web-1204-collapsible-stats.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.23.0-web-1204-collapsible-stats.1.tgz#69b03fb6d4087f4e6978a39e1dbc4c31dd829e70"
-  integrity sha512-zruh5vHm3zx3Qaa/FyLHvtSy0r2PVtlvLloH+DN2CJwyFJ92pZJdU6JVlSdMhWsENp+h0IDJzJ5c3DEWrwPyAw==
+"@tidepool/viz@1.23.0-web-1204-collapsible-stats.2":
+  version "1.23.0-web-1204-collapsible-stats.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.23.0-web-1204-collapsible-stats.2.tgz#dccc324f8a734b833cda6ac3223dd71eb06e50c4"
+  integrity sha512-difASASjlb/7fUFRgCDnCcGdCz2PLH1ee8pnNM25PvYWhUSt7bmV19oa2oGXQ6ndUiPdUG2zh8lNw5gZnakvBw==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,10 +3009,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.22.0-web-1240-square-bolus-pdf-fix.2":
-  version "1.22.0-web-1240-square-bolus-pdf-fix.2"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.22.0-web-1240-square-bolus-pdf-fix.2.tgz#dc9929f8d11e8026756a183c55cdacccba3adf66"
-  integrity sha512-PCKeTLgc0h4Fz6TdIk7Jti+QTSbo1lMuaeaQ5ze15gwDwAmoXOs9wSIm5T9r87CT4+7eJh13L8UBbZG8EacApw==
+"@tidepool/viz@1.23.0-web-1204-collapsible-stats.1":
+  version "1.23.0-web-1204-collapsible-stats.1"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.23.0-web-1204-collapsible-stats.1.tgz#69b03fb6d4087f4e6978a39e1dbc4c31dd829e70"
+  integrity sha512-zruh5vHm3zx3Qaa/FyLHvtSy0r2PVtlvLloH+DN2CJwyFJ92pZJdU6JVlSdMhWsENp+h0IDJzJ5c3DEWrwPyAw==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.0"


### PR DESCRIPTION
See [WEB-1204], [WEB-1182].  Adds `Avg Daily Insulin Ratio` stat to trends view, and sets any of the vertically-tall stats to collapsible.  Stat collapse state is persisted in local storage on a per-view basis.

Related PR: https://github.com/tidepool-org/viz/pull/285

[WEB-1204]: https://tidepool.atlassian.net/browse/WEB-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-1182]: https://tidepool.atlassian.net/browse/WEB-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ