### PR TITLE
Make sure table border can be seen in mozilla

### DIFF
--- a/app/components/elements/Table.js
+++ b/app/components/elements/Table.js
@@ -180,7 +180,6 @@ export const Table = React.memo(props => {
                   key={`${id}-header-${col.field?.replace(/\./g, '-')}`}
                   align={col.align || (index === 0 ? 'left' : 'right')}
                   sortDirection={orderBy === colSortBy ? order : false}
-
                 >
                   <Box
                     className="table-header-inner-cell"

--- a/app/components/elements/Table.js
+++ b/app/components/elements/Table.js
@@ -72,7 +72,7 @@ const StyledTable = styled(Base)`
     color: inherit;
     font-size: inherit;
     font-family: inherit;
-    background-clip: padding-box
+    background-clip: padding-box;
   }
 
   .MuiTableCell-stickyHeader {

--- a/app/components/elements/Table.js
+++ b/app/components/elements/Table.js
@@ -72,6 +72,7 @@ const StyledTable = styled(Base)`
     color: inherit;
     font-size: inherit;
     font-family: inherit;
+    background-clip: padding-box
   }
 
   .MuiTableCell-stickyHeader {
@@ -179,6 +180,7 @@ export const Table = React.memo(props => {
                   key={`${id}-header-${col.field?.replace(/\./g, '-')}`}
                   align={col.align || (index === 0 ? 'left' : 'right')}
                   sortDirection={orderBy === colSortBy ? order : false}
+
                 >
                   <Box
                     className="table-header-inner-cell"


### PR DESCRIPTION
Went down this rabbit hole  and seems to be an issue specifically with Mozilla Firefox. https://bugzilla.mozilla.org/show_bug.cgi?id=688556 
 
background-clip: padding-box seems to fix the issue.
