### PR TITLE
[WEB-1347] clinician authorization toast fixes/adjustments

### DIFF
--- a/app/pages/clinicadmin/clinicadmin.js
+++ b/app/pages/clinicadmin/clinicadmin.js
@@ -165,6 +165,26 @@ export const ClinicAdmin = (props) => {
   }, [working.fetchingClinicianInvite]);
 
   useEffect(() => {
+    const {
+      inProgress,
+      completed,
+      notification,
+    } = working.fetchingCliniciansFromClinic;
+    const prevInProgress = get(
+      previousWorking,
+      'fetchingCliniciansFromClinic.inProgress'
+    );
+    if (!inProgress && completed && prevInProgress) {
+      if (notification) {
+        setToast({
+          message: notification.message,
+          variant: 'danger',
+        });
+      }
+    }
+  }, [working.fetchingCliniciansFromClinic]);
+
+  useEffect(() => {
     if(loggedInUserId && clinic) {
       if (
         !fetchingCliniciansFromClinic.inProgress &&

--- a/app/pages/clinicadmin/clinicadmin.js
+++ b/app/pages/clinicadmin/clinicadmin.js
@@ -73,19 +73,19 @@ export const ClinicAdmin = (props) => {
       previousWorking,
       'resendingClinicianInvite.inProgress'
     );
-    if (!inProgress && completed && prevInProgress) {
-      if (notification) {
-        setToast({
-          message: notification.message,
-          variant: 'danger',
-        });
-      } else {
+    if (!inProgress && prevInProgress) {
+      if (completed) {
         setToast({
           message: t('Clinician invite resent to {{email}}.', { email: selectedInvite?.email }),
           variant: 'success',
         });
       }
-
+      if (notification) {
+        setToast({
+          message: notification.message,
+          variant: 'danger',
+        });
+      }
       closeResendInviteDialog();
     }
   }, [working.resendingClinicianInvite]);
@@ -100,21 +100,21 @@ export const ClinicAdmin = (props) => {
       previousWorking,
       'deletingClinicianInvite.inProgress'
     );
-    if (!inProgress && completed && prevInProgress) {
+    if (!inProgress && prevInProgress) {
+      if (completed) {
+        setToast({
+          message: t('Clinician invite to {{email}} has been revoked.', {
+            email: selectedInvite?.email,
+          }),
+          variant: 'success',
+        });
+      }
       if (notification) {
         setToast({
           message: notification.message,
           variant: 'danger',
         });
-      } else {
-        setToast({
-          message: t('Clinician invite to {{email}} has been revoked.', {
-            email: selectedInvite?.email
-          }),
-          variant: 'success',
-        });
       }
-
       closeRevokeInviteDialog();
     }
   }, [working.deletingClinicianInvite]);
@@ -129,32 +129,29 @@ export const ClinicAdmin = (props) => {
       previousWorking,
       'deletingClinicianFromClinic.inProgress'
     );
-    if (!inProgress && completed && prevInProgress) {
+    if (!inProgress && prevInProgress) {
+      if (completed) {
+        setToast({
+          message: t('Clinician removed from clinic.'),
+          variant: 'success',
+        });
+      }
       if (notification) {
         setToast({
           message: notification.message,
           variant: 'danger',
-        });
-      } else {
-        setToast({
-          message: t('Clinician removed from clinic.'),
-          variant: 'success',
         });
       }
     }
   }, [working.deletingClinicianFromClinic]);
 
   useEffect(() => {
-    const {
-      inProgress,
-      completed,
-      notification,
-    } = working.fetchingClinicianInvite;
+    const { inProgress, notification } = working.fetchingClinicianInvite;
     const prevInProgress = get(
       previousWorking,
       'fetchingClinicianInvite.inProgress'
     );
-    if (!inProgress && completed && prevInProgress) {
+    if (!inProgress && prevInProgress) {
       if (notification) {
         setToast({
           message: notification.message,
@@ -165,16 +162,12 @@ export const ClinicAdmin = (props) => {
   }, [working.fetchingClinicianInvite]);
 
   useEffect(() => {
-    const {
-      inProgress,
-      completed,
-      notification,
-    } = working.fetchingCliniciansFromClinic;
+    const { inProgress, notification } = working.fetchingCliniciansFromClinic;
     const prevInProgress = get(
       previousWorking,
       'fetchingCliniciansFromClinic.inProgress'
     );
-    if (!inProgress && completed && prevInProgress) {
+    if (!inProgress && prevInProgress) {
       if (notification) {
         setToast({
           message: notification.message,
@@ -185,21 +178,14 @@ export const ClinicAdmin = (props) => {
   }, [working.fetchingCliniciansFromClinic]);
 
   useEffect(() => {
-    if(loggedInUserId && clinic) {
-      if (
-        !fetchingCliniciansFromClinic.inProgress &&
-        !fetchingCliniciansFromClinic.completed &&
-        !fetchingCliniciansFromClinic.notification
-      ) {
-        dispatch(actions.async.fetchCliniciansFromClinic(api, clinic.id, { limit: 1000, offset: 0 }));
-      }
+    if (
+      loggedInUserId &&
+      clinic &&
+      !fetchingCliniciansFromClinic.inProgress
+    ) {
+      dispatch(actions.async.fetchCliniciansFromClinic(api, clinic.id, { limit: 1000, offset: 0 }));
     }
-  }, [
-    clinic,
-    loggedInUserId,
-    selectedClinicId,
-    fetchingCliniciansFromClinic,
-  ]);
+  }, [loggedInUserId, selectedClinicId]);
 
   const clinicianArray = map(
     get(clinics, [selectedClinicId, 'clinicians'], {}),

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -139,7 +139,6 @@ export const ClinicPatients = (props) => {
       loggedInUserId
       && clinic?.id
       && !fetchingPatientsForClinic.inProgress
-      && !fetchingPatientsForClinic.notification
     ) {
       const fetchOptions = { ...patientFetchOptions };
       if (isEmpty(fetchOptions.search)) delete fetchOptions.search;

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -106,7 +106,7 @@ describe('ClinicPatients', () => {
     },
   };
 
-  let store;
+  let store = mockStore(noPatientsState);
 
   const hasPatientsState = merge({}, noPatientsState, {
     blip: {
@@ -164,6 +164,75 @@ describe('ClinicPatients', () => {
       },
     },
   };
+
+  context('on mount', () => {
+    beforeEach(() => {
+      store.clearActions();
+    });
+    it('should not fetch patients for clinic if already in progress', () => {
+      store = mockStore(
+        merge({}, hasPatientsState, {
+          blip: {
+            working: {
+              fetchingPatientsForClinic: {
+                inProgress: true,
+              },
+            },
+          },
+        })
+      );
+      wrapper = mount(
+        <Provider store={store}>
+          <ToastProvider>
+            <ClinicPatients {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+      expect(store.getActions()).to.eql([]);
+    });
+
+    it('should fetch patients for clinic', () => {
+      store = mockStore(hasPatientsState);
+      wrapper = mount(
+        <Provider store={store}>
+          <ToastProvider>
+            <ClinicPatients {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+      const expectedActions = [
+        { type: 'FETCH_PATIENTS_FOR_CLINIC_REQUEST' },
+      ];
+      expect(store.getActions()).to.eql(expectedActions);
+    });
+
+    it('should fetch patients for clinic if previously errored', () => {
+      store = mockStore(
+        merge({}, hasPatientsState, {
+          blip: {
+            working: {
+              fetchingPatientsForClinic: {
+                notification: {
+                  message: 'Errored',
+                },
+              },
+            },
+          },
+        })
+      );
+      wrapper = mount(
+        <Provider store={store}>
+          <ToastProvider>
+            <ClinicPatients {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+      const expectedActions = [
+        { type: 'FETCH_PATIENTS_FOR_CLINIC_REQUEST' },
+      ];
+      expect(store.getActions()).to.eql(expectedActions);
+    });
+  });
 
   context('no patients', () => {
     beforeEach(() => {

--- a/test/unit/pages/clinicadmin.test.js
+++ b/test/unit/pages/clinicadmin.test.js
@@ -49,6 +49,9 @@ describe('ClinicAdmin', () => {
   beforeEach(() => {
     defaultProps.trackMetric.resetHistory();
     defaultProps.api.clinics.deleteClinicianFromClinic.resetHistory();
+    defaultProps.api.clinics.getCliniciansFromClinic.resetHistory();
+    defaultProps.api.clinics.deleteClinicianInvite.resetHistory();
+    defaultProps.api.clinics.resendClinicianInvite.resetHistory();
   });
 
   after(() => {
@@ -241,6 +244,7 @@ describe('ClinicAdmin', () => {
           </ToastProvider>
         </Provider>
       );
+      store.clearActions();
     });
 
     it('should render an Invite button', () => {
@@ -412,6 +416,79 @@ describe('ClinicAdmin', () => {
         </Provider>
       );
 
+      sinon.assert.calledWith(defaultProps.api.clinics.getCliniciansFromClinic, 'clinicID456', { limit: 1000, offset: 0 });
+    });
+  });
+
+  context('on mount', () => {
+    it('should not fetch clinicians if fetch is already in progress', () => {
+      const noFetchState = merge({}, fetchedMultipleAdminState, {
+        blip: {
+          working: {
+            fetchingCliniciansFromClinic: {
+              inProgress: true,
+            },
+          },
+        },
+      });
+      const noFetchStore = mockStore(noFetchState);
+      defaultProps.api.clinics.getCliniciansFromClinic.resetHistory();
+      mount(
+        <Provider store={noFetchStore}>
+          <ToastProvider>
+            <ClinicAdmin {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+
+      expect(noFetchStore.getActions()).to.eql([]);
+      sinon.assert.notCalled(defaultProps.api.clinics.getCliniciansFromClinic);
+    });
+
+    it('should fetch clinicians if not already in progress', () => {
+      const fetchStore = mockStore(fetchedMultipleAdminState);
+      mount(
+        <Provider store={fetchStore}>
+          <ToastProvider>
+            <ClinicAdmin {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+      const expectedActions = [
+        {
+          type: 'FETCH_CLINICIANS_FROM_CLINIC_REQUEST',
+        },
+      ];
+      expect(fetchStore.getActions()).to.eql(expectedActions);
+      sinon.assert.calledWith(defaultProps.api.clinics.getCliniciansFromClinic, 'clinicID456', { limit: 1000, offset: 0 });
+    });
+
+    it('should fetch clinicians even if previously errored', () => {
+      const erroredState = merge({}, fetchedMultipleAdminState, {
+        blip: {
+          working: {
+            fetchingCliniciansFromClinic: {
+              notification: {
+                message: 'Errored',
+              },
+            },
+          },
+        },
+      });
+      const errorStore = mockStore(erroredState);
+      mount(
+        <Provider store={errorStore}>
+          <ToastProvider>
+            <ClinicAdmin {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+      const expectedActions = [
+        {
+          type: 'FETCH_CLINICIANS_FROM_CLINIC_REQUEST',
+        },
+      ];
+      expect(errorStore.getActions()).to.eql(expectedActions);
       sinon.assert.calledWith(defaultProps.api.clinics.getCliniciansFromClinic, 'clinicID456', { limit: 1000, offset: 0 });
     });
   });


### PR DESCRIPTION
Feedback via testing of [WEB-1347] revealed we weren't displaying the toast in as many places/on specific user actions as desired. This will cause a re-fetch of patients or clinicians when the list component mounts, regardless of whether or not the previous attempts have failed, in order to re-assess and re-display authorization errors to the user if necessary. Also un-blocks a number of error messages that wouldn't have been displayed due to checking for completed which will always be "falsy" on errored API calls.

`.1` branch to denote rebase against release branch and deprecating original branch

[WEB-1347]: https://tidepool.atlassian.net/browse/WEB-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ