### PR TITLE
[WEB-1682] Fix for recursive patient data fetching immeditately after login

### DIFF
--- a/app/redux/reducers/working.js
+++ b/app/redux/reducers/working.js
@@ -165,6 +165,7 @@ export default (state = initialWorkingState, action) => {
           types.CREATE_CLINIC_CUSTODIAL_ACCOUNT_REQUEST,
           types.CREATE_VCA_CUSTODIAL_ACCOUNT_REQUEST,
           types.SEND_PATIENT_UPLOAD_REMINDER_REQUEST,
+          types.DATA_WORKER_REMOVE_DATA_REQUEST,
         ], action.type)) {
           return update(state, {
             [key]: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.54.3-rc.1",
+  "version": "1.54.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/redux/reducers/working.test.js
+++ b/test/unit/redux/reducers/working.test.js
@@ -2237,7 +2237,7 @@ describe('working', () => {
 
   describe('dataWorkerRemoveData', () => {
     describe('request', () => {
-      it('should leave removingData.completed unchanged', () => {
+      it('should set removingData.completed to null', () => {
         expect(initialState.removingData.completed).to.be.null;
 
         let requestAction = actions.worker.dataWorkerRemoveDataRequest();
@@ -2251,7 +2251,7 @@ describe('working', () => {
         expect(successState.removingData.completed).to.be.true;
 
         let state = reducer(successState, requestAction);
-        expect(state.removingData.completed).to.be.true;
+        expect(state.removingData.completed).to.be.null;
         expect(mutationTracker.hasMutated(tracked)).to.be.false;
       });
 


### PR DESCRIPTION
See [WEB-1682]

Basically, when the (broken) refresh functionality was fixed in `v1.52.0`, it was set to detect changes to react to the removal of patient data from the data worker.  Because the completed state of that action was never being set back to null, it was causing, in some instances, [the data fetch to fire over and over again](https://github.com/tidepool-org/blip/blob/24ee0e8a866545f6e4bbb23f8cab8e984d18fd6c/app/pages/patientdata/patientdata.js#L1457). 

[WEB-1682]: https://tidepool.atlassian.net/browse/WEB-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ