### PR TITLE
[WEB-1665] Disable non-custodial patient email editing

### DIFF
--- a/app/components/clinic/PatientForm.js
+++ b/app/components/clinic/PatientForm.js
@@ -143,6 +143,7 @@ export const PatientForm = (props) => {
           placeholder={t('Email')}
           variant="condensed"
           width="100%"
+          disabled={patient?.id && !patient?.permissions?.custodian}
         />
       </Box>
 


### PR DESCRIPTION
For [WEB-1665], disables email field editing for non-custodial patient accounts

[WEB-1665]: https://tidepool.atlassian.net/browse/WEB-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ