### PR TITLE
[WEB-1835] simplify useEffect dependencies

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -260,10 +260,6 @@ export const ClinicPatients = (props) => {
   }, [sendingPatientUploadReminder]);
 
   useEffect(() => {
-    setLoading(fetchingPatientsForClinic.inProgress);
-  }, [fetchingPatientsForClinic.inProgress]);
-
-  useEffect(() => {
     const { inProgress, completed, notification } = fetchingPatientsForClinic;
 
     if (!isFirstRender && !inProgress) {
@@ -278,6 +274,7 @@ export const ClinicPatients = (props) => {
       // the user would like to see the results
       if (!showNames && patientFetchCount > 0) setShowNames(true);
       setPatientFetchCount(patientFetchCount + 1);
+      setLoading(inProgress);
     }
   }, [fetchingPatientsForClinic]);
 


### PR DESCRIPTION
For [WEB-1835], combines two `useEffect` calls with overlapping dependency arrays. There's some subtle conflict where the combination of an object and an object's property being dependencies of two different `useEffect` calls will cause undesirable behavior. 
The `inProgress` property on `fetchingPatientsForClinic` would be `true` when I would have expected it to be `false` on the `useEffect` that should `setLoading` and then the second `useEffect` wouldn't actually run at all. By just combining them both, it runs when expected and has the proper `fetchingPatientsForClinic.inProgress` = `false` for the `FETCH_PATIENTS_FOR_CLINIC_SUCCESS` state update.

[WEB-1835]: https://tidepool.atlassian.net/browse/WEB-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ