### PR TITLE
[WEB-1701] allow page scrolling, add scroll to top button

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -27,8 +27,12 @@ import RefreshRoundedIcon from '@material-ui/icons/RefreshRounded';
 import SearchIcon from '@material-ui/icons/Search';
 import VisibilityOffOutlinedIcon from '@material-ui/icons/VisibilityOffOutlined';
 import VisibilityOutlinedIcon from '@material-ui/icons/VisibilityOutlined';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import { components as vizComponents, utils as vizUtils } from '@tidepool/viz';
 import sundial from 'sundial';
+import ScrollToTop from 'react-scroll-to-top';
+import styled from 'styled-components';
+import { colors } from '../../../app/themes/baseTheme';
 
 import {
   bindPopover,
@@ -76,6 +80,14 @@ import { borders, radii } from '../../themes/baseTheme';
 const { Loader } = vizComponents;
 const { reshapeBgClassesToBgBounds, generateBgRangeLabels } = vizUtils.bg;
 const { getLocalizedCeiling } = vizUtils.datetime;
+
+const StyledScrollToTop = styled(ScrollToTop)`
+  background-color: ${colors.purpleMedium};
+  right: 20px;
+  bottom: 70px;
+  border-radius: 20px;
+  padding-top: 4px;
+`;
 
 export const ClinicPatients = (props) => {
   const { t, api, trackMetric, searchDebounceMs } = props;
@@ -1414,8 +1426,6 @@ export const ClinicPatients = (props) => {
           onSort={handleSortChange}
           order={sort.substring(0, 1) === '+' ? 'asc' : 'desc'}
           orderBy={sort.substring(1)}
-          stickyHeader
-          containerStyles={{maxHeight: '560px', overflow: 'auto'}}
         />
 
         {pageCount > 1 && (
@@ -1453,6 +1463,11 @@ export const ClinicPatients = (props) => {
       {showEditPatientDialog && renderEditPatientDialog()}
       {showTimeInRangeDialog && renderTimeInRangeDialog()}
       {showSendUploadReminderDialog && renderSendUploadReminderDialog()}
+      <StyledScrollToTop
+        smooth
+        top={600}
+        component={<ArrowUpwardIcon />}
+      />
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "react-redux": "7.2.0",
     "react-router-dom": "5.2.0",
     "react-scroll": "1.7.10",
+    "react-scroll-to-top": "3.0.0",
     "react-select": "2.0.0",
     "react-test-renderer": "16.12.0",
     "react-window-size-listener": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15472,6 +15472,11 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-scroll-to-top@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-scroll-to-top/-/react-scroll-to-top-3.0.0.tgz#002984419d4d10fdb5654c9e3dd3341f81209a60"
+  integrity sha512-I/k45Ujai097du59tHBbzGxN7Lyc6K8Uc3IChq6HMXaBfB8N/rrfm055T5Yv0DWfVpf6pOFaBmhD3LOfH5unGw==
+
 react-scroll@1.7.10:
   version "1.7.10"
   resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.10.tgz#b59cfa11a899a362c6489607ed5865c9c5fd0b53"


### PR DESCRIPTION
An addition/alteration to [WEB-1701]. Lets the entire page scroll and adds a scroll to top button that appears as you scroll down the page.

[WEB-1701]: https://tidepool.atlassian.net/browse/WEB-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ