### PR TITLE
[UPLOAD-996] add uploader URI scheme to frameSrc CSP

### DIFF
--- a/server.js
+++ b/server.js
@@ -86,7 +86,7 @@ app.use(nonceMiddleware, helmet.contentSecurityPolicy({
     objectSrc: ['blob:'],
     workerSrc: ["'self'", 'blob:'],
     childSrc: ["'self'", 'blob:', 'https://docs.google.com', 'https://app.pendo.io'],
-    frameSrc: ['https://docs.google.com', 'https://app.pendo.io', '*.tidepool.org', 'localhost:*'],
+    frameSrc: ['https://docs.google.com', 'https://app.pendo.io', '*.tidepool.org', 'localhost:*', 'tidepooluploader://*'],
     connectSrc: [].concat([
       process.env.API_HOST || 'localhost:*',
       process.env.REALM_HOST,


### PR DESCRIPTION
for [UPLOAD-996], pretty much what it says on the tin, we need to allow our custom URI scheme on frameSrc for the mechanism that the custom URI launcher library uses for Firefox