### PR TITLE
[WEB-1672] Fix issues with patient data loading

### DIFF
--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -175,12 +175,6 @@ export class AppComponent extends React.Component {
       this.doFetching(nextProps);
     }
 
-    if (!this.props.clinicFlowActive && nextProps.clinicFlowActive && !selectedClinicId && _.keys(clinics).length) {
-      // We keep the selectedClinicId state at it's default 'null' if the app loads on the legacy
-      // patients page. Otherwise, we select the first available clinic.
-      if (location !== '/patients') nextProps.selectClinic(_.keys(clinics)[0]);
-    }
-
     const isBannerRoute = /^\/patients\/\S+\/data/.test(location);
 
     const showUploaderBanner = authenticated && moment().isBefore('2020-10-01');

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -785,7 +785,6 @@ let mapDispatchToProps = dispatch => bindActionCreators({
   showBanner: actions.sync.showBanner,
   hideBanner: actions.sync.hideBanner,
   resendEmailVerification: actions.async.resendEmailVerification,
-  selectClinic: actions.sync.selectClinic,
 }, dispatch);
 
 let mergeProps = (stateProps, dispatchProps, ownProps) => {
@@ -819,7 +818,6 @@ let mergeProps = (stateProps, dispatchProps, ownProps) => {
     hideBanner: dispatchProps.hideBanner,
     onResendEmailVerification: dispatchProps.resendEmailVerification.bind(null, api),
     onLogout: dispatchProps.logout.bind(null, api),
-    selectClinic: dispatchProps.selectClinic,
   });
 };
 

--- a/app/redux/reducers/data.js
+++ b/app/redux/reducers/data.js
@@ -54,7 +54,7 @@ const data = (state = initialState.data, action) => {
         ...initialState.data,
         cacheUntil: _.get(action.payload, 'preserveCache') ? state.cacheUntil : null,
         fetchedUntil: _.get(action.payload, 'preserveCache') ? state.fetchedUntil : null,
-        metaData: _.get(action.payload, 'preserveCache') ? state.metaData : {},
+        metaData: _.get(action.payload, 'preserveCache') ? { ...state.metaData, queryDataCount: 0 } : {},
       } });
 
     case actionTypes.DATA_WORKER_QUERY_DATA_SUCCESS:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.54.2",
+  "version": "1.54.3-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/redux/reducers/data.test.js
+++ b/test/unit/redux/reducers/data.test.js
@@ -200,7 +200,7 @@ describe('data reducer', () => {
       });
     });
 
-    it('should reset back to the initial state, but preserve some fields for caching purposes', () => {
+    it('should reset back to the initial state, but preserve some fields for caching purposes, and set `queryDataCount` back to zero', () => {
       initialStateForTest.data.combined = [ 1 ];
       initialStateForTest.data.aggregationsByDate = { foo: 'bar' };
       initialStateForTest.data.current = 'current state';
@@ -213,6 +213,7 @@ describe('data reducer', () => {
       initialStateForTest.metaData = {
         patientId: 'abc123',
         foo: 'bar',
+        queryDataCount: 3,
       };
 
       tracked = mutationTracker.trackObj(initialStateForTest);
@@ -238,6 +239,7 @@ describe('data reducer', () => {
           metaData: {
             patientId: 'abc123',
             foo: 'bar',
+            queryDataCount: 0,
           },
         });
       });


### PR DESCRIPTION
See [WEB-1672]
Fixes a regression introduced in `v1.53.0` where switching between the profile page and the patient view causes the patient view to not load.  This was due to moving the queryDataCount metadata to the Data worker, and not resetting it to zero when we drop the redux state data, but preserve the cached data in the worker, as happens when navigating to the profile page from a data view.

With the queryDataCount set to zero, it now properly fetches the initial data (from the worker) and renders the view.

As well, I noticed that some old top-level code in `app.js` that was used to ensure we had `selectedClinicId` state set was affecting the page refreshes when viewing clinic custodial account data, setting the `selectedClinicId` arbitrarily to the first available clinic.  This was causing that clinic's preferred bg units to prevail over the custodial account units.  This code should have been deleted when we transitioned to storing the `selectedClinicId` state in localstorage for persistence. 



[WEB-1672]: https://tidepool.atlassian.net/browse/WEB-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ