### PR TITLE
[WEB-1701] scroll to top on page, performance pass, eslint react-hooks/recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,9 @@
     "__INVITE_KEY__": false,
     "__LATEST_TERMS__": false
   },
+  "extends": [
+    "plugin:react-hooks/recommended"
+  ],
   "rules": {
     "quotes": [2, "single", {
       "avoidEscape": true

--- a/app/components/clinic/BgRangeSummary.js
+++ b/app/components/clinic/BgRangeSummary.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Text, Box, Flex } from 'rebass/styled-components';
 import map from 'lodash/map';
+import isEqual from 'lodash/isEqual';
 import { format } from 'd3-format';
 import { translate } from 'react-i18next';
 
@@ -17,7 +18,7 @@ import { space, shadows } from '../../themes/baseTheme';
 import { utils as vizUtils } from '@tidepool/viz';
 const { reshapeBgClassesToBgBounds, generateBgRangeLabels } = vizUtils.bg;
 
-export const BgRangeSummary = props => {
+export const BgRangeSummary = React.memo(props => {
   const { bgUnits, data, striped, targetRange, t, ...themeProps } = props;
   const formattedBgUnits = bgUnits.replace(/l$/, 'L');
 
@@ -39,6 +40,8 @@ export const BgRangeSummary = props => {
     popupId: 'summaryPopover',
   });
 
+  const popoverProps = useMemo(() => bindPopover(popupState), [popupState]);
+
   const bgPrefs = {
     bgUnits: formattedBgUnits,
     bgBounds: reshapeBgClassesToBgBounds({ bgUnits: formattedBgUnits, bgClasses: {
@@ -47,11 +50,24 @@ export const BgRangeSummary = props => {
     }}),
   };
 
+  const anchorOrigin = useMemo(() => ({
+    vertical: 'bottom',
+    horizontal: 'center',
+  }), []);
+
+  const transformOrigin = useMemo(() => ({
+    vertical: 'top',
+    horizontal: 'center',
+  }), []);
+
+  const popoverFlexStyle = useMemo(() => ({ gap: 3 }), []);
+  const wrapperStyle = useMemo(() => ({ position: 'relative' }), []);
+
   const bgLabels = generateBgRangeLabels(bgPrefs, { condensed: true });
 
   return (
     <>
-      <Box sx={{ position: 'relative' }} {...themeProps}>
+      <Box sx={wrapperStyle} {...themeProps}>
         <Flex className="range-summary-bars" width="200px" height="20px" justifyContent="center" {...bindHover(popupState)}>
           {map(data, (value, key) => (
               <Box className={`range-summary-bars-${key}`} key={key} bg={`bg.${key}`} width={`${value * 100}%`}/>
@@ -75,23 +91,17 @@ export const BgRangeSummary = props => {
 
       <Popover
         className='range-summary-data'
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'center',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
-        }}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
         width="auto"
         height="auto"
         marginTop={`${space[1]}px`}
         boxShadow={shadows.small}
-        {...bindPopover(popupState)}
+        {...popoverProps}
         useHoverPopover
       >
         <Box px={2} py={1}>
-          <Flex mb={1} sx={{ gap: 3 }} justifyContent="space-between" flexWrap="nowrap">
+          <Flex mb={1} sx={popoverFlexStyle} justifyContent="space-between" flexWrap="nowrap">
             {map(data, (value, key) => (
               <Flex key={key} flexDirection="column" alignItems="center">
                 <Flex className={`range-summary-value-${key}`} mb={2} textAlign="center" alignItems="flex-end" key={key} color={`bg.${key}`} flexWrap="nowrap">
@@ -110,7 +120,7 @@ export const BgRangeSummary = props => {
       </Popover>
     </>
   );
-};
+}, isEqual);
 
 BgRangeSummary.propTypes = {
   bgUnits: PropTypes.string.isRequired,

--- a/app/components/clinic/ClinicProfile.js
+++ b/app/components/clinic/ClinicProfile.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -45,6 +45,15 @@ export const ClinicProfile = (props) => {
   const isClinicAdmin = includes(get(clinic, ['clinicians', loggedInUserId, 'roles'], []), 'CLINIC_ADMIN');
   const isWorkspacePath = pathname.indexOf('/clinic-workspace') === 0;
   const [editing, setEditing] = useState(false);
+  const buttonText = useMemo(() =>
+    <Icon
+      variant="static"
+      icon={FileCopyRoundedIcon}
+      label={t('Copy Share Code')}
+      title={t('Copy Share Code')}
+    />, [t]
+  );
+  const buttonSuccessText = useMemo(() => <span className="success">{t('✓')}</span>, [t]);
 
   const navigationAction = {
     label: isWorkspacePath ? t('View Clinic Members'): t('View Patient List'),
@@ -74,7 +83,7 @@ export const ClinicProfile = (props) => {
     if (clinic) {
       setValues(clinicValuesFromClinic(clinic))
     }
-  }, [clinic])
+  }, [clinic, setValues])
 
   useEffect(() => {
     const { inProgress, completed, notification } = updatingClinic;
@@ -97,6 +106,13 @@ export const ClinicProfile = (props) => {
       }
     }
   }, [updatingClinic]);
+
+  const getButtonText = useCallback(() => clinic?.shareCode, [clinic?.shareCode]);
+  const buttonOnClick = useCallback(() => {
+    trackMetric('Clinic - Copy clinic share code', {
+      clinicId: selectedClinicId,
+    });
+  }, [selectedClinicId]);
 
   function handleNavigationAction() {
     const source = isWorkspacePath ? undefined : 'Clinic members';
@@ -157,19 +173,10 @@ export const ClinicProfile = (props) => {
                 <Title>{clinic.shareCode}</Title>
                 <ClipboardButton
                   buttonTitle={t('Copy Share Code')}
-                  buttonText={(
-                    <Icon
-                      variant="static"
-                      icon={FileCopyRoundedIcon}
-                      label={t('Copy Share Code')}
-                      title={t('Copy Share Code')}
-                    />
-                  )}
-                  successText={<span className="success">{t('✓')}</span>}
-                  onClick={() => {
-                    trackMetric('Clinic - Copy clinic share code', { clinicId: selectedClinicId })
-                  }}
-                  getText={() => clinic.shareCode}
+                  buttonText={buttonText}
+                  successText={buttonSuccessText}
+                  onClick={buttonOnClick}
+                  getText={getButtonText}
                 />
               </Flex>
             </Box>

--- a/app/components/elements/Popover.js
+++ b/app/components/elements/Popover.js
@@ -28,6 +28,8 @@ const PopoverContentWrapper = React.forwardRef((props, ref) => (
   <Box {...props} ref={ref} />
 ));
 
+const PaperProp = { component: PopoverContentWrapper };
+
 const Popover = props => {
   const {
     children,
@@ -45,11 +47,11 @@ const Popover = props => {
 
   React.useEffect(() => {
     setComponent(StyledPopover(useHoverPopover ? HoverPopover : Base));
-  }, []);
+  }, [useHoverPopover]);
 
   return (
     <Component
-      PaperProps={{ component: PopoverContentWrapper }}
+      PaperProps={PaperProp}
       boxshadow={boxShadow}
       margintop={marginTop}
       minwidth={minWidth}

--- a/app/components/elements/Table.js
+++ b/app/components/elements/Table.js
@@ -86,7 +86,7 @@ const StyledTable = styled(Base)`
   }
 `;
 
-export const Table = props => {
+export const Table = React.memo(props => {
   const {
     columns,
     data,
@@ -229,7 +229,7 @@ export const Table = props => {
       />}
     </Box>
   );
-};
+});
 
 Table.propTypes = {
   ...TableProps,

--- a/app/core/hooks.js
+++ b/app/core/hooks.js
@@ -6,7 +6,8 @@ import { useField, useFormikContext } from 'formik';
 // c.f. https://gist.github.com/joshsalverda/d808d92f46a7085be062b2cbde978ae6
 // Avoids some performance issues in Formik's native <FieldArray />
 // Solution stems from this issue on Formik's GH: https://github.com/jaredpalmer/formik/issues/1476
-export const useFieldArray = (props, formikContext = useFormikContext()) => {
+export const useFieldArray = (props, formikContext) => {
+  formikContext = formikContext ?? useFormikContext();
   const [field, meta] = useField(props);
   const fieldArray = useRef(field.value);
   const { setFieldValue } = formikContext;

--- a/app/pages/clinicworkspace/clinicworkspace.js
+++ b/app/pages/clinicworkspace/clinicworkspace.js
@@ -8,6 +8,7 @@ import forEach from 'lodash/forEach';
 import get from 'lodash/get'
 import values from 'lodash/values'
 import { Box } from 'rebass/styled-components';
+import { Element } from 'react-scroll';
 
 import TabGroup from '../../components/elements/TabGroup';
 import ClinicProfile from '../../components/clinic/ClinicProfile';
@@ -103,6 +104,7 @@ export const ClinicWorkspace = (props) => {
       <ClinicProfile api={api} trackMetric={trackMetric} />
 
       <Box id="clinic-workspace" alignItems="center" variant="containers.largeBordered" mb={9}>
+        <Element name="workspaceTabsTop" />
         <TabGroup
           aria-label="Clinic workspace tabs"
           id="clinic-workspace-tabs"

--- a/app/pages/prescription/reviewFormStep.js
+++ b/app/pages/prescription/reviewFormStep.js
@@ -44,9 +44,7 @@ const fieldsetPropTypes = {
 
 const emptyValueText = t('Not specified');
 
-const patientRows = values => {
-  const formikContext = useFormikContext();
-
+const patientRows = (values, formikContext) => {
   return [
     {
       label: t('Email'),
@@ -88,8 +86,7 @@ const patientRows = values => {
   ];
 };
 
-const therapySettingsRows = (pump) => {
-  const formikContext = useFormikContext();
+const therapySettingsRows = (pump, formikContext) => {
   const { values } = formikContext;
   const bgUnits = get(values, 'initialSettings.bloodGlucoseUnits');
   const thresholds = warningThresholds(pump, bgUnits, values);
@@ -302,8 +299,9 @@ export const PatientInfo = props => {
 
   const nameStep = [0, 1];
   const currentStep = [4, 0];
+  const formikContext = useFormikContext();
 
-  const { values } = useFormikContext();
+  const { values } = formikContext;
 
   const {
     firstName,
@@ -311,7 +309,7 @@ export const PatientInfo = props => {
   } = values;
 
   const patientName = [firstName, lastName].join(' ');
-  const rows = patientRows(values);
+  const rows = patientRows(values, formikContext);
 
   const Row = ({ label, value, step, initialFocusedInput, error }) => (
     <Flex mb={4} justifyContent="space-between" alignItems="center">
@@ -363,7 +361,8 @@ export const TherapySettings = props => {
   const therapySettingsStep = [3, 0];
   const currentStep = [4, 0];
 
-  const { values } = useFormikContext();
+  const formikContext = useFormikContext();
+  const { values } = formikContext;
 
   const {
     firstName,
@@ -372,7 +371,7 @@ export const TherapySettings = props => {
 
   const patientName = [firstName, lastName].join(' ');
 
-  const rows = therapySettingsRows(pump);
+  const rows = therapySettingsRows(pump, formikContext);
 
   const Row = ({ label, value, warning, id, index, error }) => {
     let rowValues = isArray(value) ? value : [value];
@@ -487,8 +486,8 @@ export const TherapySettings = props => {
                 label: t('Name'),
                 value: patientName,
               },
-              ...patientRows(values),
-            ], therapySettingsRows(pump, values))}
+              ...patientRows(values, formikContext),
+            ], therapySettingsRows(pump, formikContext))}
           />
         </Box>
       </Flex>

--- a/app/providers/ToastProvider.js
+++ b/app/providers/ToastProvider.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import get from 'lodash/get';
 
 import Toast from '../components/elements/Toast';
@@ -14,11 +14,12 @@ export function ToastProvider({ children }) {
     setOpen(get(toast, 'open', !!toast));
   }, [toast]);
 
-  const set = toast => setToast(toast);
-  const clear = () => setToast(null);
+  const set = useCallback(toast => setToast(toast), []);
+  const clear = useCallback(() => setToast(null), []);
+  const value = useMemo(() => ({set,clear}), [clear, set]);
 
   return (
-    <ToastContext.Provider value={{ set, clear }}>
+    <ToastContext.Provider value={value}>
       {children}
       {toast && <Toast onClose={clear} open={open} {...toast}/>}
     </ToastContext.Provider>

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-lodash": "6.0.0",
     "eslint-plugin-react": "7.20.3",
+    "eslint-plugin-react-hooks": "4.6.0",
     "file-loader": "2.0.0",
     "fixed-data-table-2": "1.0.2",
     "formik": "2.1.4",

--- a/test/unit/app/core/hooks.test.js
+++ b/test/unit/app/core/hooks.test.js
@@ -28,12 +28,13 @@ describe('hooks', function() {
     let setFieldValue;
 
     beforeEach(() => {
-      function fooHook() {
+      function FooHook() {
         const [foo, setFoo] = useState(initialFoo);
         return { foo, setFoo };
       }
 
-      const { result: fooResult } = renderHook(() => fooHook());
+      // eslint-disable-next-line new-cap
+      const { result: fooResult } = renderHook(() => FooHook());
       expect(fooResult.current.foo).to.equal(initialFoo);
 
       setFieldValue = sinon.stub().callsFake((name, value) => {
@@ -187,12 +188,13 @@ describe('hooks', function() {
 
   describe('usePrevious', () => {
     it('should store the previous state', () => {
-      function fooHook() {
+      function FooHook() {
         const [foo, setFoo] = useState('foo');
         return { foo, setFoo };
       }
 
-      const { result: fooResult } = renderHook(() => fooHook());
+      // eslint-disable-next-line new-cap
+      const { result: fooResult } = renderHook(() => FooHook());
       expect(fooResult.current.foo).to.equal('foo');
 
       const { result: usePreviousResult, rerender } = renderHook(() => usePrevious(fooResult.current.foo));

--- a/yarn.lock
+++ b/yarn.lock
@@ -7859,6 +7859,11 @@ eslint-plugin-lodash@6.0.0:
   dependencies:
     lodash "^4.17.15"
 
+eslint-plugin-react-hooks@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@7.20.3:
   version "7.20.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.3.tgz#0590525e7eb83890ce71f73c2cf836284ad8c2f1"


### PR DESCRIPTION
As part of the latest design tweaks for [WEB-1701] (scrolling to the top of the patient interface on pagination) it was discovered that there were performance issues causing loading state hangs in the interface. As a start, I grabbed the eslint react-hooks/recommended plugin and went about trying to satisfy all of its errors and warnings for the ClinicPatients page. This lead to a lot of dependency adding, cascading into needing to move hook dependencies into hooks themselves and use-before-define errors to solve by rearranging significant portions of code. A couple sections were moved into sub-components in order to be able to move their prop processing into their own hooks as the renders for them were already in a hook (and, of course, one does not simply nest hooks).

In trying to keep the modifications scoped, I only edited files elsewhere in the codebase to resolve eslint errors (as opposed to warnings) or things that caused other errors (adding setToast from ToastProvider as a hook dependency resulted in an infinite loop when running the test suite which was _particularly_ difficult to debug).

[WEB-1701]: https://tidepool.atlassian.net/browse/WEB-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ