### PR TITLE
[WEB-1998] redirect logout through keycloak if available

### DIFF
--- a/app/components/loginnav/loginnav.js
+++ b/app/components/loginnav/loginnav.js
@@ -6,6 +6,8 @@ import { keycloak } from '../../keycloak';
 import { translate } from 'react-i18next';
 var Link = require('react-router-dom').Link;
 
+let win = window;
+
 var LoginNav = translate()(class extends React.Component {
   static propTypes = {
     page: PropTypes.string,
@@ -46,7 +48,9 @@ var LoginNav = translate()(class extends React.Component {
       self.props.trackMetric('Clicked Sign Up Link');
       if (keycloakConfig.initialized) {
         e.preventDefault();
-        keycloak.register();
+        keycloak.register({
+          redirectUri: win.location.origin
+        });
       }
     };
 
@@ -59,7 +63,9 @@ var LoginNav = translate()(class extends React.Component {
         self.props.trackMetric('Clicked Log In Link');
         if(keycloakConfig.initialized) {
           e.preventDefault();
-          keycloak.login();
+          keycloak.login({
+            redirectUri: win.location.origin
+          });
         }
       };
     }

--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -28,7 +28,10 @@ export const updateKeycloakConfig = (info, store) => {
 export const onKeycloakEvent = (store) => (event, error) => {
   switch (event) {
     case 'onReady': {
-      store.dispatch(sync.keycloakReady(event, error));
+      let logoutUrl = keycloak.createLogoutUrl({
+        redirectUri: window.location.origin
+      });
+      store.dispatch(sync.keycloakReady(event, error, logoutUrl));
       break;
     }
     case 'onInitError': {
@@ -89,10 +92,6 @@ export const onKeycloakTokens = (store) => (tokens) => {
 
 export const keycloakMiddleware = (api) => (storeAPI) => (next) => (action) => {
   switch (action.type) {
-    case ActionTypes.LOGOUT_REQUEST: {
-      keycloak.logout();
-      break;
-    }
     case ActionTypes.FETCH_INFO_SUCCESS: {
       if (!isEqual(_keycloakConfig, action.payload?.info?.auth)) {
         updateKeycloakConfig(action.payload?.info?.auth, storeAPI);

--- a/app/pages/login/login.js
+++ b/app/pages/login/login.js
@@ -19,6 +19,7 @@ import Button from '../../components/elements/Button';
 import { components as vizComponents} from '@tidepool/viz';
 const { Loader } = vizComponents;
 import { keycloak } from '../../keycloak';
+let win = window;
 
 export let Login = translate()(class extends React.Component {
   static propTypes = {
@@ -89,12 +90,17 @@ export let Login = translate()(class extends React.Component {
       !loggingIn &&
       !this.props.isAuthenticated
     ) {
-      keycloak.login({ loginHint: this.props.seedEmail });
+      keycloak.login({
+        loginHint: this.props.seedEmail,
+        redirectUri: win.location.origin
+      });
     }
 
     // forward to keycloak login when available
     if(keycloakConfig.initialized && !loggingIn && !this.props.isAuthenticated){
-      keycloak.login();
+      keycloak.login({
+        redirectUri: win.location.origin
+      });
       return (<></>);
     }
 

--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -20,6 +20,7 @@ import { components as vizComponents} from '@tidepool/viz';
 const { Loader } = vizComponents;
 
 import check from './images/check.svg';
+let win = window;
 
 export let Signup = translate()(class extends React.Component {
   static propTypes = {
@@ -151,7 +152,7 @@ export let Signup = translate()(class extends React.Component {
   };
 
   render() {
-    const { keycloakConfig, fetchingInfo } = this.props;
+    const { keycloakConfig, fetchingInfo, inviteEmail } = this.props;
     let form = this.renderForm();
     let inviteIntro = this.renderInviteIntroduction();
     let typeSelection = this.renderTypeSelection();
@@ -160,7 +161,13 @@ export let Signup = translate()(class extends React.Component {
       (!!keycloakConfig.url && !keycloakConfig.initialized);
 
     if(keycloakConfig.initialized){
-      keycloak.register();
+      let options = {
+        redirectUri: win.location.origin
+      };
+      if(inviteEmail){
+        options.loginHint = inviteEmail;
+      }
+      keycloak.register(options);
     }
 
     let content = isLoading || keycloakConfig.initialized ? null : (

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -16,6 +16,8 @@ import { worker } from '.';
 
 import utils from '../../core/utils';
 
+let win = window;
+
 function createActionError(usrErrMessage, apiError) {
   const err = new Error(usrErrMessage);
   if (apiError) {
@@ -137,7 +139,7 @@ export function verifyCustodial(api, signupKey, signupEmail, birthday, password)
       } else {
         const { blip: { keycloakConfig } } = getState();
         if (keycloakConfig.initialized) {
-          keycloak.login({ loginHint: signupEmail, redirectUri: window.location.origin + '/login' });
+          keycloak.login({ loginHint: signupEmail, redirectUri: win.location.origin + '/login' });
         } else {
           dispatch(login(api, { username: signupEmail, password: password }, null, sync.verifyCustodialSuccess));
         }
@@ -370,12 +372,16 @@ export function login(api, credentials, options, postLoginAction) {
  */
 export function logout(api) {
   return (dispatch, getState) => {
-    const { blip: { currentPatientInViewId } } = getState();
+    const { blip: { currentPatientInViewId, keycloakConfig } } = getState();
     dispatch(sync.logoutRequest());
     dispatch(worker.dataWorkerRemoveDataRequest(null, currentPatientInViewId));
     api.user.logout(() => {
       dispatch(sync.logoutSuccess());
-      dispatch(push('/'));
+      if(keycloakConfig.logoutUrl){
+        win.location.assign(keycloakConfig.logoutUrl);
+      } else {
+        dispatch(push('/'));
+      }
     });
   }
 }

--- a/app/redux/actions/sync.js
+++ b/app/redux/actions/sync.js
@@ -2075,10 +2075,10 @@ export function deleteClinicPatientTagFailure(error, apiError) {
   };
 }
 
-export function keycloakReady(event, error){
+export function keycloakReady(event, error, logoutUrl){
   return {
     type: ActionTypes.KEYCLOAK_READY,
-    payload: { error, event },
+    payload: { error, event, logoutUrl },
   };
 }
 

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -1011,7 +1011,8 @@ export const keycloakConfig = (state = initialState.keycloakConfig, action) => {
         return _.get(action.payload, 'info.auth', {});
       }
     case types.KEYCLOAK_READY:
-      return _.extend({}, state, { initialized: true });
+      let logoutUrl = _.get(action.payload, 'logoutUrl', '');
+      return _.extend({}, state, { initialized: true, logoutUrl });
     default:
       return state;
   }

--- a/test/unit/components/loginnav.test.js
+++ b/test/unit/components/loginnav.test.js
@@ -50,9 +50,11 @@ describe('LoginNav', function () {
 
     before(() => {
       LoginNav.__Rewire__('keycloak', keycloakMock);
+      LoginNav.__Rewire__('win', { location: { origin: 'testOrigin' } });
     });
     after(() => {
       LoginNav.__ResetDependency__('keycloak');
+      LoginNav.__ResetDependency__('win');
     });
 
     it('should send users to keycloak register if keycloak is initialized', () => {
@@ -65,6 +67,7 @@ describe('LoginNav', function () {
       expect(keycloakMock.register.callCount).to.equal(0);
       link.simulate('click');
       expect(keycloakMock.register.callCount).to.equal(1);
+      expect(keycloakMock.register.calledWith({ redirectUri: 'testOrigin' })).to.be.true;
     });
   });
 });

--- a/test/unit/keycloak.test.js
+++ b/test/unit/keycloak.test.js
@@ -40,17 +40,23 @@ const asyncMock = {
   login: sinon.stub().returns(sinon.stub().callsFake(0)),
 };
 
+const keycloakMock = {
+  createLogoutUrl: sinon.stub().returns('keycloakLogoutUrl')
+};
+
 describe('keycloak', () => {
   const mockStore = configureStore([thunk]);
 
   before(() => {
     keycloak.__Rewire__('api', apiMock);
     keycloak.__Rewire__('async', asyncMock);
+    keycloak.__Rewire__('keycloak', keycloakMock);
   });
 
   after(() => {
     keycloak.__ResetDependency__('api');
     keycloak.__ResetDependency__('async');
+    keycloak.__ResetDependency__('keycloak');
   });
 
   beforeEach(() => {
@@ -73,6 +79,7 @@ describe('keycloak', () => {
           payload: {
             event: 'onReady',
             error: null,
+            logoutUrl: 'keycloakLogoutUrl'
           },
         },
       ];
@@ -223,14 +230,6 @@ describe('keycloak', () => {
     after(() => {
       keycloak.__ResetDependency__('keycloak');
       keycloak.__ResetDependency__('updateKeycloakConfig');
-    });
-
-    it('should call keycloak logout on LOGOUT_REQUEST', () => {
-      expect(keycloakMock.logout.callCount).to.equal(0);
-      keycloakMiddleware()()(sinon.stub())({
-        type: ActionTypes.LOGOUT_REQUEST,
-      });
-      expect(keycloakMock.logout.callCount).to.equal(1);
     });
 
     it('should update keycloak config if FETCH_INFO returns new config', () => {

--- a/test/unit/pages/login.test.js
+++ b/test/unit/pages/login.test.js
@@ -77,6 +77,7 @@ describe('Login', function () {
 
       before(() => {
         Login.__Rewire__('keycloak', keycloakMock);
+        Login.__Rewire__('win', { location: { origin: 'testOrigin' } });
         RewiredLogin = require('../../../app/pages/login/login.js').default;
         wrapper = mount(
           <Provider store={store}>
@@ -89,10 +90,12 @@ describe('Login', function () {
 
       after(() => {
         Login.__ResetDependency__('keycloak');
+        Login.__ResetDependency__('win');
       });
 
       it('should forward a user to keycloak login when initialized', () => {
         expect(keycloakMock.login.callCount).to.equal(1);
+        expect(keycloakMock.login.calledWith({ redirectUri: 'testOrigin' })).to.be.true;
       });
     });
   });

--- a/test/unit/pages/signup.test.js
+++ b/test/unit/pages/signup.test.js
@@ -271,6 +271,7 @@ describe('Signup', function () {
 
     before(() => {
       Signup.__Rewire__('keycloak', keycloakMock);
+      Signup.__Rewire__('win', { location: { origin: 'testOrigin' } });
       RewiredSignup = require('../../../app/pages/signup/signup.js').default;
       wrapper = mount(
         createElement(
@@ -288,6 +289,7 @@ describe('Signup', function () {
 
     after(() => {
       Signup.__ResetDependency__('keycloak');
+      Signup.__ResetDependency__('win');
     });
 
     it('should send the user to keycloak signup if keycloak is initialized', () => {
@@ -303,6 +305,7 @@ describe('Signup', function () {
         },
       });
       expect(keycloakMock.register.callCount).to.equal(1);
+      expect(keycloakMock.register.calledWith({ redirectUri: 'testOrigin' })).to.be.true;
     });
   });
 


### PR DESCRIPTION
For [WEB-1998], will send the user to the keycloak logout URL if it's available instead of redirecting to `\`, which can potentially beat out the `keycloak.logout()` call we were previously using, resulting in a not-logged-out state.

[WEB-1998]: https://tidepool.atlassian.net/browse/WEB-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ