### PR TITLE
[WEB-1641] - Add error message for failed custodial account creation due to duplicate email address

### DIFF
--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -2101,6 +2101,9 @@ export function fetchPatientFromClinic(api, clinicId, patientId) {
         if (err?.status === 403) {
           errMsg = ErrorMessages.ERR_CREATING_CUSTODIAL_ACCOUNT_UNAUTHORIZED;
         }
+        if (err?.status === 409) {
+          errMsg = ErrorMessages.ERR_ACCOUNT_ALREADY_EXISTS;
+        }
         dispatch(sync.createClinicCustodialAccountFailure(
           createActionError(errMsg, err), err
         ));


### PR DESCRIPTION
See [WEB-1641]

[WEB-1641]: https://tidepool.atlassian.net/browse/WEB-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ