### PR TITLE
[WEB-1365] share status

### DIFF
--- a/app/pages/share/AccessManagement.js
+++ b/app/pages/share/AccessManagement.js
@@ -392,7 +392,12 @@ export const AccessManagement = (props) => {
           label={status === 'pending' ? t('invite sent') : t('invite declined')}
           colorPalette={status === 'pending' ? colors.status.pending : colors.status.declined}
         />
-      ) : ''}
+      ) : (
+        <Pill
+          text={t('shared')}
+          label={t('shared')}
+          colorPalette="indigos" />
+      )}
     </Box>
   );
 

--- a/app/pages/share/AccessManagement.js
+++ b/app/pages/share/AccessManagement.js
@@ -394,8 +394,8 @@ export const AccessManagement = (props) => {
         />
       ) : (
         <Pill
-          text={t('shared')}
-          label={t('shared')}
+          text={t('sharing')}
+          label={t('sharing')}
           colorPalette="indigos" />
       )}
     </Box>

--- a/test/unit/pages/share/AccessManagement.test.js
+++ b/test/unit/pages/share/AccessManagement.test.js
@@ -300,7 +300,7 @@ describe('AccessManagement', () => {
       const table = wrapper.find(Table)
 
       const accountRow = table.find('tr').at(1);
-      expect(accountRow.text()).contains('Fooey McBear').and.contains('member');
+      expect(accountRow.text()).contains('Fooey McBear').and.contains('member').and.contains('shared');
 
       const popoverMenu = accountRow.find('PopoverMenu');
       expect(popoverMenu).to.have.length(1);

--- a/test/unit/pages/share/AccessManagement.test.js
+++ b/test/unit/pages/share/AccessManagement.test.js
@@ -300,7 +300,7 @@ describe('AccessManagement', () => {
       const table = wrapper.find(Table)
 
       const accountRow = table.find('tr').at(1);
-      expect(accountRow.text()).contains('Fooey McBear').and.contains('member').and.contains('shared');
+      expect(accountRow.text()).contains('Fooey McBear').and.contains('member').and.contains('sharing');
 
       const popoverMenu = accountRow.find('PopoverMenu');
       expect(popoverMenu).to.have.length(1);


### PR DESCRIPTION
Set a `SHARING` status for invites that don't have another status (pending or declined). Handles [WEB-1365]

[WEB-1365]: https://tidepool.atlassian.net/browse/WEB-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ