### PR TITLE
[WEB-2006] Repeat patient deletes, tags, upload reminders fail

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -597,6 +597,8 @@ export const ClinicPatients = (props) => {
   }
 
   const previousFetchingPatientsForClinic = usePrevious(fetchingPatientsForClinic);
+  const previousDeletingPatientFromClinic = usePrevious(deletingPatientFromClinic);
+  const previousSendingPatientUploadReminder = usePrevious(sendingPatientUploadReminder);
 
   const prefixPopHealthMetric = useCallback(metric => `Clinic - Population Health - ${metric}`, []);
 
@@ -643,12 +645,6 @@ export const ClinicPatients = (props) => {
   }, [creatingClinicCustodialAccount, handleAsyncResult, t]);
 
   useEffect(() => {
-    handleAsyncResult(deletingPatientFromClinic, t('{{name}} has been removed from the clinic.', {
-      name: get(selectedPatient, 'fullName', t('This patient')),
-    }));
-  }, [deletingPatientFromClinic, handleAsyncResult, selectedPatient, t]);
-
-  useEffect(() => {
     handleAsyncResult(creatingClinicPatientTag, t('Tag created.'), () => clinicPatientTagFormContext?.resetForm());
   }, [clinicPatientTagFormContext, creatingClinicPatientTag, handleAsyncResult, t]);
 
@@ -670,10 +666,80 @@ export const ClinicPatients = (props) => {
   }, [patientTags]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    handleAsyncResult(sendingPatientUploadReminder, t('Uploader reminder email for {{name}} has been sent.', {
+    const { inProgress, completed, notification } = deletingPatientFromClinic;
+    const successMessage = t('{{name}} has been removed from the clinic.', {
+      name: get(selectedPatient, 'fullName', t('This patient')),
+    });
+
+    if (
+      !isFirstRender &&
+      !inProgress &&
+      previousDeletingPatientFromClinic?.inProgress
+    ) {
+      if (completed) {
+        handleCloseOverlays();
+        setToast({
+          message: successMessage,
+          variant: 'success',
+        });
+      }
+
+      if (completed === false) {
+        setToast({
+          message: get(notification, 'message'),
+          variant: 'danger',
+        });
+      }
+
+      setLoading(false);
+    }
+  }, [
+    deletingPatientFromClinic,
+    handleAsyncResult,
+    isFirstRender,
+    previousDeletingPatientFromClinic?.inProgress,
+    selectedPatient,
+    setToast,
+    t,
+  ]);
+
+  useEffect(() => {
+    const { inProgress, completed, notification } = sendingPatientUploadReminder;
+    const successMessage = t('Uploader reminder email for {{name}} has been sent.', {
       name: get(selectedPatient, 'fullName', t('this patient')),
-    }));
-  }, [handleAsyncResult, selectedPatient, sendingPatientUploadReminder, t]);
+    });
+
+    if (
+      !isFirstRender &&
+      !inProgress &&
+      previousSendingPatientUploadReminder?.inProgress
+    ) {
+      if (completed) {
+        handleCloseOverlays();
+        setToast({
+          message: successMessage,
+          variant: 'success',
+        });
+      }
+
+      if (completed === false) {
+        setToast({
+          message: get(notification, 'message'),
+          variant: 'danger',
+        });
+      }
+
+      setLoading(false);
+    }
+  }, [
+    handleAsyncResult,
+    isFirstRender,
+    previousSendingPatientUploadReminder?.inProgress,
+    selectedPatient,
+    sendingPatientUploadReminder,
+    setToast,
+    t,
+  ]);
 
   useEffect(() => {
     const { inProgress, completed, notification } = fetchingPatientsForClinic;


### PR DESCRIPTION
In order to handle [WEB-2006], this unwraps a couple of the `handleAsyncResult` calls in order to more finely control when they fire. Specifically we need to prevent the selected patient reset and dialog closures on complete detection when only the selected patient value as changed (and not the working state). This ensures that the remove patient and send upload reminder handlers don't effectively reset the selected patient and dialogs states whenever attempting either of those actions a second time. 

[WEB-2006]: https://tidepool.atlassian.net/browse/WEB-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ