### PR TITLE
Add local environment to apiHost config options list

### DIFF
--- a/config/local.example.js
+++ b/config/local.example.js
@@ -26,6 +26,7 @@ const featureFlags = {
 };
 
 const environments = {
+  local: 'http://localhost:31500',
   dev: 'https://dev1.dev.tidepool.org',
   qa1: 'https://qa1.development.tidepool.org',
   qa2: 'https://qa2.development.tidepool.org',


### PR DESCRIPTION
Local option was never added to the example file.  Now added.