### PR TITLE
[WEB-1701] Use page size of 50 instead of 10 for patient list

### DIFF
--- a/app/components/elements/Table.js
+++ b/app/components/elements/Table.js
@@ -102,6 +102,7 @@ export const Table = props => {
     orderBy: orderByProp,
     pagination,
     paginationProps,
+    containerStyles,
     ...tableProps
   } = props;
 
@@ -158,7 +159,7 @@ export const Table = props => {
   }, [props.page]);
 
   return (
-    <Box as={TableContainer}>
+    <Box as={TableContainer} style={containerStyles}>
       <Box as={StyledTable} id={id} variant={`tables.${variant}`} aria-label={label} {...tableProps}>
         <TableHead>
           <TableRow>
@@ -261,6 +262,7 @@ Table.propTypes = {
   onSort: PropTypes.func,
   stickyHeader: PropTypes.bool,
   variant: PropTypes.oneOf(['default', 'condensed']),
+  containerStyles: PropTypes.object,
 };
 
 Table.defaultProps = {
@@ -271,6 +273,7 @@ Table.defaultProps = {
   paginationProps: {
     style: { fontSize: '14px' },
   },
+  containerStyles: {},
 };
 
 export default Table;

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -287,7 +287,7 @@ export const ClinicPatients = (props) => {
     setShowSummaryData(clinic?.tier >= 'tier0200');
     setPatientFetchOptions({
       ...defaultPatientFetchOptions,
-      limit: clinic?.tier >= 'tier0200' ? 10 : 8,
+      limit: 50,
     });
   }, [clinic?.id]);
 
@@ -313,7 +313,7 @@ export const ClinicPatients = (props) => {
     const filterOptions = {
       offset: 0,
       sort: patientFetchOptions.sort || defaultPatientFetchOptions.sort,
-      limit: clinic?.tier >= 'tier0200' ? 10 : 8,
+      limit: 50,
     }
 
     if (activeFilters.lastUploadDate) {
@@ -1414,6 +1414,8 @@ export const ClinicPatients = (props) => {
           onSort={handleSortChange}
           order={sort.substring(0, 1) === '+' ? 'asc' : 'desc'}
           orderBy={sort.substring(1)}
+          stickyHeader
+          containerStyles={{maxHeight: '560px', overflow: 'auto'}}
         />
 
         {pageCount > 1 && (

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -557,7 +557,7 @@ describe('ClinicPatients', () => {
             { type: 'FETCH_PATIENTS_FOR_CLINIC_REQUEST' },
           ]);
 
-          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', { limit: 8, offset: 0, search: 'Two', sort: '+fullName' });
+          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', { limit: 50, offset: 0, search: 'Two', sort: '+fullName' });
           done();
         }, 300);
       });
@@ -969,7 +969,7 @@ describe('ClinicPatients', () => {
           expect(refreshButton).to.have.lengthOf(1);
           defaultProps.api.clinics.getPatientsForClinic.resetHistory();
           refreshButton.simulate('click');
-          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ limit: 10, offset: 0, sort: '+fullName' }));
+          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ limit: 50, offset: 0, sort: '+fullName' }));
         });
 
         it('should show the time since the last patient data fetch', () => {
@@ -1012,7 +1012,7 @@ describe('ClinicPatients', () => {
 
           defaultProps.api.clinics.getPatientsForClinic.resetHistory();
           applyButton().simulate('click');
-          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ limit: 10, offset: 0, sort: '+fullName', 'summary.lastUploadDateFrom': sinon.match.string, 'summary.lastUploadDateTo': sinon.match.string }));
+          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ limit: 50, offset: 0, sort: '+fullName', 'summary.lastUploadDateFrom': sinon.match.string, 'summary.lastUploadDateTo': sinon.match.string }));
           sinon.assert.calledWith(defaultProps.trackMetric, 'Clinic - Population Health - Last upload apply filter', sinon.match({ clinicId: 'clinicID123', dateRange: '30 days' }));
         });
 
@@ -1090,7 +1090,7 @@ describe('ClinicPatients', () => {
           const applyButton = dialog().find('#timeInRangeFilterConfirm').hostNodes();
           applyButton.simulate('click');
 
-          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({limit: 10,
+          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({limit: 50,
             offset: 0,
             sort: '+fullName',
             'summary.periods.14d.timeInHighPercent': '>=0.25',
@@ -1186,7 +1186,7 @@ describe('ClinicPatients', () => {
 
           it('should fetch the initial patient based on the stored filters', () => {
             sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({
-              limit: 10,
+              limit: 50,
               offset: 0,
               sort: '+fullName',
               'summary.lastUploadDateFrom': sinon.match.string,


### PR DESCRIPTION
for [WEB-1701], sets page size to 50 and adds support for scrolling table by capping the table container height

[WEB-1701]: https://tidepool.atlassian.net/browse/WEB-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ