### PR TITLE
[WEB-2064] Hotfix: Ensure latest pump settings are fetched

### DIFF
--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -1062,16 +1062,18 @@ export function fetchPatientData(api, options, id) {
             // diabetes datum time and going back 30 days
             const diabetesDatums = _.reject(latestDatums, d => _.includes(['food', 'upload', 'pumpSettings'], d.type));
             const latestDiabetesDatumTime = _.max(_.map(diabetesDatums, d => (d.time)));
+            const latestDatumTime = _.max(_.map(latestDatums, d => (d.time)));
 
             // If we have no latest diabetes datum time, we fall back to use the server time as the
             // ideal end date.
             const fetchFromTime = latestDiabetesDatumTime || serverTime;
+            const fetchToTime = latestDatumTime || serverTime;
 
             options.startDate = moment.utc(fetchFromTime).subtract(30, 'days').startOf('day').toISOString();
 
             // We add a 1 day buffer to the end date since we can get `time` fields that are slightly
             // in the future due to timezones or incorrect device and/or computer time upon upload.
-            options.endDate = moment.utc(fetchFromTime).add(1, 'days').toISOString();
+            options.endDate = moment.utc(fetchToTime).add(1, 'days').toISOString();
 
             // We want to make sure the latest upload, which may be beyond the data range we'll be
             // fetching, is stored so we can include it with the fetched results

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -4103,7 +4103,7 @@ describe('Actions', () => {
           }).callCount).to.equal(1);
         });
 
-        it.only('should fetch the patient data 30 days prior to the latest diabetes datum time returned', () => {
+        it('should fetch the patient data 30 days prior to the latest diabetes datum time returned', () => {
           let store = mockStore({ blip: {
             ...initialState,
           }, router: { location: { pathname: `data/${patientId}` } } });

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -4103,7 +4103,7 @@ describe('Actions', () => {
           }).callCount).to.equal(1);
         });
 
-        it('should fetch the patient data 30 days prior to the latest diabetes datum time returned', () => {
+        it.only('should fetch the patient data 30 days prior to the latest diabetes datum time returned', () => {
           let store = mockStore({ blip: {
             ...initialState,
           }, router: { location: { pathname: `data/${patientId}` } } });
@@ -4115,10 +4115,11 @@ describe('Actions', () => {
           expect(api.patientData.get.callCount).to.equal(3);
 
           // Should set the start date based on the latest smbg, even though the pump settings and upload are more recent
+          // End date should use the most recent date (the upload) to ensure they are still fetched
           expect(api.patientData.get.withArgs(patientId, {
             ...options,
             startDate: '2017-12-31T00:00:00.000Z',
-            endDate: '2018-01-31T00:00:00.000Z',
+            endDate: '2018-06-02T00:00:00.000Z',
           }).callCount).to.equal(1);
         });
       });


### PR DESCRIPTION
[WEB-2064] 
Currently, we exclude the latest `pumpSettings`, `upload`, and `food` datums when determining the fetch range for the initial data fetch.

This can lead to a situation, however, where the latest `pumpSettings` are not fetched and added to the data worker, so this fix still uses only the latest diabetes (insulin or bg) datums to determine the start date of the fetch range, but ensures the end date accounts for the non-diabetes datums as well. 

[WEB-2064]: https://tidepool.atlassian.net/browse/WEB-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ