### PR TITLE
fix of readme link in dev guide (currently gives 404)

### DIFF
--- a/docs/StartHere.md
+++ b/docs/StartHere.md
@@ -2,7 +2,7 @@
 
 Blip is a single-page application built using [React](https://facebook.github.io/react/ 'React') - a JavaScript library for building user interfaces.
 
-The root-level [README]('../README.md') contains the nuts & bolts of installing, configuring, and commands to accomplish various tasks such as running the tests and testing the production build.
+The root-level [README](../README.md) contains the nuts & bolts of installing, configuring, and commands to accomplish various tasks such as running the tests and testing the production build.
 
 As you're getting ready to develop code in this repository, we recommend starting with the following documents:
 


### PR DESCRIPTION
Currently the dev guide has a typo in the link to the root readme leading to a 404. Fixed typo and now the link works.

I agree to the terms of Tidepool Project’s Volunteer/Contributor License Agreement v1.1 as
it exists at http://tidepool-org.github.io/files/TidepoolVCLA-1.1.pdf on 4/28/22