### PR TITLE
[WEB-1543] Clear patient form between submissions

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -523,8 +523,8 @@ export const ClinicPatients = (props) => {
       {renderHeader()}
       {renderPeopleArea()}
       {renderRemoveDialog()}
-      {renderAddPatientDialog()}
-      {renderEditPatientDialog()}
+      {showAddPatientDialog && renderAddPatientDialog()}
+      {showEditPatientDialog && renderEditPatientDialog()}
     </div>
   );
 };

--- a/app/pages/clinicworkspace/ClinicianPatients.js
+++ b/app/pages/clinicworkspace/ClinicianPatients.js
@@ -460,8 +460,8 @@ export const ClinicianPatients = (props) => {
       {renderHeader()}
       {renderPeopleArea()}
       {renderRemoveDialog()}
-      {renderAddPatientDialog()}
-      {renderEditPatientDialog()}
+      {showAddPatientDialog && renderAddPatientDialog()}
+      {showEditPatientDialog && renderEditPatientDialog()}
     </Box>
   );
 };

--- a/app/pages/clinicworkspace/ClinicianPatients.js
+++ b/app/pages/clinicworkspace/ClinicianPatients.js
@@ -47,6 +47,7 @@ export const ClinicianPatients = (props) => {
   const dispatch = useDispatch();
   const { set: setToast } = useToasts();
   const loggedInUserId = useSelector((state) => state.blip.loggedInUserId);
+  const membershipPermissionsInOtherCareTeams = useSelector((state) => state.blip.membershipPermissionsInOtherCareTeams);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showAddPatientDialog, setShowAddPatientDialog] = useState(false);
   const [showEditPatientDialog, setShowEditPatientDialog] = useState(false);
@@ -365,21 +366,24 @@ export const ClinicianPatients = (props) => {
 
   const renderMore = patient => {
     const items = [];
+    const isLoggedInUser = patient.id === loggedInUserId;
 
-    items.push({
-      icon: EditIcon,
-      iconLabel: t('Edit Patient Information'),
-      iconPosition: 'left',
-      id: `edit-${patient.id}`,
-      variant: 'actionListItem',
-      onClick: _popupState => {
-        _popupState.close();
-        handleEditPatient(patient);
-      },
-      text: t('Edit Patient Information'),
-    });
+    if (isLoggedInUser || membershipPermissionsInOtherCareTeams?.[patient.id]?.custodian) {
+      items.push({
+        icon: EditIcon,
+        iconLabel: t('Edit Patient Information'),
+        iconPosition: 'left',
+        id: `edit-${patient.id}`,
+        variant: 'actionListItem',
+        onClick: _popupState => {
+          _popupState.close();
+          handleEditPatient(patient);
+        },
+        text: t('Edit Patient Information'),
+      });
+    }
 
-    if (patient.id !== loggedInUserId) items.push({
+    if (!isLoggedInUser) items.push({
       icon: DeleteIcon,
       iconLabel: t('Remove Patient'),
       iconPosition: 'left',

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -193,9 +193,10 @@ describe('ClinicPatients', () => {
 
       const dialog = () => wrapper.find('Dialog#addPatient');
 
-      expect(dialog().props().open).to.be.false;
+      expect(dialog()).to.have.length(0);
       addButton.simulate('click');
       wrapper.update();
+      expect(dialog()).to.have.length(1);
       expect(dialog().props().open).to.be.true;
 
       expect(defaultProps.trackMetric.calledWith('Clinic - Add patient')).to.be.true;
@@ -326,7 +327,7 @@ describe('ClinicPatients', () => {
 
           sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', { limit: 8, offset: 0, search: 'Two', sort: '+fullName' });
           done();
-        }, 100);
+        }, 300);
       });
 
       it('should link to a patient data view when patient name is clicked', () => {
@@ -380,9 +381,10 @@ describe('ClinicPatients', () => {
 
         const dialog = () => wrapper.find('Dialog#editPatient');
 
-        expect(dialog().props().open).to.be.false;
+        expect(dialog()).to.have.length(0);
         editButton.simulate('click');
         wrapper.update();
+        expect(dialog()).to.have.length(1);
         expect(dialog().props().open).to.be.true;
 
         expect(defaultProps.trackMetric.calledWith('Clinic - Edit patient')).to.be.true;

--- a/test/unit/pages/ClinicianPatients.test.js
+++ b/test/unit/pages/ClinicianPatients.test.js
@@ -163,9 +163,10 @@ describe('ClinicianPatients', () => {
 
       const dialog = () => wrapper.find('Dialog#addPatient');
 
-      expect(dialog().props().open).to.be.false;
+      expect(dialog()).to.have.length(0);
       addButton.simulate('click');
       wrapper.update();
+      expect(dialog()).to.have.length(1);
       expect(dialog().props().open).to.be.true;
 
       expect(defaultProps.trackMetric.calledWith('Clinician - Add patient')).to.be.true;
@@ -338,9 +339,10 @@ describe('ClinicianPatients', () => {
 
         const dialog = () => wrapper.find('Dialog#editPatient');
 
-        expect(dialog().props().open).to.be.false;
+        expect(dialog()).to.have.length(0);
         editButton.simulate('click');
         wrapper.update();
+        expect(dialog()).to.have.length(1);
         expect(dialog().props().open).to.be.true;
 
         expect(defaultProps.trackMetric.calledWith('Clinician - Edit patient')).to.be.true;

--- a/test/unit/pages/ClinicianPatients.test.js
+++ b/test/unit/pages/ClinicianPatients.test.js
@@ -18,6 +18,7 @@ import Popover from '../../../app/components/elements/Popover';
 /* global beforeEach */
 /* global before */
 /* global after */
+/* global assert */
 
 const expect = chai.expect;
 const mockStore = configureStore([thunk]);
@@ -132,6 +133,10 @@ describe('ClinicianPatients', () => {
         patient1,
         patient2,
       },
+      membershipPermissionsInOtherCareTeams: {
+        patient1: { view: {} },
+        patient2: { custodian: {} },
+      }
     },
   });
 
@@ -329,6 +334,24 @@ describe('ClinicianPatients', () => {
         expect(wrapper.find(Popover).at(0).props().open).to.be.false;
         moreMenuIcon.simulate('click');
         expect(wrapper.find(Popover).at(0).props().open).to.be.true;
+      });
+
+      it('should not show the patient edit link for non-custodial patient accounts', () => {
+        const table = wrapper.find(Table);
+        expect(table).to.have.length(1);
+        expect(table.find('tr')).to.have.length(3); // header row + 2 invites
+        const patientRow1 = table.find('tr').at(1);
+        const patientRow2 = table.find('tr').at(2);
+
+        expect(patientRow1.text()).contains('Patient One');
+        const patient1EditButton = patientRow1.find('Button[iconLabel="Edit Patient Information"]');
+        assert(!hasPatientsState.blip.membershipPermissionsInOtherCareTeams.patient1.custodian)
+        expect(patient1EditButton).to.have.length(0);
+
+        expect(patientRow2.text()).contains('Patient Two');
+        assert(hasPatientsState.blip.membershipPermissionsInOtherCareTeams.patient2.custodian)
+        const patient2EditButton = patientRow2.find('Button[iconLabel="Edit Patient Information"]');
+        expect(patient2EditButton).to.have.length(1);
       });
 
       it('should open a modal for patient editing when edit link is clicked', done => {


### PR DESCRIPTION
Addresses [WEB-1543], for both the clinic and legacy clinician "Add Patient" forms.
As well, I noticed that the "Edit Patient" action was available on the legacy (private workspace) patient list for accounts without the appropriate permissions, so that now only shows if the clinician has `custodian` permission for the account (or if it's their own account)

[WEB-1543]: https://tidepool.atlassian.net/browse/WEB-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ