### PR TITLE
[WEB-1857] reset currentPage on default fetch options

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -538,6 +538,7 @@ export const ClinicPatients = (props) => {
           ...defaultPatientFetchOptions,
           limit: 50,
         });
+        setCurrentPage(1);
       }
     }
   }, [


### PR DESCRIPTION
See [WEB-1857], reset local current page on default fetch options being set to avoid scrolling on perceived page change when navigating from page > 1 to a new clinic. 

[WEB-1857]: https://tidepool.atlassian.net/browse/WEB-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ