### PR TITLE
[WEB-1522] Clinic route restriction fixes

### DIFF
--- a/app/components/navbar/NavigationMenu.js
+++ b/app/components/navbar/NavigationMenu.js
@@ -72,11 +72,13 @@ export const NavigationMenu = props => {
     label: t('Logout'),
   };
 
-  const [menuOptions, setMenuOptions] = useState([
+  const defaultMenuOptions = [
     privateWorkspaceOption,
     accountSettingsOption,
     logoutOption,
-  ]);
+  ];
+
+  const [menuOptions, setMenuOptions] = useState(defaultMenuOptions);
 
   useEffect(() => {
     const userClinics = filter(values(clinics), ({ clinicians }) => has(clinicians, loggedInUserId));
@@ -98,6 +100,8 @@ export const NavigationMenu = props => {
       ];
 
       setMenuOptions(options);
+    } else {
+      setMenuOptions(defaultMenuOptions)
     }
   }, [clinics, pendingReceivedClinicianInvites, isClinicProfileFormPath]);
 

--- a/app/pages/clinicdetails/clinicdetails.js
+++ b/app/pages/clinicdetails/clinicdetails.js
@@ -328,7 +328,7 @@ export const ClinicDetails = (props) => {
       variant="containers.mediumBordered"
       p={4}
     >
-      {working.fetchingClinicianInvites.completed ? (
+      {working.fetchingClinicianInvites.completed !== null ? (
         <>
           <Headline mb={2}>{t('Update your account')}</Headline>
 

--- a/app/pages/clinicdetails/clinicdetails.js
+++ b/app/pages/clinicdetails/clinicdetails.js
@@ -162,7 +162,7 @@ export const ClinicDetails = (props) => {
       'updatingUser.inProgress'
     );
 
-    if (submitting === 'partial' && !inProgress && completed && prevInProgress) {
+    if (submitting === 'partial' && !inProgress && completed !== null && prevInProgress) {
       setSubmitting(false);
 
       if (notification) {
@@ -193,7 +193,7 @@ export const ClinicDetails = (props) => {
       'updatingClinic.inProgress'
     );
 
-    if (!inProgress && completed && prevInProgress) {
+    if (!inProgress && completed !== null && prevInProgress) {
       if (notification) {
         setToast({
           message: notification.message,
@@ -232,7 +232,7 @@ export const ClinicDetails = (props) => {
       'triggeringInitialClinicMigration.inProgress'
     );
 
-    if (!inProgress && completed && prevInProgress) {
+    if (!inProgress && completed !== null && prevInProgress) {
       if (notification) {
         setToast({
           message: notification.message,

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -239,7 +239,7 @@ export function login(api, credentials, options, postLoginAction) {
             const userHasClinicProfile = !!_.get(user, ['profile', 'clinic'], false);
             const isClinicianAccount = personUtils.isClinicianAccount(user);
 
-            if (config.CLINICS_ENABLED && isClinicianAccount) {
+            if (config.CLINICS_ENABLED) {
               // Fetch clinic-clinician relationships and pending clinic invites, and only proceed
               // to the clinic workflow if a relationship with a clinic object or an invite exists.
               const fetchers = {

--- a/app/routes.js
+++ b/app/routes.js
@@ -99,7 +99,7 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
           // We should also run these checks for path restrictions in the event that the clinic
           // migration was triggered, but failed. Otherwise, a user could theoretically navigate
           // to restricted Clinic UI without completing the migration process.
-          state.working.triggeringInitialClinicMigration.completed !== null && state.working.triggeringInitialClinicMigration.completed === false
+          state.working.triggeringInitialClinicMigration.completed === false
         )
       ) {
         const fetchers = {

--- a/app/routes.js
+++ b/app/routes.js
@@ -95,6 +95,12 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
         && !state.working.fetchingClinicsForClinician.inProgress
         && !state.working.fetchingClinicsForClinician.completed
         && !state.working.fetchingClinicsForClinician.notification
+        || (
+          // We should also run these checks for path restrictions in the event that the clinic
+          // migration was triggered, but failed. Otherwise, a user could theoretically navigate
+          // to restricted Clinic UI without completing the migration process.
+          state.working.triggeringInitialClinicMigration.completed !== null && state.working.triggeringInitialClinicMigration.completed === false
+        )
       ) {
         const fetchers = {
           clinics: cb => dispatch(actions.async.getClinicsForClinician(api, user.userid, {}, cb)),
@@ -104,18 +110,19 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
         async.parallel(async.reflectAll(fetchers), (err, results) => {
           const errors = _.mapValues(results, ({error}) => error);
           const values = _.mapValues(results, ({value}) => value);
-          const hasError = _.some(errors, err => !_.isUndefined(err));
 
-          if (hasError) return cb();
-
+          const currentPathname = routerState.location?.pathname;
           const isClinicianAccount = personUtils.isClinicianAccount(user);
           const hasClinicProfile = !!_.get(user, ['profile', 'clinic'], false);
           const firstEmptyOrUnmigratedClinic = _.find(values.clinics, clinic => _.isEmpty(clinic.clinic?.name) || clinic.clinic?.canMigrate);
 
-          const clinicUIRoutes = [
+          const unrestrictedClinicUIRoutes = [
+            routes.clinicDetails,
+            routes.clinicianDetails,
+          ];
+
+          const restrictedClinicUIRoutes = [
             '/clinic-admin',
-            '/clinic-details',
-            '/clinician-details',
             '/clinic-details',
             '/clinic-invite',
             '/clinic-workspace',
@@ -124,7 +131,17 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
             '/prescriptions',
           ];
 
-          const isClinicUIRoute = _.some(clinicUIRoutes, route => _.startsWith(routerState.location?.pathname, route));
+          const isClinicUIRoute = _.some([...unrestrictedClinicUIRoutes, ...restrictedClinicUIRoutes], route => _.startsWith(currentPathname, route));
+          const isRestrictedClinicUIRoute = _.some(restrictedClinicUIRoutes, route => _.startsWith(currentPathname, route));
+
+          if (err || errors?.clinics) {
+            // In this case, we can't reliably know whether a user even has associated clinics,
+            // let alone the migration/profile state, so we send them to the patients page if they
+            // are on any Clinic UI route, except for the clinician account details route, where
+            // missing clinic information would be irrelevant.
+            if (isClinicUIRoute && currentPathname !== routes.clinicianDetails) dispatch(push(routes.patients));
+            return cb();
+          }
 
           if (isClinicianAccount && (firstEmptyOrUnmigratedClinic || !hasClinicProfile)) {
             // Navigate to the appropriate page for a clinician user or team member who needs to
@@ -134,7 +151,10 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
           } else if (values.invites?.length) {
             // Redirect user to address clinic invite
             dispatch(push(!hasClinicProfile ? routes.clinicDetails : routes.workspaces));
-          } else if (!isClinicianAccount && isClinicUIRoute) {
+          } else if (
+            (isClinicUIRoute && !isClinicianAccount) ||
+            (isRestrictedClinicUIRoute && !(state.clinicFlowActive || state.selectedClinicId))
+          ) {
             // Redirect non clinic members to the patients page if they access a clinic UI page
             dispatch(push(routes.patients));
           }
@@ -142,7 +162,7 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
           cb();
         });
       } else {
-        // Clinic UI feature is off.  Callback and continue
+        // Clinic UI feature is off. Callback and continue
         cb();
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.51.0",
+  "version": "1.51.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.51.1-rc.1",
+  "version": "1.51.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -549,6 +549,7 @@ describe('Actions', () => {
           user: {
             login: sinon.stub().callsArgWith(2, null),
             get: sinon.stub().callsArgWith(0, null, user),
+            logout: sinon.stub(),
           },
           clinics: {
             getClinicianInvites: sinon.stub().callsArgWith(1, null, []),
@@ -588,6 +589,7 @@ describe('Actions', () => {
           user: {
             login: sinon.stub().callsArgWith(2, null),
             get: sinon.stub().callsArgWith(0, null, user),
+            logout: sinon.stub(),
           },
           patient: {
             get: sinon.stub().callsArgWith(1, null, patient),
@@ -631,6 +633,7 @@ describe('Actions', () => {
           user: {
             login: sinon.stub().callsArgWith(2, null),
             get: sinon.stub().callsArgWith(0, null, user),
+            logout: sinon.stub(),
           },
           patient: {
             get: sinon.stub().callsArgWith(1, null, patient),
@@ -674,6 +677,7 @@ describe('Actions', () => {
           user: {
             login: sinon.stub().callsArgWith(2, null),
             get: sinon.stub().callsArgWith(0, null, user),
+            logout: sinon.stub(),
           },
           patient: {
             get: sinon.stub().callsArgWith(1, null, patient),
@@ -741,6 +745,7 @@ describe('Actions', () => {
                 login: sinon.stub().callsArgWith(2, null),
                 get: sinon.stub().callsArgWith(0, null, user),
                 getAssociatedAccounts: sinon.stub().callsArgWith(0, patientsError, { patients }),
+                logout: sinon.stub(),
               },
               patient: {
                 get: sinon.stub().callsArgWith(1, null, patient)
@@ -1152,6 +1157,21 @@ describe('Actions', () => {
               { type: 'FETCH_ASSOCIATED_ACCOUNTS_REQUEST' },
               { type: 'FETCH_ASSOCIATED_ACCOUNTS_SUCCESS', payload: { patients: [] }},
               { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 400, body: 'Error!'}}},
+              {
+                type: 'LOGOUT_REQUEST',
+              },
+              {
+                meta: {
+                  WebWorker: true,
+                  origin: 'http://localhost:9876',
+                  patientId: null,
+                  worker: 'data',
+                },
+                payload: {
+                  predicate: undefined,
+                },
+                type: 'DATA_WORKER_REMOVE_DATA_REQUEST',
+              },
             ];
             _.each(expectedActions, (action) => {
               expect(isTSA(action)).to.be.true;
@@ -1189,6 +1209,21 @@ describe('Actions', () => {
               { type: 'FETCH_ASSOCIATED_ACCOUNTS_REQUEST' },
               { type: 'FETCH_ASSOCIATED_ACCOUNTS_SUCCESS', payload: { patients: [] }},
               { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 400, body: 'Error!'}}},
+              {
+                type: 'LOGOUT_REQUEST',
+              },
+              {
+                meta: {
+                  WebWorker: true,
+                  origin: 'http://localhost:9876',
+                  patientId: null,
+                  worker: 'data',
+                },
+                payload: {
+                  predicate: undefined,
+                },
+                type: 'DATA_WORKER_REMOVE_DATA_REQUEST',
+              },
             ];
             _.each(expectedActions, (action) => {
               expect(isTSA(action)).to.be.true;
@@ -1227,6 +1262,21 @@ describe('Actions', () => {
               { type: 'FETCH_ASSOCIATED_ACCOUNTS_REQUEST' },
               { type: 'FETCH_ASSOCIATED_ACCOUNTS_FAILURE', error: err, meta: { apiError: {status: 400, body: 'Error!'}}},
               { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 400, body: 'Error!'}}},
+              {
+                type: 'LOGOUT_REQUEST',
+              },
+              {
+                meta: {
+                  WebWorker: true,
+                  origin: 'http://localhost:9876',
+                  patientId: null,
+                  worker: 'data',
+                },
+                payload: {
+                  predicate: undefined,
+                },
+                type: 'DATA_WORKER_REMOVE_DATA_REQUEST',
+              },
             ];
             _.each(expectedActions, (action) => {
               expect(isTSA(action)).to.be.true;
@@ -1358,6 +1408,7 @@ describe('Actions', () => {
           user: {
             login: sinon.stub().callsArgWith(2, null),
             get: sinon.stub().callsArgWith(0, {status: 500, body: 'Error!'}),
+            logout: sinon.stub(),
           },
           clinics: {
             getClinicianInvites: sinon.stub().callsArgWith(1, null, []),
@@ -1372,7 +1423,22 @@ describe('Actions', () => {
           { type: 'LOGIN_REQUEST' },
           { type: 'FETCH_USER_REQUEST' },
           { type: 'FETCH_USER_FAILURE', error: err, meta: { apiError: {status: 500, body: 'Error!'} } },
-          { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 500, body: 'Error!'} } }
+          { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 500, body: 'Error!'} } },
+          {
+            type: 'LOGOUT_REQUEST',
+          },
+          {
+            meta: {
+              WebWorker: true,
+              origin: 'http://localhost:9876',
+              patientId: null,
+              worker: 'data',
+            },
+            payload: {
+              predicate: undefined,
+            },
+            type: 'DATA_WORKER_REMOVE_DATA_REQUEST',
+          },
         ];
         _.each(expectedActions, (action) => {
           expect(isTSA(action)).to.be.true;
@@ -1401,6 +1467,7 @@ describe('Actions', () => {
           user: {
             login: sinon.stub().callsArgWith(2, null),
             get: sinon.stub().callsArgWith(0, null, user),
+            logout: sinon.stub(),
           },
           clinics: {
             getClinicianInvites: sinon.stub().callsArgWith(1, null, []),
@@ -1417,7 +1484,22 @@ describe('Actions', () => {
           { type: 'FETCH_USER_SUCCESS', payload: { user: user }},
           { type: 'FETCH_PATIENT_REQUEST' },
           { type: 'FETCH_PATIENT_FAILURE', error: err, payload: { link: null }, meta: { apiError: {status: 500, body: 'Error!'} } },
-          { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 500, body: 'Error!'} } }
+          { type: 'LOGIN_FAILURE', error: err, payload: null, meta: { apiError: {status: 500, body: 'Error!'} } },
+          {
+            type: 'LOGOUT_REQUEST',
+          },
+          {
+            meta: {
+              WebWorker: true,
+              origin: 'http://localhost:9876',
+              patientId: null,
+              worker: 'data',
+            },
+            payload: {
+              predicate: undefined,
+            },
+            type: 'DATA_WORKER_REMOVE_DATA_REQUEST',
+          },
         ];
         _.each(expectedActions, (action) => {
           expect(isTSA(action)).to.be.true;


### PR DESCRIPTION
Hotfix for [WEB-1522]
Primarily addresses users potentially being able to skip the route restriction checks on clinic UI routes if one of the backend calls made prior to the checks returns an error.

I also fixed a small bug where the nav menu wasn't updating to the default options if the user navigated away from the clinic profile page, and cleaned up the error handling on login failures a bit too, including dispatching the logout action if the backend calls fail.

[WEB-1522]: https://tidepool.atlassian.net/browse/WEB-1522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ