### PR TITLE
[WEB-1702] Fix Table component js error for older versions of Chrome

### DIFF
--- a/app/components/elements/Table.js
+++ b/app/components/elements/Table.js
@@ -168,8 +168,8 @@ export const Table = props => {
 
               return (
                 <TableCell
-                  id={`${id}-header-${col.field?.replaceAll('.', '-')}`}
-                  key={`${id}-header-${col.field?.replaceAll('.', '-')}`}
+                  id={`${id}-header-${col.field?.replace(/\./g, '-')}`}
+                  key={`${id}-header-${col.field?.replace(/\./g, '-')}`}
                   align={col.align || (index === 0 ? 'left' : 'right')}
                   sortDirection={orderBy === colSortBy ? order : false}
                 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.55.1-rc.1",
+  "version": "1.55.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.55.0",
+  "version": "1.55.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
Hotfix for [WEB-1702]

`String.replaceAll` fails for chrome versions below `85` (released August 2020).  Switching to the far more broadly-supported `repalce` with a regex and global flag.

[WEB-1702]: https://tidepool.atlassian.net/browse/WEB-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ