### PR TITLE
[WEB-1997] pass loginHint if available

### DIFF
--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -151,7 +151,7 @@ export let Signup = translate()(class extends React.Component {
   };
 
   render() {
-    const { keycloakConfig, fetchingInfo } = this.props;
+    const { keycloakConfig, fetchingInfo, inviteEmail } = this.props;
     let form = this.renderForm();
     let inviteIntro = this.renderInviteIntroduction();
     let typeSelection = this.renderTypeSelection();
@@ -160,7 +160,11 @@ export let Signup = translate()(class extends React.Component {
       (!!keycloakConfig.url && !keycloakConfig.initialized);
 
     if(keycloakConfig.initialized){
-      keycloak.register();
+      if (inviteEmail) {
+        keycloak.register({ loginHint: inviteEmail });
+      } else {
+        keycloak.register();
+      }
     }
 
     let content = isLoading || keycloakConfig.initialized ? null : (

--- a/test/unit/pages/signup.test.js
+++ b/test/unit/pages/signup.test.js
@@ -269,6 +269,10 @@ describe('Signup', function () {
     let RewiredSignup;
     let wrapper;
 
+    afterEach(() => {
+      keycloakMock.register.reset();
+    });
+
     before(() => {
       Signup.__Rewire__('keycloak', keycloakMock);
       RewiredSignup = require('../../../app/pages/signup/signup.js').default;
@@ -304,6 +308,25 @@ describe('Signup', function () {
       });
       expect(keycloakMock.register.callCount).to.equal(1);
     });
+
+    it('should provide loginHint if inviteEmail is provided', () => {
+      expect(keycloakMock.register.callCount).to.equal(0);
+      storeState = merge(storeState, {
+        blip: { keycloakConfig: { initialized: true } },
+      });
+      store = mockStore(storeState);
+      wrapper.setProps({
+        inviteEmail: 'someEmail@provider.com',
+        keycloakConfig: {
+          url: 'keycloakUrl',
+          initialized: true,
+        },
+      });
+      expect(keycloakMock.register.callCount).to.equal(1);
+      expect(keycloakMock.register.calledWith({loginHint: 'someEmail@provider.com'}));
+    });
+
+
   });
 
   describe('initial state', function() {


### PR DESCRIPTION
To resolve [WEB-1997], pass along the email address for registration to keycloak if available

[WEB-1997]: https://tidepool.atlassian.net/browse/WEB-1997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ