### PR TITLE
[WEB-1838] force remount on data fetch after refresh

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1542,6 +1542,7 @@ export const PatientDataClass = createReactClass({
           excludedDevices: undefined,
           timePrefs,
           bgPrefs,
+          forceRemountAfterQuery: this.state.chartKey > 0
         });
       }
 

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -2493,6 +2493,32 @@ describe('PatientData', function () {
           });
         });
 
+        it('should query for intial data and force remount if `data.metaData.queryDataCount < 1` and state.chartKey > 0', () => {
+          const queryDataSpy = sinon.spy(instance, 'queryData');
+          sinon.assert.notCalled(queryDataSpy);
+
+          wrapper.setState({chartKey: 1});
+
+          wrapper.setProps(_.assign(props, {
+            data: {
+              metaData: { patientId: '40', queryDataCount: 0 },
+            },
+          }));
+
+          sinon.assert.calledWithMatch(queryDataSpy, {
+            types: {
+              upload: {
+                select: 'id,deviceId,deviceTags',
+              },
+            },
+            metaData: 'latestDatumByType,latestPumpUpload,size,bgSources,devices,excludedDevices,queryDataCount',
+            excludedDevices: undefined,
+            timePrefs: sinon.match.object,
+            bgPrefs: sinon.match.object,
+            forceRemountAfterQuery: true,
+          });
+        });
+
         context('querying data is completed', () => {
           const completedDataQueryProps = _.assign({}, props, {
             queryingData: {


### PR DESCRIPTION
For [WEB-1838]. If the `chartKey` happens to match up with the incoming query metadata on a query that tries to force a remount, the result of the update is nil. This can happen because the chartKey only gets updated on forced remount attempts and can recycle through values as the query count gets reset to 0 on use of the Refresh button. If we force a remount (and thus update the chartKey state value) on "initial" queries when we've already got a value for `state.chartKey`, we can keep the values better in sync post-Refresh. 

[WEB-1838]: https://tidepool.atlassian.net/browse/WEB-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ