### PR TITLE
[WEB-1644] summary stat percentage rounding

### DIFF
--- a/app/components/clinic/BgRangeSummary.js
+++ b/app/components/clinic/BgRangeSummary.js
@@ -43,7 +43,7 @@ export const formatValue = (inputValue, key) => {
         precision = 2;
         percentage = roundUp(percentage, precision);
       }
-      if (percentage > 0.5 && percentage < 1) {
+      if (percentage >= 0.5 && percentage < 1) {
         precision = 1;
         percentage = roundDown(percentage, precision);
       }

--- a/app/components/clinic/BgRangeSummary.js
+++ b/app/components/clinic/BgRangeSummary.js
@@ -17,22 +17,71 @@ import { space, shadows } from '../../themes/baseTheme';
 import { utils as vizUtils } from '@tidepool/viz';
 const { reshapeBgClassesToBgBounds, generateBgRangeLabels } = vizUtils.bg;
 
+const roundUp = (value, precision = 1) => {
+  let shift = 10 ** precision;
+  return Math.ceil(value * shift) / shift;
+};
+
+const roundDown = (value, precision = 1) => {
+  let shift = 10 ** precision;
+  return Math.floor(value * shift) / shift;
+};
+
+export const formatValue = (inputValue, key) => {
+  let precision = 0;
+  let percentage = inputValue * 100;
+
+  // We want to show extra precision on very small percentages so that we avoid showing 0%
+  // when there is some data there.
+  if (percentage > 0 && percentage < 0.5) {
+    precision = percentage < 0.05 ? 2 : 1;
+  }
+
+  switch (key) {
+    case 'veryLow':
+      if (percentage > 0 && percentage < 0.5) {
+        precision = 2;
+        percentage = roundUp(percentage, precision);
+      }
+      if (percentage > 0.5 && percentage < 1) {
+        precision = 1;
+        percentage = roundDown(percentage, precision);
+      }
+      break;
+    case 'low':
+      if (percentage > 3 && percentage < 4) {
+        precision = 1;
+        percentage = roundDown(percentage, precision);
+      }
+      break;
+    case 'target':
+      if (percentage > 69 && percentage < 70) {
+        precision = 1;
+        percentage = roundDown(percentage, precision);
+      }
+      break;
+    case 'high':
+      if (percentage > 24 && percentage < 25) {
+        precision = 1;
+        percentage = roundDown(percentage, precision);
+      }
+      break;
+    case 'veryHigh':
+      if (percentage > 4 && percentage < 5) {
+        precision = 1;
+        percentage = roundDown(percentage, precision);
+      }
+      break;
+    default:
+      break;
+  }
+
+  return format(`.${precision}f`)(percentage);
+};
+
 export const BgRangeSummary = props => {
   const { bgUnits, data, striped, targetRange, t, ...themeProps } = props;
   const formattedBgUnits = bgUnits.replace(/l$/, 'L');
-
-  const formatValue = (value) => {
-    let precision = 0;
-    const percentage = value * 100;
-
-    // We want to show extra precision on very small percentages so that we avoid showing 0%
-    // when there is some data there.
-    if (percentage > 0 && percentage < 0.5) {
-      precision = percentage < 0.05 ? 2 : 1;
-    }
-
-    return format(`.${precision}f`)(percentage);
-  }
 
   const popupState = usePopupState({
     variant: 'popover',
@@ -96,7 +145,7 @@ export const BgRangeSummary = props => {
               <Flex key={key} flexDirection="column" alignItems="center">
                 <Flex className={`range-summary-value-${key}`} mb={2} textAlign="center" alignItems="flex-end" key={key} color={`bg.${key}`} flexWrap="nowrap">
                   <Text fontWeight="bold" lineHeight={1} fontSize={1}>
-                    {formatValue(value)}
+                    {formatValue(value, key)}
                   </Text>
                   <Text lineHeight={1} color="inherit" fontSize=".65em">%</Text>
                 </Flex>

--- a/test/unit/components/clinic/BgRangeSummary.test.js
+++ b/test/unit/components/clinic/BgRangeSummary.test.js
@@ -107,55 +107,56 @@ describe('BgRangeSummary', () => {
     const veryHighRange = popover().find('.range-summary-range-veryHigh').hostNodes();
     expect(veryHighRange.text()).to.equal('>250');
   });
+});
 
-  describe('formatValue', () => {
-    it('should round up for `veryLow` between 0 and 0.5 percent with 0.01 precision', () => {
-      expect(formatValue(0.00001, 'veryLow')).to.equal('0.01');
-      expect(formatValue(0.00052, 'veryLow')).to.equal('0.06');
-      expect(formatValue(0.00242, 'veryLow')).to.equal('0.25');
-      expect(formatValue(0.00436, 'veryLow')).to.equal('0.44');
-    });
-    it('should round down for `veryLow` between 0.5 and 1 percent with 0.1 precision', () => {
-      expect(formatValue(0.0068, 'veryLow')).to.equal('0.6');
-      expect(formatValue(0.0082, 'veryLow')).to.equal('0.8');
-      expect(formatValue(0.0132, 'veryLow')).to.equal('1');
-      expect(formatValue(0.015, 'veryLow')).to.equal('2');
-    });
-    it('should round down for `low` between 3 and 4 percent with 0.1 precision', () => {
-      expect(formatValue(0.0327, 'low')).to.equal('3.2');
-      expect(formatValue(0.0384, 'low')).to.equal('3.8');
-      expect(formatValue(0.025, 'low')).to.equal('3');
-      expect(formatValue(0.0462, 'low')).to.equal('5');
-    });
-    it('should round down for `target` between 69 and 70 percent with 0.1 precision', () => {
-      expect(formatValue(0.6999, 'target')).to.equal('69.9');
-      expect(formatValue(0.6942, 'target')).to.equal('69.4');
-      expect(formatValue(0.685, 'target')).to.equal('69');
-      expect(formatValue(0.705, 'target')).to.equal('71');
-    });
-    it('should round down for `high` between 24 and 25 percent with 0.1 precision', () => {
-      expect(formatValue(0.2499, 'high')).to.equal('24.9');
-      expect(formatValue(0.2442, 'high')).to.equal('24.4');
-      expect(formatValue(0.235, 'high')).to.equal('24');
-      expect(formatValue(0.255, 'high')).to.equal('26');
-    });
-    it('should round down for `veryHigh` between 4 and 5 percent with 0.1 precision', () => {
-      expect(formatValue(0.0499, 'veryHigh')).to.equal('4.9');
-      expect(formatValue(0.0442, 'veryHigh')).to.equal('4.4');
-      expect(formatValue(0.035, 'veryHigh')).to.equal('4');
-      expect(formatValue(0.055, 'veryHigh')).to.equal('6');
-    });
-    it('should use normal rounding with 1.0 precision for other values over 0.5 percent', () => {
-      expect(formatValue(0.26459, 'veryHigh')).to.equal('26');
-      expect(formatValue(0.00589, 'low')).to.equal('1');
-    });
-    it('should use normal rounding with 0.1 precision for other values under 0.5 and over 0.05', () => {
-      expect(formatValue(0.0043, 'veryHigh')).to.equal('0.4');
-      expect(formatValue(0.0035, 'high')).to.equal('0.4');
-    });
-    it('should use normal rounding with 0.01 precision for values under 0.05', () => {
-      expect(formatValue(0.00043, 'veryHigh')).to.equal('0.04');
-      expect(formatValue(0.00025, 'high')).to.equal('0.03');
-    });
+describe('formatValue', () => {
+  it('should round up for `veryLow` between 0 and 0.5 percent with 0.01 precision', () => {
+    expect(formatValue(0.00001, 'veryLow')).to.equal('0.01');
+    expect(formatValue(0.00052, 'veryLow')).to.equal('0.06');
+    expect(formatValue(0.00242, 'veryLow')).to.equal('0.25');
+    expect(formatValue(0.00436, 'veryLow')).to.equal('0.44');
+  });
+  it('should round down for `veryLow` from 0.5 up to 1 percent with 0.1 precision', () => {
+    expect(formatValue(0.005, 'veryLow')).to.equal('0.5');
+    expect(formatValue(0.0068, 'veryLow')).to.equal('0.6');
+    expect(formatValue(0.0082, 'veryLow')).to.equal('0.8');
+    expect(formatValue(0.0132, 'veryLow')).to.equal('1');
+    expect(formatValue(0.015, 'veryLow')).to.equal('2');
+  });
+  it('should round down for `low` between 3 and 4 percent with 0.1 precision', () => {
+    expect(formatValue(0.0327, 'low')).to.equal('3.2');
+    expect(formatValue(0.0384, 'low')).to.equal('3.8');
+    expect(formatValue(0.025, 'low')).to.equal('3');
+    expect(formatValue(0.0462, 'low')).to.equal('5');
+  });
+  it('should round down for `target` between 69 and 70 percent with 0.1 precision', () => {
+    expect(formatValue(0.6999, 'target')).to.equal('69.9');
+    expect(formatValue(0.6942, 'target')).to.equal('69.4');
+    expect(formatValue(0.685, 'target')).to.equal('69');
+    expect(formatValue(0.705, 'target')).to.equal('71');
+  });
+  it('should round down for `high` between 24 and 25 percent with 0.1 precision', () => {
+    expect(formatValue(0.2499, 'high')).to.equal('24.9');
+    expect(formatValue(0.2442, 'high')).to.equal('24.4');
+    expect(formatValue(0.235, 'high')).to.equal('24');
+    expect(formatValue(0.255, 'high')).to.equal('26');
+  });
+  it('should round down for `veryHigh` between 4 and 5 percent with 0.1 precision', () => {
+    expect(formatValue(0.0499, 'veryHigh')).to.equal('4.9');
+    expect(formatValue(0.0442, 'veryHigh')).to.equal('4.4');
+    expect(formatValue(0.035, 'veryHigh')).to.equal('4');
+    expect(formatValue(0.055, 'veryHigh')).to.equal('6');
+  });
+  it('should use normal rounding with 1.0 precision for other values over 0.5 percent', () => {
+    expect(formatValue(0.26459, 'veryHigh')).to.equal('26');
+    expect(formatValue(0.00589, 'low')).to.equal('1');
+  });
+  it('should use normal rounding with 0.1 precision for other values under 0.5 and over 0.05', () => {
+    expect(formatValue(0.0043, 'veryHigh')).to.equal('0.4');
+    expect(formatValue(0.0035, 'high')).to.equal('0.4');
+  });
+  it('should use normal rounding with 0.01 precision for values under 0.05', () => {
+    expect(formatValue(0.00043, 'veryHigh')).to.equal('0.04');
+    expect(formatValue(0.00025, 'high')).to.equal('0.03');
   });
 });

--- a/test/unit/components/clinic/BgRangeSummary.test.js
+++ b/test/unit/components/clinic/BgRangeSummary.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createMount } from '@material-ui/core/test-utils';
-import BgRangeSummary from '../../../../app/components/clinic/BgRangeSummary';
+import BgRangeSummary, { formatValue } from '../../../../app/components/clinic/BgRangeSummary';
 import { MGDL_UNITS } from '../../../../app/core/constants';
 
 /* global chai */
@@ -106,5 +106,56 @@ describe('BgRangeSummary', () => {
 
     const veryHighRange = popover().find('.range-summary-range-veryHigh').hostNodes();
     expect(veryHighRange.text()).to.equal('>250');
+  });
+
+  describe('formatValue', () => {
+    it('should round up for `veryLow` between 0 and 0.5 percent with 0.01 precision', () => {
+      expect(formatValue(0.00001, 'veryLow')).to.equal('0.01');
+      expect(formatValue(0.00052, 'veryLow')).to.equal('0.06');
+      expect(formatValue(0.00242, 'veryLow')).to.equal('0.25');
+      expect(formatValue(0.00436, 'veryLow')).to.equal('0.44');
+    });
+    it('should round down for `veryLow` between 0.5 and 1 percent with 0.1 precision', () => {
+      expect(formatValue(0.0068, 'veryLow')).to.equal('0.6');
+      expect(formatValue(0.0082, 'veryLow')).to.equal('0.8');
+      expect(formatValue(0.0132, 'veryLow')).to.equal('1');
+      expect(formatValue(0.015, 'veryLow')).to.equal('2');
+    });
+    it('should round down for `low` between 3 and 4 percent with 0.1 precision', () => {
+      expect(formatValue(0.0327, 'low')).to.equal('3.2');
+      expect(formatValue(0.0384, 'low')).to.equal('3.8');
+      expect(formatValue(0.025, 'low')).to.equal('3');
+      expect(formatValue(0.0462, 'low')).to.equal('5');
+    });
+    it('should round down for `target` between 69 and 70 percent with 0.1 precision', () => {
+      expect(formatValue(0.6999, 'target')).to.equal('69.9');
+      expect(formatValue(0.6942, 'target')).to.equal('69.4');
+      expect(formatValue(0.685, 'target')).to.equal('69');
+      expect(formatValue(0.705, 'target')).to.equal('71');
+    });
+    it('should round down for `high` between 24 and 25 percent with 0.1 precision', () => {
+      expect(formatValue(0.2499, 'high')).to.equal('24.9');
+      expect(formatValue(0.2442, 'high')).to.equal('24.4');
+      expect(formatValue(0.235, 'high')).to.equal('24');
+      expect(formatValue(0.255, 'high')).to.equal('26');
+    });
+    it('should round down for `veryHigh` between 4 and 5 percent with 0.1 precision', () => {
+      expect(formatValue(0.0499, 'veryHigh')).to.equal('4.9');
+      expect(formatValue(0.0442, 'veryHigh')).to.equal('4.4');
+      expect(formatValue(0.035, 'veryHigh')).to.equal('4');
+      expect(formatValue(0.055, 'veryHigh')).to.equal('6');
+    });
+    it('should use normal rounding with 1.0 precision for other values over 0.5 percent', () => {
+      expect(formatValue(0.26459, 'veryHigh')).to.equal('26');
+      expect(formatValue(0.00589, 'low')).to.equal('1');
+    });
+    it('should use normal rounding with 0.1 precision for other values under 0.5 and over 0.05', () => {
+      expect(formatValue(0.0043, 'veryHigh')).to.equal('0.4');
+      expect(formatValue(0.0035, 'high')).to.equal('0.4');
+    });
+    it('should use normal rounding with 0.01 precision for values under 0.05', () => {
+      expect(formatValue(0.00043, 'veryHigh')).to.equal('0.04');
+      expect(formatValue(0.00025, 'high')).to.equal('0.03');
+    });
   });
 });


### PR DESCRIPTION
For [WEB-1644], applies a number of rounding rules to prevent rounding display values into filter boundaries.

[WEB-1644]: https://tidepool.atlassian.net/browse/WEB-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ