### PR TITLE
[WEB-1363] additional pendo clinic updates and middleware migration

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -409,42 +409,6 @@ utils.getUploaderDownloadURL = (releases) => {
   };
 }
 
-const environments = {
-  'dev1.dev.tidepool.org': 'dev',
-  'qa1.development.tidepool.org': 'qa1',
-  'qa2.development.tidepool.org': 'qa2',
-  'int-app.tidepool.org': 'int',
-  'app.tidepool.org': 'prd',
-  localhost: 'local',
-};
-
-utils.initializePendo = (user, location, window) => {
-  const noPendo = _.get(location, 'query.noPendo', false);
-  if (noPendo) return;
-  const initialize = _.get(window, 'pendo.initialize', false);
-  if (_.isFunction(initialize)) {
-    const hostname = _.get(window, 'location.hostname');
-    const env = _.get(environments, hostname, 'unknown');
-    const role =
-      _.indexOf(_.get(user, 'roles', []), 'clinic') !== -1
-        ? 'clinician'
-        : 'personal';
-
-    initialize({
-      visitor: {
-        id: `${env}-${user.userid}`,
-        role,
-        // permission: [administrator, clinician, prescriber], when available
-        application: 'Web',
-      },
-      account: {
-        id: `${env}-tidepool`,
-        // clinic: [Clinic Name], when available
-      },
-    });
-  }
-};
-
 utils.readableStatName = statId => ({
   readingsInRange: 'Readings in range',
   timeInAuto: 'Time in automation',

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -325,7 +325,6 @@ export function login(api, credentials, options, postLoginAction) {
 
           function handleLoginSuccess(user) {
             dispatch(sync.loginSuccess(user));
-            config.PENDO_ENABLED && utils.initializePendo(user, _.get(options, 'location', {}), window);
 
             if (postLoginAction) {
               dispatch(postLoginAction());

--- a/app/redux/store/configureStore.dev.js
+++ b/app/redux/store/configureStore.dev.js
@@ -38,6 +38,7 @@ import { loadLocalState, saveLocalState } from './localStorage';
 import createErrorLogger from '../utils/logErrorMiddleware';
 import trackingMiddleware from '../utils/trackingMiddleware';
 import createWorkerMiddleware from '../utils/workerMiddleware';
+import pendoMiddleware from '../utils/pendoMiddleware';
 
 function getDebugSessionKey() {
   const matches = window.location.href.match(/[?&]debug_session=([^&]+)\b/);
@@ -69,6 +70,7 @@ if (!__DEV_TOOLS__) {
         routerMiddleware(history),
         createErrorLogger(api),
         trackingMiddleware(api),
+        pendoMiddleware(api),
       ),
       persistState(getDebugSessionKey()),
     );
@@ -84,6 +86,7 @@ if (!__DEV_TOOLS__) {
         routerMiddleware(history),
         createErrorLogger(api),
         trackingMiddleware(api),
+        pendoMiddleware(api),
         mutationTracker(),
       ),
       // We can persist debug sessions this way

--- a/app/redux/store/configureStore.prod.js
+++ b/app/redux/store/configureStore.prod.js
@@ -33,6 +33,7 @@ import { loadLocalState, saveLocalState } from './localStorage';
 import createErrorLogger from '../utils/logErrorMiddleware';
 import trackingMiddleware from '../utils/trackingMiddleware';
 import createWorkerMiddleware from '../utils/workerMiddleware';
+import pendoMiddleware from '../utils/pendoMiddleware';
 
 export const history = qhistory(createBrowserHistory(), stringify, parse);
 
@@ -50,7 +51,8 @@ function _createStore(api) {
     thunkMiddleware,
     routerMiddleware(history),
     createErrorLogger(api),
-    trackingMiddleware(api)
+    trackingMiddleware(api),
+    pendoMiddleware(api),
   )(createStore);
 
   const initialState = { blip: assign(blipState, loadLocalState()) };

--- a/app/redux/utils/pendoMiddleware.js
+++ b/app/redux/utils/pendoMiddleware.js
@@ -1,0 +1,109 @@
+import filter from 'lodash/filter';
+import includes from 'lodash/includes';
+import indexOf from 'lodash/indexOf';
+import isEmpty from 'lodash/isEmpty';
+import isNull from 'lodash/isNull';
+import config from '../../config';
+import * as ActionTypes from '../constants/actionTypes';
+
+const trackingActions = [ActionTypes.LOGIN_SUCCESS, ActionTypes.SELECT_CLINIC];
+
+const environments = {
+  'dev1.dev.tidepool.org': 'dev',
+  'qa1.development.tidepool.org': 'qa1',
+  'qa2.development.tidepool.org': 'qa2',
+  'int-app.tidepool.org': 'int',
+  'app.tidepool.org': 'prd',
+  localhost: 'local',
+};
+
+const pendoMiddleware = (api, win = window) => (storeAPI) => (next) => (action) => {
+  const { getState } = storeAPI;
+  const {
+    router: { location },
+  } = getState();
+  if (
+    !config.PENDO_ENABLED ||
+    !includes(trackingActions, action.type) ||
+    location?.query?.noPendo
+  ) {
+    return next(action);
+  }
+  const { initialize, updateOptions } = win?.pendo || {};
+  switch (action.type) {
+    case ActionTypes.LOGIN_SUCCESS: {
+      const {
+        blip: { clinics, allUsersMap, loggedInUserId },
+      } = getState();
+      const user = allUsersMap[loggedInUserId];
+      const hostname = win?.location?.hostname;
+      const env = environments?.[hostname] || 'unknown';
+      const clinicianOf = filter(clinics, (clinic) => {
+        return clinic?.clinicians?.[user?.userid];
+      });
+      const optionalVisitorProperties = {};
+      const optionalAccountProperties = {};
+      if (!isEmpty(clinicianOf)) {
+        if (clinicianOf.length === 1) {
+          const clinic = clinicianOf[0];
+          optionalVisitorProperties.permission = includes(
+            clinic?.clinicians?.[user.userid]?.roles,
+            'CLINIC_ADMIN'
+          )
+            ? 'administrator'
+            : 'member';
+          optionalAccountProperties.clinic = clinic?.name;
+        }
+      }
+      const role = indexOf(user?.roles, 'clinic') !== -1 ? 'clinician' : 'personal';
+
+      initialize({
+        visitor: {
+          id: `${env}-${user.userid}`,
+          role,
+          application: 'Web',
+          ...optionalVisitorProperties,
+        },
+        account: {
+          id: `${env}-tidepool`,
+          ...optionalAccountProperties,
+        },
+      });
+      break;
+    }
+    case ActionTypes.SELECT_CLINIC: {
+      const {
+        blip: { clinics, allUsersMap, loggedInUserId },
+      } = getState();
+      const user = allUsersMap[loggedInUserId];
+      const clinicId = action.payload.clinicId;
+      if(isNull(clinicId)){
+        updateOptions({
+          visitor: {
+            permission: null,
+          },
+          account: { clinic: null },
+        });
+      } else {
+        const selectedClinic = clinics[clinicId];
+        updateOptions({
+          visitor: {
+            permission: includes(
+              selectedClinic?.clinicians?.[user.userid]?.roles,
+              'CLINIC_ADMIN'
+            )
+              ? 'administrator'
+              : 'member',
+          },
+          account: { clinic: selectedClinic?.name },
+        });
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return next(action);
+};
+
+export default pendoMiddleware;

--- a/test/unit/redux/utils/pendoMiddleware.test.js
+++ b/test/unit/redux/utils/pendoMiddleware.test.js
@@ -1,0 +1,359 @@
+/* global sinon */
+/* global describe */
+/* global it */
+/* global expect */
+/* global beforeEach */
+
+import * as ActionTypes from '../../../../app/redux/constants/actionTypes';
+import pendoMiddleware from '../../../../app/redux/utils/pendoMiddleware';
+
+describe('pendoMiddleware', () => {
+  const api = {};
+  const emptyState = {
+    router: {
+      location: {
+        query: {},
+      },
+    },
+    blip: {
+      clinics: {},
+      allUsersMap: {},
+      loggedInUserId: '',
+    },
+  };
+  const getStateObj = {
+    getState: sinon.stub().returns(emptyState),
+  };
+  const next = sinon.stub();
+
+  pendoMiddleware.__Rewire__('config', { PENDO_ENABLED: true });
+
+  const winMock = {
+    location: {
+      hostname: 'localhost',
+    },
+    pendo: {
+      initialize: sinon.stub(),
+      updateOptions: sinon.stub(),
+    },
+  };
+
+  beforeEach(() => {
+    winMock.pendo.initialize.resetHistory();
+    winMock.pendo.updateOptions.resetHistory();
+    getStateObj.getState.returns(emptyState);
+  });
+
+  it('should be a function', () => {
+    expect(pendoMiddleware).to.be.a('function');
+  });
+
+  it('should not call initialize for LOGIN_SUCCESS if not PENDO_ENABLED', () => {
+    pendoMiddleware.__Rewire__('config', { PENDO_ENABLED: false });
+    const loginSuccess = {
+      type: ActionTypes.LOGIN_SUCCESS,
+      payload: {
+        user: {},
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware(api, winMock)(getStateObj)(next)(loginSuccess);
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware.__Rewire__('config', { PENDO_ENABLED: true });
+  });
+
+  it('should not call initialize if noPendo query is set', () => {
+    const loginSuccess = {
+      type: ActionTypes.LOGIN_SUCCESS,
+      payload: {
+        user: {},
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        router: {
+          location: {
+            query: {
+              noPendo: true,
+            },
+          },
+        },
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware(api, winMock)(getStateObj)(next)(loginSuccess);
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+  });
+
+  it('should call initialize for LOGIN_SUCCESS', () => {
+    const loginSuccess = {
+      type: ActionTypes.LOGIN_SUCCESS,
+      payload: {
+        user: {},
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+    const expectedConfig = {
+      account: {
+        clinic: 'Mock Clinic Name',
+        id: 'local-tidepool',
+      },
+      visitor: {
+        application: 'Web',
+        id: 'local-userID345',
+        permission: 'administrator',
+        role: 'personal',
+      },
+    };
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware(api, winMock)(getStateObj)(next)(loginSuccess);
+    expect(winMock.pendo.initialize.callCount).to.equal(1);
+    expect(winMock.pendo.initialize.calledWith(expectedConfig)).to.be.true;
+  });
+
+  it('should set not set clinic info on LOGIN_SUCCESS if multiple clinics available', () => {
+    const loginSuccess = {
+      type: ActionTypes.LOGIN_SUCCESS,
+      payload: {
+        user: {},
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+            clinicID987: {
+              clinicians: { userID345: { roles: ['CLINIC_MEMBER'] } },
+              name: 'Other Mock Clinic',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+    const expectedConfig = {
+      account: {
+        id: 'local-tidepool',
+      },
+      visitor: {
+        application: 'Web',
+        id: 'local-userID345',
+        role: 'personal',
+      },
+    };
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware(api, winMock)(getStateObj)(next)(loginSuccess);
+    expect(winMock.pendo.initialize.callCount).to.equal(1);
+    expect(winMock.pendo.initialize.calledWith(expectedConfig)).to.be.true;
+  });
+
+  it('should set the appropriate environment based on hostname', () => {
+    const loginSuccess = {
+      type: ActionTypes.LOGIN_SUCCESS,
+      payload: {
+        user: {},
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+    const expectedProdConfig = {
+      account: {
+        clinic: 'Mock Clinic Name',
+        id: 'prd-tidepool',
+      },
+      visitor: {
+        application: 'Web',
+        id: 'prd-userID345',
+        permission: 'administrator',
+        role: 'personal',
+      },
+    };
+    const expectedQA1Config = {
+      account: {
+        clinic: 'Mock Clinic Name',
+        id: 'qa1-tidepool',
+      },
+      visitor: {
+        application: 'Web',
+        id: 'qa1-userID345',
+        permission: 'administrator',
+        role: 'personal',
+      },
+    };
+
+    const prdWinMock = {
+      ...winMock,
+      ...{ location: { hostname: 'app.tidepool.org' } },
+    };
+    const qa1WinMock = {
+      ...winMock,
+      ...{ location: { hostname: 'qa1.development.tidepool.org' } },
+    };
+
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware(api, prdWinMock)(getStateObj)(next)(loginSuccess);
+    expect(winMock.pendo.initialize.callCount).to.equal(1);
+    expect(winMock.pendo.initialize.calledWith(expectedProdConfig)).to.be.true;
+    winMock.pendo.initialize.resetHistory();
+
+    expect(winMock.pendo.initialize.callCount).to.equal(0);
+    pendoMiddleware(api, qa1WinMock)(getStateObj)(next)(loginSuccess);
+    expect(winMock.pendo.initialize.callCount).to.equal(1);
+    expect(winMock.pendo.initialize.calledWith(expectedQA1Config)).to.be.true;
+  });
+
+  it('should call update for SELECT_CLINIC', () => {
+    const selectClinic = {
+      type: ActionTypes.SELECT_CLINIC,
+      payload: {
+        clinicId: 'clinicID987',
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+            clinicID987: {
+              clinicians: { userID345: { roles: ['CLINIC_MEMBER'] } },
+              name: 'Other Mock Clinic',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+    const expectedConfig = {
+      account: {
+        clinic: 'Other Mock Clinic',
+      },
+      visitor: {
+        permission: 'member',
+      },
+    };
+    expect(winMock.pendo.updateOptions.callCount).to.equal(0);
+    pendoMiddleware(api, winMock)(getStateObj)(next)(selectClinic);
+    expect(winMock.pendo.updateOptions.callCount).to.equal(1);
+    expect(winMock.pendo.updateOptions.calledWith(expectedConfig)).to.be.true;
+  });
+
+  it('should call update and clear properties for SELECT_CLINIC with clinicID null', () => {
+    const selectClinic = {
+      type: ActionTypes.SELECT_CLINIC,
+      payload: {
+        clinicId: null,
+      },
+    };
+    getStateObj.getState.returns({
+      ...emptyState,
+      ...{
+        blip: {
+          clinics: {
+            clinicID123: {
+              clinicians: { userID345: { roles: ['CLINIC_ADMIN'] } },
+              name: 'Mock Clinic Name',
+            },
+            clinicID987: {
+              clinicians: { userID345: { roles: ['CLINIC_MEMBER'] } },
+              name: 'Other Mock Clinic',
+            },
+          },
+          loggedInUserId: 'userID345',
+          allUsersMap: {
+            userID345: { userid: 'userID345', roles: ['migrated_clinic'] },
+          },
+        },
+      },
+    });
+    const expectedConfig = {
+      account: {
+        clinic: null,
+      },
+      visitor: {
+        permission: null,
+      },
+    };
+    expect(winMock.pendo.updateOptions.callCount).to.equal(0);
+    pendoMiddleware(api, winMock)(getStateObj)(next)(selectClinic);
+    expect(winMock.pendo.updateOptions.callCount).to.equal(1);
+    expect(winMock.pendo.updateOptions.args[0][0]).to.eql(expectedConfig);
+  });
+});

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -537,50 +537,6 @@ describe('utils', () => {
     });
   });
 
-  describe('initializePendo', () => {
-    let initialize = sinon.stub();
-    let window = { pendo: { initialize } };
-
-    afterEach(() => {
-      initialize.reset();
-    });
-
-    it('should not initialize if noPendo query param is set', () => {
-      const location = { query: { noPendo: true } };
-      utils.initializePendo({}, location, window);
-      expect(initialize.notCalled).to.be.true;
-    });
-
-    it('should set the appropriate environment based on hostname', () => {
-      const location = {};
-      const user = { userid: 'user1234' };
-      const prdWin = _.extend(window, {
-        location: { hostname: 'app.tidepool.org' },
-      });
-      const qa1Win = _.extend(window, {
-        location: { hostname: 'qa1.development.tidepool.org' },
-      });
-
-      utils.initializePendo(user, location, prdWin);
-      expect(initialize.calledWithMatch({ account: { id: 'prd-tidepool' } }));
-      initialize.reset();
-      utils.initializePendo(user, location, qa1Win);
-      expect(initialize.calledWithMatch({ account: { id: 'qa1-tidepool' } }));
-    });
-
-    it('should set the appropriate role based on clinical role status', () => {
-      const location = {};
-      const personalUser = { userid: 'user1234' };
-      const clinicUser = { userid: 'clinic5678', roles: ['clinic'] };
-
-      utils.initializePendo(personalUser, location, window);
-      expect(initialize.calledWithMatch({ visitor: { role: 'personal' } }));
-      initialize.reset();
-      utils.initializePendo(clinicUser, location, window);
-      expect(initialize.calledWithMatch({ visitor: { role: 'clinician' } }));
-    });
-  });
-
   describe('readableStatName', function() {
     it('should return a readable name for stats, and fall back to the argument provided if no readable name exists', function() {
       expect(utils.readableStatName('readingsInRange')).to.equal('Readings in range');


### PR DESCRIPTION
To address [WEB-1363]. Moves pendo related code into a middleware instead of being one-off utility functions called directly from our async action creators since I felt like it more appropriately resides there. Adds in some new clinic system specific properties for pendo and handles setting pendo states when switching clinic accounts.

[WEB-1363]: https://tidepool.atlassian.net/browse/WEB-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ