### PR TITLE
[WEB-2059] Dexcom reconnect banner

### DIFF
--- a/app/components/clinic/PatientForm.js
+++ b/app/components/clinic/PatientForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { translate, Trans } from 'react-i18next';
+import { translate } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import compact from 'lodash/compact';
 import find from 'lodash/find';
@@ -19,7 +19,6 @@ import CloseRoundedIcon from '@material-ui/icons/CloseRounded';
 import CheckCircleRoundedIcon from '@material-ui/icons/CheckCircleRounded';
 import ErrorOutlineRoundedIcon from '@material-ui/icons/ErrorOutlineRounded';
 import { Box, Flex, Text, BoxProps } from 'rebass/styled-components';
-import sundial from 'sundial';
 import moment from 'moment';
 
 import * as actions from '../../redux/actions';
@@ -32,17 +31,10 @@ import { getCommonFormikFieldProps } from '../../core/forms';
 import { useIsFirstRender } from '../../core/hooks';
 import { dateRegex, patientSchema as validationSchema } from '../../core/clinicUtils';
 import { accountInfoFromClinicPatient } from '../../core/personutils';
-import { Body0, Body1, MediumTitle } from '../../components/elements/FontStyles';
+import { Body0 } from '../../components/elements/FontStyles';
 import { borders, colors } from '../../themes/baseTheme';
 import Icon from '../elements/Icon';
 import DexcomLogoIcon from '../../core/icons/DexcomLogo.svg';
-
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-} from '../../components/elements/Dialog';
 
 function getFormValues(source, clinicPatientTags, disableDexcom) {
   const hasDexcomDataSource = !!find(source?.dataSources, { providerName: 'dexcom' });
@@ -75,7 +67,6 @@ export const PatientForm = (props) => {
   const { set: setToast } = useToasts();
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const clinic = useSelector(state => state.blip.clinics?.[selectedClinicId]);
-  const timePrefs = useSelector((state) => state.blip.timePrefs);
   const dateInputFormat = 'MM/DD/YYYY';
   const dateMaskFormat = dateInputFormat.replace(/[A-Z]/g, '9');
   const [initialValues, setInitialValues] = useState({});
@@ -88,15 +79,6 @@ export const PatientForm = (props) => {
   const showDexcomConnectState = !!selectedClinicId && !!dexcomDataSource?.state;
   const [showResendDexcomConnectRequest, setShowResendDexcomConnectRequest] = useState(false);
   const { sendingPatientDexcomConnectRequest } = useSelector((state) => state.blip.working);
-
-  const formattedLastRequestedDexcomConnectDate =
-    patient?.lastRequestedDexcomConnectTime &&
-    sundial.formatInTimezone(
-      patient?.lastRequestedDexcomConnectTime,
-      timePrefs?.timezoneName ||
-        new Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'MM/DD/YYYY [at] h:mm a'
-    );
 
   const dexcomConnectStateUI = {
     pending: {
@@ -255,12 +237,12 @@ export const PatientForm = (props) => {
   }, [sendingPatientDexcomConnectRequest]);
 
   function handleResendDexcomConnectEmail() {
-    trackMetric('Clinic - Resend Dexcom connect email', { clinicId: selectedClinicId, dexcomConnectState })
+    trackMetric('Clinic - Resend Dexcom connect email', { clinicId: selectedClinicId, dexcomConnectState, source: 'patientForm' })
     setShowResendDexcomConnectRequest(true);
   }
 
   function handleResendDexcomConnectEmailConfirm() {
-    trackMetric('Clinic - Resend Dexcom connect email confirm', { clinicId: selectedClinicId });
+    trackMetric('Clinic - Resend Dexcom connect email confirm', { clinicId: selectedClinicId, source: 'patientForm' });
     formikContext.setStatus('resendingDexcomConnectRequest');
     dispatch(actions.async.sendPatientDexcomConnectRequest(api, selectedClinicId, patient.id));
   }
@@ -525,45 +507,15 @@ export const PatientForm = (props) => {
             </Body0>
           )}
 
-          <Dialog
-            id="resendDexcomConnectRequest"
-            aria-labelledby="dialog-title"
-            open={showResendDexcomConnectRequest}
+          <ResendDexcomConnectRequestDialog
+            api={api}
             onClose={() => setShowResendDexcomConnectRequest(false)}
-          >
-            <DialogTitle onClose={() => setShowResendDexcomConnectRequest(false)}>
-              <MediumTitle id="dialog-title">{t('Confirm Resending Connection Request')}</MediumTitle>
-            </DialogTitle>
-            <DialogContent>
-              <Body1>
-                {formattedLastRequestedDexcomConnectDate && (
-                  <Trans>
-                    <Text>
-                      You requested <Text as='span' fontWeight='bold'>{{patient: patient?.fullName || patient?.email}}</Text> to connect to <Text as='span' fontWeight='bold'>Dexcom</Text> on <Text as='span' fontWeight='bold'>{{requestDate: formattedLastRequestedDexcomConnectDate}}</Text>.
-                    </Text>
-                  </Trans>
-                )}
-                <Text>
-                  {t('Are you sure you want to resend this connection request?')}
-                </Text>
-              </Body1>
-            </DialogContent>
-            <DialogActions>
-              <Button variant="secondary" onClick={() => setShowResendDexcomConnectRequest(false)}>
-                {t('Cancel')}
-              </Button>
-              <Button
-                className="resend-dexcom-connect-request"
-                variant="primary"
-                processing={sendingPatientDexcomConnectRequest.inProgress}
-                onClick={() => {
-                  handleResendDexcomConnectEmailConfirm();
-                }}
-              >
-                {t('Resend Request')}
-              </Button>
-            </DialogActions>
-          </Dialog>
+            onConfirm={handleResendDexcomConnectEmailConfirm}
+            open={showResendDexcomConnectRequest}
+            patient={patient}
+            t={t}
+            trackMetric={trackMetric}
+          />
         </Box>
       )}
 

--- a/app/components/clinic/PatientForm.js
+++ b/app/components/clinic/PatientForm.js
@@ -26,6 +26,7 @@ import Checkbox from '../../components/elements/Checkbox';
 import TextInput from '../../components/elements/TextInput';
 import Button from '../../components/elements/Button';
 import { TagList } from '../../components/elements/Tag';
+import ResendDexcomConnectRequestDialog from './ResendDexcomConnectRequestDialog';
 import { useToasts } from '../../providers/ToastProvider';
 import { getCommonFormikFieldProps } from '../../core/forms';
 import { useIsFirstRender } from '../../core/hooks';

--- a/app/components/clinic/ResendDexcomConnectRequestDialog.js
+++ b/app/components/clinic/ResendDexcomConnectRequestDialog.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate, Trans } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { Text } from 'rebass/styled-components';
+import sundial from 'sundial';
+
+import Button from '../../components/elements/Button';
+import { Body1, MediumTitle } from '../../components/elements/FontStyles';
+
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '../../components/elements/Dialog';
+
+export const ResendDexcomConnectRequestDialog = (props) => {
+  const { t, onClose, onConfirm, open, patient } = props;
+  const timePrefs = useSelector((state) => state.blip.timePrefs);
+  const { sendingPatientDexcomConnectRequest } = useSelector((state) => state.blip.working);
+
+  const formattedLastRequestedDexcomConnectDate =
+    patient?.lastRequestedDexcomConnectTime &&
+    sundial.formatInTimezone(
+      patient?.lastRequestedDexcomConnectTime,
+      timePrefs?.timezoneName ||
+        new Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'MM/DD/YYYY [at] h:mm a'
+    );
+
+  return (
+    <Dialog
+      id="resendDexcomConnectRequest"
+      aria-labelledby="dialog-title"
+      open={open}
+      onClose={onClose}
+    >
+      <DialogTitle onClose={onClose}>
+        <MediumTitle id="dialog-title">{t('Confirm Resending Connection Request')}</MediumTitle>
+      </DialogTitle>
+      <DialogContent>
+        <Body1>
+          {formattedLastRequestedDexcomConnectDate && (
+            <Trans>
+              <Text>
+                You requested <Text as='span' fontWeight='bold'>{{patient: patient?.fullName || patient?.email}}</Text> to connect to <Text as='span' fontWeight='bold'>Dexcom</Text> on <Text as='span' fontWeight='bold'>{{requestDate: formattedLastRequestedDexcomConnectDate}}</Text>.
+              </Text>
+            </Trans>
+          )}
+          <Text>
+            {t('Are you sure you want to resend this connection request?')}
+          </Text>
+        </Body1>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('Cancel')}
+        </Button>
+        <Button
+          className="resend-dexcom-connect-request"
+          variant="primary"
+          processing={sendingPatientDexcomConnectRequest.inProgress}
+          onClick={onConfirm}
+        >
+          {t('Resend Request')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+ResendDexcomConnectRequestDialog.propTypes = {
+  api: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+  patient: PropTypes.object,
+  t: PropTypes.func.isRequired,
+  trackMetric: PropTypes.func.isRequired,
+};
+
+export default translate()(ResendDexcomConnectRequestDialog);

--- a/app/components/datasources/datasources.js
+++ b/app/components/datasources/datasources.js
@@ -116,7 +116,7 @@ export default translate()(class DataSources extends Component {
 
   calculateErrorMessage(error) {
     const { t } = this.props;
-    if (error.code && error.code === DATA_SOURCE_ERROR_CODE_UNAUTHENTICATED) {
+    if (error?.code && error.code === DATA_SOURCE_ERROR_CODE_UNAUTHENTICATED) {
       return t('Login expired - try signing out & in again');
     }
     return t('An unknown error occurred');

--- a/app/components/dexcombanner/dexcombanner.js
+++ b/app/components/dexcombanner/dexcombanner.js
@@ -16,33 +16,85 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
-import { translate } from 'react-i18next';
+import React, { useEffect, useState } from 'react';
+import { translate, Trans } from 'react-i18next';
 import { push } from 'connected-react-router';
-import { connect } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
+import get from 'lodash/get';
 
 import { URL_DEXCOM_CONNECT_INFO } from '../../core/constants';
+import { useIsFirstRender } from '../../core/hooks';
+import { async, sync } from '../../redux/actions';
+import { useToasts } from '../../providers/ToastProvider';
+import ResendDexcomConnectRequestDialog from '../clinic/ResendDexcomConnectRequestDialog';
 
 export const DexcomBanner = translate()((props) => {
   const {
+    api,
+    clinicPatient,
+    userIsCurrentPatient,
+    dataSourceState,
     onClick,
     onClose,
     patient,
+    selectedClinicId,
     trackMetric,
     t,
     push,
   } = props;
 
-  const getMessageText = () => {
-    return t('Using Dexcom G5 Mobile on Android? See your data in Tidepool.');
+  const dispatch = useDispatch();
+  const isFirstRender = useIsFirstRender();
+  const { set: setToast } = useToasts();
+  const [showResendDexcomConnectRequest, setShowResendDexcomConnectRequest] = useState(false);
+  const { sendingPatientDexcomConnectRequest } = useSelector((state) => state.blip.working);
+
+  const redirectToProfile = (source = 'banner') => {
+    push(`/patients/${patient.userid}/profile?dexcomConnect=${source}`);
   };
 
-  const getButtonText = () => {
-    return t('Get Started');
+  function handleAsyncResult(workingState, successMessage) {
+    const { inProgress, completed, notification } = workingState;
+
+    if (!isFirstRender && !inProgress) {
+      if (completed) {
+        setShowResendDexcomConnectRequest(false);
+        dispatch(sync.dismissBanner('dexcom'));
+
+        setToast({
+          message: successMessage,
+          variant: 'success',
+        });
+      }
+
+      if (completed === false) {
+        setToast({
+          message: get(notification, 'message'),
+          variant: 'danger',
+        });
+      }
+    }
+  }
+
+  useEffect(() => {
+    handleAsyncResult(sendingPatientDexcomConnectRequest, t('Dexcom connection request to {{email}} has been resent.', {
+      email: patient?.email,
+    }));
+  }, [sendingPatientDexcomConnectRequest]);
+
+  const handleSendReconnectionEmail = () => {
+    trackMetric('Clinic - Resend Dexcom connect email', { clinicId: selectedClinicId, dexcomConnectState: dataSourceState, source: 'banner' })
+    setShowResendDexcomConnectRequest(true);
+  };
+
+  const handleSendReconnectionEmailConfirm = () => {
+    trackMetric('Clinic - Resend Dexcom connect email confirm', { clinicId: selectedClinicId, source: 'banner' });
+    dispatch(async.sendPatientDexcomConnectRequest(api, selectedClinicId, clinicPatient.id));
   };
 
   const handleDismiss = () => {
     onClose(patient.userid);
+    clinicPatient && dispatch(sync.dismissBanner('dexcom'));
 
     if (trackMetric) {
       trackMetric('dismiss Dexcom OAuth banner');
@@ -57,46 +109,97 @@ export const DexcomBanner = translate()((props) => {
 
   const handleSubmit = () => {
     onClick(patient.userid);
+    let metric = 'clicked get started on Dexcom banner';
+    let source = 'banner';
 
-    push(`/patients/${patient.userid}/profile?dexcomConnect=banner`);
+    if (userIsCurrentPatient) {
+      if (dataSourceState === 'error') {
+        metric = 'clicked reconnect on Dexcom banner';
+        source = 'reconnectBanner';
+      }
+
+      redirectToProfile(source);
+    } else if (clinicPatient) {
+      metric = 'clicked request reconnection on Dexcom banner';
+      handleSendReconnectionEmail();
+    }
 
     if (trackMetric) {
-      trackMetric('clicked get started on Dexcom banner');
+      trackMetric(metric);
     }
   }
 
-  const renderLink = () => {
-    const link = {
-      href: URL_DEXCOM_CONNECT_INFO,
-      text: t('Learn More'),
-      target: '_blank',
-    };
-
-    return (
-      <a
-        className="message-link" href={link.href} target={link.target} onClick={handleClickLearnMore} rel="noreferrer noopener">
-        {link.text}
-      </a>
+  const getMessageText = () => {
+    let text = (
+      <Trans i18nKey="html.dexcom-banner-connect">
+        Using Dexcom G5 Mobile on Android? See your data in Tidepool.
+        <a
+          className="message-link"
+          target="_blank"
+          rel="noreferrer noopener"
+          href={URL_DEXCOM_CONNECT_INFO}
+          onClick={handleClickLearnMore}
+        >
+          Learn More
+        </a>
+      </Trans>
     );
+
+    if (dataSourceState === 'error') {
+      text = clinicPatient
+        ? (
+            <>
+              {t('Tidepool is no longer receiving CGM data for this account.')}<br />
+              {t('Click \'Request Reconnection\' to send an email to the account owner enabling them to reconnect their Dexcom Clarity account to Tidepool.')}
+            </>
+        ) : (
+          t('Tidepool is no longer receiving CGM data for your account.')
+        );
+    }
+
+    return text;
+  };
+
+  const getButtonText = () => {
+    let text = t('Get Started');
+
+    if (dataSourceState === 'error') {
+      text = userIsCurrentPatient
+        ? t('Fix in My Data Sources')
+        : t('Request Reconnection');
+    }
+
+    return text;
   };
 
   return (
-    <div className='dexcomBanner container-box-outer'>
-      <div className="container-box-inner">
-        <div className="dexcomBanner-message">
-          <div className="message-text" children={getMessageText()} />
-          {renderLink()}
-        </div>
+    <>
+      <div className='dexcomBanner container-box-outer'>
+        <div className="container-box-inner">
+          <div className="dexcomBanner-message">
+            <div className="message-text" children={getMessageText()} />
+          </div>
 
-        <div className="dexcomBanner-action">
-          <button onClick={handleSubmit}>{getButtonText()}</button>
-        </div>
+          <div className="dexcomBanner-action">
+            <button onClick={handleSubmit}>{getButtonText()}</button>
+          </div>
 
-        <div className="dexcomBanner-close">
-          <a href="#" className="close" onClick={handleDismiss}>&times;</a>
+          <div className="dexcomBanner-close">
+            <a href="#" className="close" onClick={handleDismiss}>&times;</a>
+          </div>
         </div>
       </div>
-    </div>
+
+      <ResendDexcomConnectRequestDialog
+        api={api}
+        onClose={() => setShowResendDexcomConnectRequest(false)}
+        onConfirm={handleSendReconnectionEmailConfirm}
+        open={showResendDexcomConnectRequest}
+        patient={clinicPatient}
+        t={t}
+        trackMetric={trackMetric}
+      />
+    </>
   );
 });
 
@@ -104,7 +207,11 @@ DexcomBanner.propTypes = {
   onClick: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   trackMetric: PropTypes.func.isRequired,
+  clinicPatient: PropTypes.object,
   patient: PropTypes.object.isRequired,
+  dataSourceState: PropTypes.string.isRequired,
+  selectedClinicId: PropTypes.string,
+  userIsCurrentPatient: PropTypes.bool,
 };
 
 export default connect(null, { push })(DexcomBanner);

--- a/app/components/dexcombanner/dexcombanner.js
+++ b/app/components/dexcombanner/dexcombanner.js
@@ -93,7 +93,7 @@ export const DexcomBanner = translate()((props) => {
   };
 
   const handleDismiss = () => {
-    onClose(patient.userid);
+    onClose(clinicPatient?.id || patient?.userid);
     clinicPatient && dispatch(sync.dismissBanner('dexcom'));
 
     if (trackMetric) {
@@ -108,7 +108,7 @@ export const DexcomBanner = translate()((props) => {
   };
 
   const handleSubmit = () => {
-    onClick(patient.userid);
+    onClick(clinicPatient?.id || patient?.userid);
     let metric = 'clicked get started on Dexcom banner';
     let source = 'banner';
 

--- a/app/components/dexcombanner/dexcombanner.less
+++ b/app/components/dexcombanner/dexcombanner.less
@@ -45,6 +45,9 @@
   .message-link {
     display: inline-block;
     &:extend(.dexcomBannerLink);
+    padding-left: .25em;
+    padding-right: .25em;
+    cursor: pointer;
 
     &:hover {
       &:extend(.dexcomBannerLinkHover);
@@ -56,6 +59,7 @@
   width: 24px;
   text-align: right;
   padding-top: 5px;
+  flex-shrink: 0;
 
   a {
     &:extend(.dexcomBannerLink);
@@ -79,6 +83,7 @@
     border-radius: 4px;
     padding: 7px 12px;
     font-weight: 600;
+    white-space: nowrap;
 
     &:hover {
       background-color: @white-color;

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -256,7 +256,7 @@ export class AppComponent extends React.Component {
         this.props.showBanner('dexcom');
 
         if (this.props.context.trackMetric && !this.state.dexcomConnectBanner.metricTracked) {
-          this.props.context.trackMetric('Dexcom OAuth banner displayed');
+          this.props.context.trackMetric('Dexcom OAuth banner displayed', { clinicId: nextProps.selectedClinicId, dexcomConnectState: dexcomDataSource?.state });
           bannerStateUpdates.metricTracked = true;
         }
 

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -97,11 +97,11 @@ export class AppComponent extends React.Component {
     super(props);
 
     this.state = {
-      dexcomShowBannerMetricTracked: false,
-      donateShowBannerMetricTracked: false,
-      shareDataBannerMetricTracked: false,
-      updateTypeBannerMetricTracked: false,
-      uploaderBannerMetricTracked: false,
+      uploaderBanner: { priority: 1, metricTracked: false },
+      shareDataBanner: { priority: 2, metricTracked: false },
+      donateBanner: { priority: 3, metricTracked: false },
+      dexcomConnectBanner: { priority: 4, metricTracked: false },
+      updateTypeBanner: { priority: 5, metricTracked: false },
     }
   }
 
@@ -159,14 +159,14 @@ export class AppComponent extends React.Component {
       location,
       userHasData,
       userHasConnectedDataSources,
+      userDexcomDataSource,
+      patientDexcomDataSource,
       userHasSharedDataWithClinician,
       userHasDiabetesType,
       userIsCurrentPatient,
       userIsSupportingNonprofit,
       patient,
       authenticated,
-      clinics,
-      selectedClinicId,
     } = nextProps;
 
     if (
@@ -177,91 +177,110 @@ export class AppComponent extends React.Component {
     }
 
     const isBannerRoute = /^\/patients\/\S+\/data/.test(location);
-
     const showUploaderBanner = authenticated && moment().isBefore('2020-10-01');
-    let displayUploaderBanner = false;
 
     if (showingUploaderBanner !== false) {
       if (showUploaderBanner) {
         this.props.showBanner('uploader');
-        displayUploaderBanner = true;
 
-        if (this.props.context.trackMetric && !this.state.uploaderShowBannerMetricTracked) {
+        if (this.props.context.trackMetric && !this.state.uploaderBanner.metricTracked) {
           this.props.context.trackMetric('Uploader banner displayed');
-          this.setState({ uploaderShowBannerMetricTracked: true });
+          this.setState({ uploaderBanner: { ...this.state.uploaderBanner, metricTracked: true } });
         }
       } else if (showingUploaderBanner) {
         this.props.hideBanner('uploader');
       }
     }
 
-    let displayShareDataBanner = false;
-
-    if (showingShareDataBanner !== false && !displayUploaderBanner) {
+    if (showingShareDataBanner !== false) {
       const showShareDataBanner = isBannerRoute && userIsCurrentPatient && userHasData && !userHasSharedDataWithClinician && !seenShareDataBannerMax;
+
       if (showShareDataBanner) {
         this.props.showBanner('sharedata');
-        displayShareDataBanner = true;
         updateShareDataBannerSeen(patient.userid);
 
-        if (this.props.context.trackMetric && !this.state.shareDataBannerMetricTracked) {
+        if (this.props.context.trackMetric && !this.state.shareDataBanner.metricTracked) {
           this.props.context.trackMetric('Share Data banner displayed');
-          this.setState({ shareDataBannerMetricTracked: true });
+          this.setState({ shareDataBanner: { ...this.state.shareDataBanner, metricTracked: true } });
         }
       } else if (showingShareDataBanner) {
         this.props.hideBanner('sharedata');
       }
     }
 
-    let displayDonateBanner = false;
-
-    if (showingDonateBanner !== false && !displayUploaderBanner && !displayShareDataBanner) {
+    if (showingDonateBanner !== false) {
       const showDonateBanner = isBannerRoute && userIsCurrentPatient && userHasData && !userIsSupportingNonprofit;
-          if (showDonateBanner) {
-            this.props.showBanner('donate');
-            displayDonateBanner = true;
 
-            if (this.props.context.trackMetric && !this.state.donateShowBannerMetricTracked) {
-              this.props.context.trackMetric('Big Data banner displayed');
-              this.setState({ donateShowBannerMetricTracked: true });
-            }
-          } else if (showingDonateBanner) {
-            this.props.hideBanner('donate');
-          }
+      if (showDonateBanner) {
+        this.props.showBanner('donate');
+
+        if (this.props.context.trackMetric && !this.state.donateBanner.metricTracked) {
+          this.props.context.trackMetric('Big Data banner displayed');
+          this.setState({ donateBanner: { ...this.state.donateBanner, metricTracked: true } });
         }
+      } else if (showingDonateBanner) {
+        this.props.hideBanner('donate');
+      }
+    }
 
-    let displayDexcomConnectBanner = false;
+    const dexcomDataSource = userDexcomDataSource || patientDexcomDataSource;
 
-    if (showingDexcomConnectBanner !== false && !displayUploaderBanner && !displayShareDataBanner && !displayDonateBanner) {
-      const showDexcomBanner = isBannerRoute && userIsCurrentPatient && userHasData && !userHasConnectedDataSources;
+    if (showingDexcomConnectBanner !== false) {
+      let showDexcomBanner;
+      let dexcomBannerWasAcknowledged;
+
+      if (userIsCurrentPatient) {
+        // Hide the Dexcom banner if the currently logged-in patient has already interacted with the
+        // banner and there hasn't been a Dexcom data source update since
+        const dexcomDataSourceModifiedTime = dexcomDataSource?.modifiedTime || '';
+        const dismissedBannerTime = _.get(nextProps, 'user.preferences.dismissedDexcomConnectBannerTime', '');
+        const clickedBannerTime = _.get(nextProps, 'user.preferences.clickedDexcomConnectBannerTime', '');
+        const latestBannerInteractionTime = _.max([dismissedBannerTime, clickedBannerTime]);
+
+        dexcomBannerWasAcknowledged = !_.isEmpty(dexcomDataSourceModifiedTime)
+         ? latestBannerInteractionTime > dexcomDataSourceModifiedTime
+         : !_.isEmpty(latestBannerInteractionTime);
+      }
+
+      const isDexcomErrorState = dexcomDataSource?.state === 'error';
+      const bannerStateUpdates = { display: true };
+
+      // Give the Dexcom banner highest priority if the connection state is 'error'
+      if (isDexcomErrorState) bannerStateUpdates.priority = 0;
+
+      if (isBannerRoute && !dexcomBannerWasAcknowledged) {
+        showDexcomBanner = isDexcomErrorState || (userIsCurrentPatient && !userHasConnectedDataSources);
+      }
+
       if (showDexcomBanner) {
         this.props.showBanner('dexcom');
-        displayDexcomConnectBanner = true;
 
-        if (this.props.context.trackMetric && !this.state.dexcomShowBannerMetricTracked) {
+        if (this.props.context.trackMetric && !this.state.dexcomConnectBanner.metricTracked) {
           this.props.context.trackMetric('Dexcom OAuth banner displayed');
-          this.setState({ dexcomShowBannerMetricTracked: true });
+          bannerStateUpdates.metricTracked = true;
         }
+
+        this.setState({ dexcomConnectBanner: { ...this.state.dexcomConnectBanner, ...bannerStateUpdates } });
       } else if (showingDexcomConnectBanner) {
         this.props.hideBanner('dexcom');
       }
     }
 
-    if (showingUpdateTypeBanner !== false && !displayUploaderBanner && !displayShareDataBanner && !displayDonateBanner && !displayDexcomConnectBanner) {
-      const showUpdateTypeBanner = isBannerRoute && userIsCurrentPatient && userHasData && !userHasConnectedDataSources && !userHasDiabetesType;
+    if (showingUpdateTypeBanner !== false) {
+      const showUpdateTypeBanner = isBannerRoute && userIsCurrentPatient && !userHasDiabetesType;
+
       if (showUpdateTypeBanner) {
         this.props.showBanner('updatetype');
 
-        if (this.props.context.trackMetric && !this.state.updateTypeShowBannerMetricTracked) {
+        if (this.props.context.trackMetric && !this.state.updateTypeBanner.metricTracked) {
           this.props.context.trackMetric('Update Type banner displayed');
-          this.setState({ updateTypeShowBannerMetricTracked: true });
+          this.setState({ updateTypeBanner: { ...this.state.updateTypeBanner, metricTracked: true } });
         }
       } else if (showingUpdateTypeBanner) {
         this.props.hideBanner('updatetype');
       }
     }
   }
-
 
   /**
    * Render Functions
@@ -326,6 +345,39 @@ export class AppComponent extends React.Component {
     return null;
   }
 
+  renderBanner() {
+    const banners = [
+      'uploaderBanner',
+      'shareDataBanner',
+      'donateBanner',
+      'dexcomConnectBanner',
+      'updateTypeBanner',
+    ];
+
+    const prioritizedBanners = _.orderBy(
+      _.filter(
+        _.map(banners, name => {
+          const capitalizedName = _.upperFirst(name);
+          const renderMethodKey = `render${capitalizedName}`;
+          const displayStateKey = `showing${capitalizedName}`;
+
+          return {
+            name,
+            ...this.state[name],
+            render: this[renderMethodKey].bind(this),
+            display: this.props[displayStateKey],
+          };
+        }),
+        { display: true }
+      ),
+      ['priority']
+    );
+
+    return !!prioritizedBanners.length
+      ? prioritizedBanners[0].render()
+      : null;
+  }
+
   renderShareDataBanner() {
     this.props.context.log('Rendering share data banner');
 
@@ -383,21 +435,21 @@ export class AppComponent extends React.Component {
   renderDexcomConnectBanner() {
     this.props.context.log('Rendering dexcom connect banner');
 
-    const {
-      showingDexcomConnectBanner,
-      onClickDexcomConnectBanner,
-      onDismissDexcomConnectBanner,
-      patient,
-    } = this.props;
-
-    if (showingDexcomConnectBanner) {
+    if (this.props.showingDexcomConnectBanner) {
       return (
         <div className="App-dexcombanner">
           <DexcomBanner
-            onClick={onClickDexcomConnectBanner}
-            onClose={onDismissDexcomConnectBanner}
+            api={this.props.context.api}
+            clinicPatient={this.props.clinicPatient}
+            onClick={this.props.userIsCurrentPatient ? this.props.onClickDexcomConnectBanner : _.noop}
+            onClose={this.props.userIsCurrentPatient ? this.props.onDismissDexcomConnectBanner : _.noop}
             trackMetric={this.props.context.trackMetric}
-            patient={patient} />
+            patient={this.props.patient}
+            dataSourceState={this.props.userDexcomDataSource?.state || this.props.patientDexcomDataSource?.state}
+            userIsCurrentPatient={this.props.userIsCurrentPatient}
+            isClinicPatient={this.props.clinicFlowActive && this.props.selectedClinicId && !this.props.userIsCurrentPatient}
+            selectedClinicId={this.props.selectedClinicId}
+          />
         </div>
       );
     }
@@ -587,11 +639,7 @@ export class AppComponent extends React.Component {
     var overlay = this.renderOverlay();
     var navbar = this.renderNavbar();
     var notification = this.renderNotification();
-    var donatebanner = this.renderDonateBanner();
-    var dexcombanner = this.renderDexcomConnectBanner();
-    var sharedatabanner = this.renderShareDataBanner();
-    var updatetypebanner = this.renderUpdateTypeBanner();
-    var uploaderbanner = this.renderUploaderBanner();
+    var banner = this.renderBanner();
     var emailbanner = this.renderAddEmailBanner();
     var footer = this.renderFooter();
 
@@ -601,11 +649,7 @@ export class AppComponent extends React.Component {
         {emailbanner}
         {navbar}
         {notification}
-        {donatebanner}
-        {dexcombanner}
-        {sharedatabanner}
-        {updatetypebanner}
-        {uploaderbanner}
+        {banner}
         {this.props.children}
         {footer}
       </div>
@@ -638,11 +682,14 @@ export function getFetchers(stateProps, dispatchProps, api) {
 export function mapStateToProps(state) {
   let user = null;
   let patient = null;
+  let patientDexcomDataSource;
   let clinicPatient;
   let permissions = null;
   let permsOfLoggedInUser = null;
   let userIsDonor = _.get(state, 'blip.dataDonationAccounts', []).length > 0;
-  let userHasConnectedDataSources = _.get(state, 'blip.dataSources', []).length > 0;
+  let dataSources = _.get(state, 'blip.dataSources', []);
+  let userHasConnectedDataSources = dataSources.length > 0;
+  let userDexcomDataSource = _.find(dataSources, { providerName: 'dexcom' });
   let userHasSharedData = _.get(state, 'blip.membersOfTargetCareTeam', []).length > 0;
   let userHasSharedDataWithClinician = false;
   let userIsSupportingNonprofit = false;
@@ -682,12 +729,15 @@ export function mapStateToProps(state) {
         state.blip.currentPatientInViewId,
         null
       );
+
       clinicPatient = _.get(state.blip.clinics, [state.blip.selectedClinicId, 'patients', state.blip.currentPatientInViewId]);
+
       permissions = _.get(
         state.blip.permissionsOfMembersInTargetCareTeam,
         state.blip.currentPatientInViewId,
         {}
       );
+
       permsOfLoggedInUser = state.blip.selectedClinicId
         ? _.get(
           state.blip.clinics,
@@ -703,6 +753,10 @@ export function mapStateToProps(state) {
           state.blip.currentPatientInViewId,
           {}
         );
+
+      if (clinicPatient) {
+        patientDexcomDataSource = _.find(clinicPatient.dataSources, { providerName: 'dexcom' });
+      }
     }
 
     // Check to see if a data-donating patient has selected a nonprofit to support
@@ -783,6 +837,8 @@ export function mapStateToProps(state) {
     userHasDiabetesType,
     userIsDonor,
     userHasConnectedDataSources,
+    userDexcomDataSource,
+    patientDexcomDataSource,
     userHasSharedDataWithClinician,
     userIsSupportingNonprofit,
     resendEmailVerificationInProgress: state.blip.working.resendingEmailVerification.inProgress,

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -168,6 +168,7 @@ export class AppComponent extends React.Component {
       userIsSupportingNonprofit,
       patient,
       authenticated,
+      currentPatientInViewId,
     } = nextProps;
 
     if (
@@ -193,7 +194,7 @@ export class AppComponent extends React.Component {
 
       if (showShareDataBanner) {
         this.props.showBanner('sharedata');
-        updateShareDataBannerSeen(patient.userid);
+        updateShareDataBannerSeen(currentPatientInViewId);
       } else if (showingShareDataBanner) {
         this.props.hideBanner('sharedata');
       }
@@ -349,6 +350,8 @@ export class AppComponent extends React.Component {
     );
 
     let prioritizedBanner;
+
+    console.log('prioritizedBanners', prioritizedBanners);
 
     if (prioritizedBanners.length > 0) {
       prioritizedBanner = prioritizedBanners[0];

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -351,8 +351,6 @@ export class AppComponent extends React.Component {
 
     let prioritizedBanner;
 
-    console.log('prioritizedBanners', prioritizedBanners);
-
     if (prioritizedBanners.length > 0) {
       prioritizedBanner = prioritizedBanners[0];
       const dexcomDataSource = this.props.userDexcomDataSource || this.props.patientDexcomDataSource;

--- a/app/redux/reducers/misc.js
+++ b/app/redux/reducers/misc.js
@@ -105,7 +105,7 @@ export const showingDonateBanner = (state = initialState.showingDonateBanner, ac
       const dismissedBanner = _.get(action.payload, 'user.preferences.dismissedDonateYourDataBannerTime');
       return dismissedBanner ? false : state;
     case types.HIDE_BANNER:
-        return (action.payload.type === 'donate') ? null : state;
+      return (action.payload.type === 'donate') ? null : state;
     case types.LOGOUT_REQUEST:
       return null;
     default:
@@ -119,12 +119,12 @@ export const showingDexcomConnectBanner = (state = initialState.showingDexcomCon
       return (action.payload.type === 'dexcom' && state !== false) ? true : state;
     case types.DISMISS_BANNER:
       return (action.payload.type === 'dexcom') ? false : state;
-    case types.FETCH_USER_SUCCESS:
-      const dismissedBanner = _.get(action.payload, 'user.preferences.dismissedDexcomConnectBannerTime');
-      const clickedBanner = _.get(action.payload, 'user.preferences.clickedDexcomConnectBannerTime');
-      return (dismissedBanner || clickedBanner) ? false : state;
+    case types.FETCH_PATIENT_FROM_CLINIC_SUCCESS:
+      const patientDexcomDataSourceConnectState = (_.find(action.payload.patient?.dataSources, { providerName: 'dexcom' }) || {}).state;
+      return patientDexcomDataSourceConnectState === 'error' || state;
     case types.HIDE_BANNER:
-        return (action.payload.type === 'dexcom') ? null : state;
+      return (action.payload.type === 'dexcom') ? null : state;
+    case types.DATA_WORKER_REMOVE_DATA_REQUEST:
     case types.LOGOUT_REQUEST:
       return null;
     default:
@@ -143,7 +143,7 @@ export const showingUpdateTypeBanner = (state = initialState.showingUpdateTypeBa
       const clickedBanner = _.get(action.payload, 'user.preferences.clickedUpdateTypeBannerTime');
       return (dismissedBanner || clickedBanner) ? false : state;
     case types.HIDE_BANNER:
-        return (action.payload.type === 'updatetype') ? null : state;
+      return (action.payload.type === 'updatetype') ? null : state;
     case types.LOGOUT_REQUEST:
       return null;
     default:
@@ -162,7 +162,7 @@ export const showingUploaderBanner = (state = initialState.showingUploaderBanner
       const clickedBanner = _.get(action.payload, 'user.preferences.clickedUploaderBannerTime');
       return (dismissedBanner || clickedBanner) ? false : state;
     case types.HIDE_BANNER:
-        return (action.payload.type === 'uploader') ? null : state;
+      return (action.payload.type === 'uploader') ? null : state;
     case types.LOGOUT_REQUEST:
       return null;
     default:
@@ -181,7 +181,7 @@ export const showingShareDataBanner = (state = initialState.showingShareDataBann
       const clickedBanner = _.get(action.payload, 'user.preferences.clickedShareDataBannerTime');
       return (dismissedBanner || clickedBanner) ? false : state;
     case types.HIDE_BANNER:
-        return (action.payload.type === 'sharedata') ? null : state;
+      return (action.payload.type === 'sharedata') ? null : state;
     case types.LOGOUT_REQUEST:
       return null;
     default:

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -20,7 +20,6 @@ import {
 import initialState from '../../../app/redux/reducers/initialState';
 
 import * as ErrorMessages from '../../../app/redux/constants/errorMessages';
-import { wrap } from 'lodash';
 
 var App = require('../../../app/pages/app/app.js').AppComponent;
 var api = require('../../../app/core/api');

--- a/test/unit/app/app.test.js
+++ b/test/unit/app/app.test.js
@@ -816,6 +816,24 @@ describe('App', () => {
 
         sinon.assert.callCount(props.context.trackMetric, 2);
       });
+
+      it('should prioritize over other banners, but only if connection is in error state', () => {
+        wrapper.setProps({
+          userIsCurrentPatient: true,
+          userHasData: true,
+          location: '/patients/1234/data',
+          showingUploaderBanner: true,
+          showingDexcomConnectBanner: true,
+        });
+
+        expect(wrapper.find('.App-uploaderbanner')).to.have.lengthOf(1);
+        expect(wrapper.find('.App-dexcombanner')).to.have.lengthOf(0);
+
+        wrapper.setProps({ patientDexcomDataSource: { state: 'error' } })
+
+        expect(wrapper.find('.App-uploaderbanner')).to.have.lengthOf(0);
+        expect(wrapper.find('.App-dexcombanner')).to.have.lengthOf(1);
+      });
     });
 
     context('share data banner is showing', () => {

--- a/test/unit/components/dexcombanner.test.js
+++ b/test/unit/components/dexcombanner.test.js
@@ -31,6 +31,7 @@ import thunk from 'redux-thunk';
 import { DexcomBanner } from '../../../app/components/dexcombanner';
 import { ToastProvider } from '../../../app/providers/ToastProvider';
 import { URL_DEXCOM_CONNECT_INFO } from '../../../app/core/constants';
+import Button from '../../../app/components/elements/Button';
 
 const expect = chai.expect;
 const mockStore = configureStore([thunk]);
@@ -39,9 +40,14 @@ describe('DexcomBanner', () => {
   const props = {
     onClick: sinon.stub(),
     onClose: sinon.stub(),
-    patient: { userid: 1234 },
+    patient: { userid: 'patient1' },
     trackMetric: sinon.stub(),
     push: sinon.stub(),
+    api: {
+      clinics: {
+        sendPatientDexcomConnectRequest: sinon.stub().callsArgWith(2, null, { lastRequestedDexcomConnectTime: '2022-02-02T00:00:00.000Z'}),
+      },
+    },
   };
 
   const defaultWorkingState = {
@@ -55,14 +61,29 @@ describe('DexcomBanner', () => {
       working: {
         sendingPatientDexcomConnectRequest: defaultWorkingState,
       },
+      timePrefs: {
+        timezoneName: 'UTC'
+      },
     },
+  };
+
+  const clinicPatient = {
+    id: 'clinicPatient123',
+    email: 'patient1@test.ca',
+    fullName: 'patient1',
+    birthDate: '1999-01-01',
+    lastRequestedDexcomConnectTime: '2021-10-19T16:27:59.504Z',
+    dataSources: [
+      { providerName: 'dexcom', state: 'error' },
+    ],
   };
 
   let store = mockStore(blipState);
 
   let wrapper;
-  beforeEach(() => {
-    wrapper = mount(
+
+  const createWrapper = (props) => {
+    return wrapper = mount(
       <Provider store={store}>
         <ToastProvider>
           <DexcomBanner
@@ -71,6 +92,10 @@ describe('DexcomBanner', () => {
         </ToastProvider>
       </Provider>
     );
+  };
+
+  beforeEach(() => {
+    wrapper = createWrapper(props);
   });
 
   afterEach(() => {
@@ -84,20 +109,6 @@ describe('DexcomBanner', () => {
 
     expect(wrapper.find('.dexcomBanner')).to.have.length(1);
     expect(console.error.callCount).to.equal(0);
-  });
-
-  it('should render a link to the dexcom connect info on the website', () => {
-    const expectedText = 'Learn More'
-    const messageLink = wrapper.find('.message-link');
-
-    expect(messageLink).to.have.length(1);
-    expect(messageLink.find({ href: URL_DEXCOM_CONNECT_INFO })).to.have.length(1);
-    expect(messageLink.text()).contains(expectedText);
-  });
-
-  it('should render a close link to dismiss the banner', () => {
-    const closeLink = wrapper.find('a.close');
-    expect(closeLink).to.have.length(1);
   });
 
   it('should call the dismiss handler with the patient userid when the close link is clicked', () => {
@@ -114,26 +125,6 @@ describe('DexcomBanner', () => {
     sinon.assert.calledWith(props.trackMetric, 'dismiss Dexcom OAuth banner');
   });
 
-  it('should track the appropriate metric when the learn more link is clicked', () => {
-    const moreLink = wrapper.find('a.message-link');
-    moreLink.simulate('click');
-    sinon.assert.calledOnce(props.trackMetric);
-    sinon.assert.calledWith(props.trackMetric, 'clicked learn more Dexcom OAuth banner');
-  });
-
-  it('should call the submit handler when the dexcom button is clicked', () => {
-    const button = wrapper.find('.dexcomBanner-action button');
-    button.simulate('click');
-    sinon.assert.calledOnce(props.onClick);
-  });
-
-  it('should track the metrics when the dexcom button is clicked', () => {
-    const button = wrapper.find('.dexcomBanner-action button');
-    button.simulate('click');
-    sinon.assert.calledOnce(props.trackMetric);
-    sinon.assert.calledWith(props.trackMetric, 'clicked get started on Dexcom banner');
-  });
-
   describe('render', function () {
     it('should render without errors when provided all required props', () => {
       console.error = sinon.stub();
@@ -142,34 +133,210 @@ describe('DexcomBanner', () => {
       expect(console.error.callCount).to.equal(0);
     });
 
-    it('should render a dexcom message', () => {
-      const expectedText = 'Using Dexcom G5 Mobile on Android? See your data in Tidepool.'
-      const messageText = wrapper.find('.message-text');
+    context('initial connection banner', () => {
+      it('should track the appropriate metric when the learn more link is clicked', () => {
+        const moreLink = wrapper.find('a.message-link');
+        moreLink.simulate('click');
+        sinon.assert.calledOnce(props.trackMetric);
+        sinon.assert.calledWith(props.trackMetric, 'clicked learn more Dexcom OAuth banner');
+      });
 
-      expect(messageText).to.have.length(1);
-      expect(messageText.text()).contains(expectedText);
+      it('should call the submit handler when the dexcom button is clicked', () => {
+        const button = wrapper.find('.dexcomBanner-action button');
+        button.simulate('click');
+        sinon.assert.calledOnce(props.onClick);
+      });
+
+      it('should track the metrics when the dexcom button is clicked', () => {
+        const button = wrapper.find('.dexcomBanner-action button');
+        button.simulate('click');
+        sinon.assert.calledOnce(props.trackMetric);
+        sinon.assert.calledWith(props.trackMetric, 'clicked get started on Dexcom banner');
+      });
+
+      it('should call the dismiss handler with the patient userid when the close link is clicked', () => {
+        const closeLink = wrapper.find('a.close');
+        closeLink.simulate('click');
+        sinon.assert.calledOnce(props.onClose);
+        sinon.assert.calledWith(props.onClose, props.patient.userid);
+      });
+
+      it('should render the correct dexcom connection message', () => {
+        const expectedText = 'Using Dexcom G5 Mobile on Android? See your data in Tidepool.'
+        const messageText = wrapper.find('.message-text');
+
+        expect(messageText).to.have.length(1);
+        expect(messageText.text()).contains(expectedText);
+      });
+
+      it('should render a link to the dexcom connect info on the website', () => {
+        const expectedText = 'Learn More'
+        const messageLink = wrapper.find('.message-link');
+
+        expect(messageLink).to.have.length(1);
+        expect(messageLink.find({ href: URL_DEXCOM_CONNECT_INFO })).to.have.length(1);
+        expect(messageLink.text()).contains(expectedText);
+      });
+
+      it('should render a get started button', () => {
+        const expectedText = 'Get Started'
+        const button = wrapper.find('.dexcomBanner-action button');
+
+        expect(button).to.have.length(1);
+        expect(button.text()).contains(expectedText);
+      });
+
+      it('should render a close link to dismiss the banner', () => {
+        const closeLink = wrapper.find('a.close');
+        expect(closeLink).to.have.length(1);
+      });
     });
 
-    it('should render a link to the dexcom connect info on the website', () => {
-      const expectedText = 'Learn More'
-      const messageLink = wrapper.find('.message-link');
+    context('reconnection required banner - user viewing own data', () => {
+      beforeEach(() => {
+        wrapper = createWrapper({
+          ...props,
+          dataSourceState: 'error',
+          userIsCurrentPatient: true,
+        });
+      });
 
-      expect(messageLink).to.have.length(1);
-      expect(messageLink.find({ href: URL_DEXCOM_CONNECT_INFO })).to.have.length(1);
-      expect(messageLink.text()).contains(expectedText);
+      it('should call the submit handler when the dexcom button is clicked', () => {
+        const button = wrapper.find('.dexcomBanner-action button');
+        button.simulate('click');
+        sinon.assert.calledOnce(props.onClick);
+        sinon.assert.calledWith(props.onClick, props.patient.userid);
+      });
+
+      it('should track the metrics when the dexcom button is clicked', () => {
+        const button = wrapper.find('.dexcomBanner-action button');
+        button.simulate('click');
+        sinon.assert.calledOnce(props.trackMetric);
+        sinon.assert.calledWith(props.trackMetric, 'clicked reconnect on Dexcom banner');
+      });
+
+      it('should call the dismiss handler with the patient userid when the close link is clicked', () => {
+        const closeLink = wrapper.find('a.close');
+        closeLink.simulate('click');
+        sinon.assert.calledOnce(props.onClose);
+        sinon.assert.calledWith(props.onClose, props.patient.userid);
+      });
+
+      it('should render the correct dexcom connection message', () => {
+        const expectedText = 'Tidepool is no longer receiving CGM data for your account.'
+        const messageText = wrapper.find('.message-text');
+
+        expect(messageText).to.have.length(1);
+        expect(messageText.text()).contains(expectedText);
+      });
+
+      it('should render a "Fix in My Data Sources" button', () => {
+        const expectedText = 'Fix in My Data Sources'
+        const button = wrapper.find('.dexcomBanner-action button');
+
+        expect(button).to.have.length(1);
+        expect(button.text()).contains(expectedText);
+      });
+
+      it('should render a close link to dismiss the banner', () => {
+        const closeLink = wrapper.find('a.close');
+        expect(closeLink).to.have.length(1);
+      });
     });
 
-    it('should render a get started button', () => {
-      const expectedText = 'Get Started'
-      const button = wrapper.find('.dexcomBanner-action button');
+    context('reconnection required banner - clinician user viewing patient data', () => {
+      beforeEach(() => {
+        wrapper = createWrapper({
+          ...props,
+          clinicPatient,
+          dataSourceState: 'error',
+          userIsCurrentPatient: false,
+          selectedClinicId: 'clinicID123',
+        });
+      });
 
-      expect(button).to.have.length(1);
-      expect(button.text()).contains(expectedText);
-    });
+      it('should call the submit handler when the dexcom button is clicked', () => {
+        const button = wrapper.find('.dexcomBanner-action button');
+        button.simulate('click');
+        sinon.assert.calledOnce(props.onClick);
+        sinon.assert.calledWith(props.onClick, 'clinicPatient123');
+      });
 
-    it('should render a close link to dismiss the banner', () => {
-      const closeLink = wrapper.find('a.close');
-      expect(closeLink).to.have.length(1);
+      it('should track the metrics when the dexcom button is clicked', () => {
+        const button = wrapper.find('.dexcomBanner-action button');
+        button.simulate('click');
+        sinon.assert.calledTwice(props.trackMetric);
+        sinon.assert.calledWith(props.trackMetric, 'Clinic - Resend Dexcom connect email', {
+          clinicId: 'clinicID123',
+          dexcomConnectState: 'error',
+          source: 'banner',
+        });
+        sinon.assert.calledWith(props.trackMetric, 'clicked request reconnection on Dexcom banner');
+      });
+
+      it('should call the dismiss handler with the patient userid when the close link is clicked', () => {
+        const closeLink = wrapper.find('a.close');
+        closeLink.simulate('click');
+        sinon.assert.calledOnce(props.onClose);
+        sinon.assert.calledWith(props.onClose, 'clinicPatient123');
+      });
+
+      it('should render the correct dexcom connection message', () => {
+        const expectedText = 'Tidepool is no longer receiving CGM data for this account.'
+        const messageText = wrapper.find('.message-text');
+
+        expect(messageText).to.have.length(1);
+        expect(messageText.text()).contains(expectedText);
+      });
+
+      it('should render a "Request Reconnection" button', () => {
+        const expectedText = 'Request Reconnection'
+        const button = wrapper.find('.dexcomBanner-action button');
+
+        expect(button).to.have.length(1);
+        expect(button.text()).contains(expectedText);
+      });
+
+      it('should open a confirmation dialog to resend the reconnection email', () => {
+        const resendButton = () => wrapper.find('.dexcomBanner-action button');
+        const resendDialog = () => wrapper.find('#resendDexcomConnectRequest').at(1);
+          expect(resendDialog().props().open).to.be.false;
+          resendButton().simulate('click');
+          expect(resendDialog().props().open).to.be.true;
+
+          expect(resendDialog().text()).to.have.string('10/19/2021 at 4:27 pm');
+
+          const resendInvite = resendDialog().find(Button).filter({variant: 'primary'});
+          expect(resendInvite).to.have.length(1);
+
+          const expectedActions = [
+            {
+              type: 'SEND_PATIENT_DEXCOM_CONNECT_REQUEST_REQUEST',
+            },
+            {
+              type: 'SEND_PATIENT_DEXCOM_CONNECT_REQUEST_SUCCESS',
+              payload: {
+                clinicId: 'clinicID123',
+                lastRequestedDexcomConnectTime: '2022-02-02T00:00:00.000Z',
+                patientId: 'clinicPatient123',
+              },
+            },
+          ];
+
+          store.clearActions();
+          resendInvite.props().onClick();
+          expect(store.getActions()).to.eql(expectedActions);
+          sinon.assert.calledWith(
+            props.api.clinics.sendPatientDexcomConnectRequest,
+            'clinicID123',
+            'clinicPatient123'
+          );
+      });
+
+      it('should render a close link to dismiss the banner', () => {
+        const closeLink = wrapper.find('a.close');
+        expect(closeLink).to.have.length(1);
+      });
     });
   });
 });

--- a/test/unit/components/dexcombanner.test.js
+++ b/test/unit/components/dexcombanner.test.js
@@ -24,11 +24,16 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 
 import { DexcomBanner } from '../../../app/components/dexcombanner';
+import { ToastProvider } from '../../../app/providers/ToastProvider';
 import { URL_DEXCOM_CONNECT_INFO } from '../../../app/core/constants';
 
 const expect = chai.expect;
+const mockStore = configureStore([thunk]);
 
 describe('DexcomBanner', () => {
   const props = {
@@ -39,12 +44,32 @@ describe('DexcomBanner', () => {
     push: sinon.stub(),
   };
 
+  const defaultWorkingState = {
+    inProgress: false,
+    completed: false,
+    notification: null,
+  };
+
+  const blipState = {
+    blip: {
+      working: {
+        sendingPatientDexcomConnectRequest: defaultWorkingState,
+      },
+    },
+  };
+
+  let store = mockStore(blipState);
+
   let wrapper;
   beforeEach(() => {
     wrapper = mount(
-      <DexcomBanner
-        {...props}
-      />
+      <Provider store={store}>
+        <ToastProvider>
+          <DexcomBanner
+            {...props}
+          />
+        </ToastProvider>
+      </Provider>
     );
   });
 
@@ -97,13 +122,13 @@ describe('DexcomBanner', () => {
   });
 
   it('should call the submit handler when the dexcom button is clicked', () => {
-    const button = wrapper.find('button');
+    const button = wrapper.find('.dexcomBanner-action button');
     button.simulate('click');
     sinon.assert.calledOnce(props.onClick);
   });
 
   it('should track the metrics when the dexcom button is clicked', () => {
-    const button = wrapper.find('button');
+    const button = wrapper.find('.dexcomBanner-action button');
     button.simulate('click');
     sinon.assert.calledOnce(props.trackMetric);
     sinon.assert.calledWith(props.trackMetric, 'clicked get started on Dexcom banner');
@@ -136,7 +161,7 @@ describe('DexcomBanner', () => {
 
     it('should render a get started button', () => {
       const expectedText = 'Get Started'
-      const button = wrapper.find('button');
+      const button = wrapper.find('.dexcomBanner-action button');
 
       expect(button).to.have.length(1);
       expect(button.text()).contains(expectedText);

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -11,7 +11,6 @@ import Table from '../../../app/components/elements/Table';
 import ClinicPatients from '../../../app/pages/clinicworkspace/ClinicPatients';
 import Popover from '../../../app/components/elements/Popover';
 import { MMOLL_UNITS, MGDL_UNITS } from '../../../app/core/constants';
-import { Dialog } from '../../../app/components/elements/Dialog';
 import Button from '../../../app/components/elements/Button';
 
 /* global chai */

--- a/test/unit/redux/reducers/showingDexcomConnectBanner.test.js
+++ b/test/unit/redux/reducers/showingDexcomConnectBanner.test.js
@@ -71,6 +71,22 @@ describe('showingDexcomConnectBanner', () => {
     });
   });
 
+  describe('dataWorkerRemoveDataRequest', () => {
+    it('should set state to null', () => {
+      let initialStateForTest = true;
+
+      let action = actions.worker.dataWorkerRemoveDataRequest();
+
+      let intermediate = reducer(initialStateForTest, action);
+
+      expect(intermediate).to.be.null;
+
+      let nextState = reducer(null, action);
+
+      expect(nextState).to.be.null;
+    });
+  });
+
   describe('logoutReqest', () => {
     it('should set state to null', () => {
       let initialStateForTest = true;
@@ -103,45 +119,23 @@ describe('showingDexcomConnectBanner', () => {
     });
   });
 
-  describe('fetchUserSuccess', () => {
-    it('should set state to false if user clicked the banner', () => {
-      let initialStateForTest = true;
+  describe('fetchPatientFromClinicSuccess', () => {
+    it('should set state to true if patient has a dexcom data source in an error state', () => {
+      let initialStateForTest = null;
 
-      const user = {
-        preferences: {
-          clickedDexcomConnectBannerTime: 'today',
-        },
+      const patient = {
+        dataSources: [{ providerName: 'dexcom', state: 'error' }],
       };
 
-      let action = actions.sync.fetchUserSuccess(user);
+      let action = actions.sync.fetchPatientFromClinicSuccess('clinicId', patient);
 
       let intermediate = reducer(initialStateForTest, action);
 
-      expect(intermediate).to.be.false;
+      expect(intermediate).to.be.true;
 
       let nextState = reducer(null, action);
 
-      expect(nextState).to.be.false;
-    });
-
-    it('should set state to false if user dismissed the banner', () => {
-      let initialStateForTest = true;
-
-      const user = {
-        preferences: {
-          dismissedDexcomConnectBannerTime: 'today',
-        },
-      };
-
-      let action = actions.sync.fetchUserSuccess(user);
-
-      let intermediate = reducer(initialStateForTest, action);
-
-      expect(intermediate).to.be.false;
-
-      let nextState = reducer(null, action);
-
-      expect(nextState).to.be.false;
+      expect(nextState).to.be.true;
     });
   });
 });


### PR DESCRIPTION
[WEB-2059]

There is a lot more code shift here than I originally anticipated, so a few changes of note are worth highlighting:

- Moved dexcom connect request dialog out of the `PatientForm` component for reuse in the banner
- Decided it was better to expand the existing dexcom banner to allow handling both initial connection and reconnection states.  Splitting into separate banners with separate redux state seemed excessive, and would have required adding additional 'dismissTime' and 'clickedTime' properties to our seagull preferences.
- Removed forced disabling of `showingDexcomConnectBanner` upon user fetch, since we now need to allow a banner to show even if the initial banner was previously interacted with (dismissed or actioned) based also on the latest dexcom data source `modifiedTime`.  This logic was moved to `app.js`
- Updated the show/hide logic in app.js to avoid some of the conditional chaining to determine whether or not a banner can show based on if a prior one was set to show.  They are now stored in component state with a priority that determines which of all the "show-able" banners we display.  We needed a different priority for dexcom error states.
- Tracking the metrics for each to avoid re-sending metrics is now done on a per-patient-ID basis - also stored in the component's banner state objects than manage priority
- This all means the redux states for these banner displays (i.e. `showingDexcomConnectBanner`) now define whether or not the banner is a candidate for display, but not necessarily whether it's been shown.  I had toyed around with the idea of pulling the banner states from redux altogether, but felt it was still the best way to handle resetting the state upon logout.

[WEB-2059]: https://tidepool.atlassian.net/browse/WEB-2059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ