### PR TITLE
[WEB-1660] Fix for clinic preferred BG units not being applied correctly in certain circumstances.

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -341,29 +341,36 @@ utils.getTimePrefsForDataProcessing = (latestUpload, queryParams) => {
   return timePrefsForTideline;
 };
 
-utils.getBGPrefsForDataProcessing = (patientSettings, { units: overrideUnits, source }) => {
-  var bgUnits = _.get(patientSettings, 'units.bg', overrideUnits?.replace('/', '').toLowerCase() === 'mmoll' ? MMOLL_UNITS : MGDL_UNITS);
+utils.getBGPrefsForDataProcessing = (patientSettings, { units: overrideUnits, source: overrideSource }) => {
+  // Allow overriding stored BG Unit preferences via query param or preferred clinic BG units
+  // If no override is specified, use patient settings units if availiable, otherwise 'mg/dL'
+  // const patientSettingsBgUnits = _.get(patientSettings, 'units.bg',  MGDL_UNITS);
+  const patientSettingsBgUnits = patientSettings?.units?.bg;
 
+  const bgUnits = overrideUnits
+    ? (overrideUnits?.replace('/', '').toLowerCase() === 'mmoll' ? MMOLL_UNITS : MGDL_UNITS)
+    : patientSettingsBgUnits || MGDL_UNITS;
+
+  const settingsOverrideActive = patientSettingsBgUnits && patientSettingsBgUnits !== bgUnits;
   const low = _.get(patientSettings, 'bgTarget.low', DEFAULT_BG_BOUNDS[bgUnits].targetLowerBound);
   const high = _.get(patientSettings, 'bgTarget.high', DEFAULT_BG_BOUNDS[bgUnits].targetUpperBound);
 
   var bgClasses = {
-    low: { boundary: utils.roundBgTarget(low, bgUnits) },
-    target: { boundary: utils.roundBgTarget(high, bgUnits) },
+    low: {
+      boundary: utils.roundBgTarget(
+        settingsOverrideActive ? utils.translateBg(patientSettings.bgTarget.low, bgUnits) : low,
+        bgUnits
+      )
+    },
+    target: {
+      boundary: utils.roundBgTarget(
+        settingsOverrideActive ? utils.translateBg(patientSettings.bgTarget.high, bgUnits) : high,
+        bgUnits
+      )
+    },
   };
 
-  // Allow overriding stored BG Unit preferences via query param
-  const bgUnitsFormatted = bgUnits.replace('/', '').toLowerCase();
-
-  console.log('overrideUnits', overrideUnits);
-  console.log('bgUnitsFormatted', bgUnitsFormatted);
-
-  if (!_.isEmpty(overrideUnits) && overrideUnits !== bgUnitsFormatted && _.includes([ 'mgdl', 'mmoll' ], overrideUnits)) {
-    bgUnits = overrideUnits === 'mmoll' ? MMOLL_UNITS : MGDL_UNITS;
-    bgClasses.low.boundary = utils.roundBgTarget(utils.translateBg(patientSettings.bgTarget.low, bgUnits), bgUnits);
-    bgClasses.target.boundary = utils.roundBgTarget(utils.translateBg(patientSettings.bgTarget.high, bgUnits), bgUnits);
-    console.log(`Displaying BG in ${bgUnits} from ${source}`);
-  }
+  if (settingsOverrideActive) console.log(`Displaying BG in ${bgUnits} from ${overrideSource}`);
 
   return {
     bgUnits,

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -344,13 +344,13 @@ utils.getTimePrefsForDataProcessing = (latestUpload, queryParams) => {
 utils.getBGPrefsForDataProcessing = (patientSettings, { units: overrideUnits, source: overrideSource }) => {
   // Allow overriding stored BG Unit preferences via query param or preferred clinic BG units
   // If no override is specified, use patient settings units if availiable, otherwise 'mg/dL'
-  const patientSettingsBgUnits = patientSettings?.units?.bg;
+  const patientSettingsBgUnits = patientSettings?.units?.bg || MGDL_UNITS;
 
   const bgUnits = overrideUnits
     ? (overrideUnits?.replace('/', '').toLowerCase() === 'mmoll' ? MMOLL_UNITS : MGDL_UNITS)
-    : patientSettingsBgUnits || MGDL_UNITS;
+    : patientSettingsBgUnits;
 
-  const settingsOverrideActive = patientSettingsBgUnits && patientSettingsBgUnits !== bgUnits;
+  const settingsOverrideActive = patientSettingsBgUnits !== bgUnits;
   const low = _.get(patientSettings, 'bgTarget.low', DEFAULT_BG_BOUNDS[bgUnits].targetLowerBound);
   const high = _.get(patientSettings, 'bgTarget.high', DEFAULT_BG_BOUNDS[bgUnits].targetUpperBound);
 

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -344,7 +344,6 @@ utils.getTimePrefsForDataProcessing = (latestUpload, queryParams) => {
 utils.getBGPrefsForDataProcessing = (patientSettings, { units: overrideUnits, source: overrideSource }) => {
   // Allow overriding stored BG Unit preferences via query param or preferred clinic BG units
   // If no override is specified, use patient settings units if availiable, otherwise 'mg/dL'
-  // const patientSettingsBgUnits = _.get(patientSettings, 'units.bg',  MGDL_UNITS);
   const patientSettingsBgUnits = patientSettings?.units?.bg;
 
   const bgUnits = overrideUnits

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -357,13 +357,13 @@ utils.getBGPrefsForDataProcessing = (patientSettings, { units: overrideUnits, so
   var bgClasses = {
     low: {
       boundary: utils.roundBgTarget(
-        settingsOverrideActive ? utils.translateBg(patientSettings.bgTarget.low, bgUnits) : low,
+        settingsOverrideActive && patientSettings?.bgTarget?.low ? utils.translateBg(patientSettings.bgTarget.low, bgUnits) : low,
         bgUnits
       )
     },
     target: {
       boundary: utils.roundBgTarget(
-        settingsOverrideActive ? utils.translateBg(patientSettings.bgTarget.high, bgUnits) : high,
+        settingsOverrideActive && patientSettings?.bgTarget?.high ? utils.translateBg(patientSettings.bgTarget.high, bgUnits) : high,
         bgUnits
       )
     },

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -707,8 +707,8 @@ export const PatientDataClass = createReactClass({
     let bgPrefs = this.state.bgPrefs || {};
 
     const bgUnitsOverride = {
-      units: this.props.clinic?.preferredBgUnits || this.props.queryParams?.units,
-      source: this.props.clinic?.preferredBgUnits ? 'preferred clinic units' : 'query params',
+      units: this.props.queryParams?.units || this.props.clinic?.preferredBgUnits,
+      source: this.props.queryParams?.units ? 'query params' : 'preferred clinic units',
     };
 
     if (!bgPrefs.useDefaultRange) {
@@ -1509,14 +1509,13 @@ export const PatientDataClass = createReactClass({
 
       // Set bgPrefs to state
       let bgPrefs = this.state.bgPrefs;
-      console.log('bgPrefs', bgPrefs);
+
       if (!bgPrefs) {
         const bgUnitsOverride = {
-          units: nextProps.clinic?.preferredBgUnits || nextProps.queryParams?.units,
-          source: nextProps.clinic?.preferredBgUnits ? 'preferred clinic units' : 'query params',
+          units: nextProps.queryParams?.units || nextProps.clinic?.preferredBgUnits,
+          source: nextProps.queryParams?.units ? 'query params' : 'preferred clinic units',
         };
 
-        console.log('bgUnitsOverride', bgUnitsOverride);
         bgPrefs = utils.getBGPrefsForDataProcessing(patientSettings, bgUnitsOverride);
         bgPrefs.bgBounds = vizUtils.bg.reshapeBgClassesToBgBounds(bgPrefs);
         if (isCustomBgRange(bgPrefs)) stateUpdates.isCustomBgRange = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.54.0",
+  "version": "1.54.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.54.1-rc.1",
+  "version": "1.54.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
See [WEB-1660]

The main issue was that the code block that was intended to perform the override had some incorrect conditional logic for when to apply the overrides.  

Specifically, the override units from the clinic were stored in the following formats:  `mmol/L | mg/dL` 
The conditional code was validating that it matched one of `[mmoll, mgdl]`

I also updated it to allow the query param `units` override to take precedence over the clinic's preferred bg units so that it's still a functional option within a clinic context.

[WEB-1660]: https://tidepool.atlassian.net/browse/WEB-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ