### PR TITLE
[UPLOAD-999], [UPLOAD-1000] uploader launch Safari additions

### DIFF
--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -113,7 +113,8 @@ export const KeycloakWrapper = (props) => {
   const store = useStore();
   let Wrapper = React.Fragment;
   let wrapperProps = props;
-  if (keycloakConfig?.url) {
+  const isOauthRedirectRoute = /^(\/upload-redirect)/.test(window?.location?.pathname);
+  if (keycloakConfig?.url && !isOauthRedirectRoute) {
     Wrapper = ReactKeycloakProvider;
     wrapperProps = {
       ...wrapperProps,

--- a/app/pages/uploadredirect/uploadredirect.js
+++ b/app/pages/uploadredirect/uploadredirect.js
@@ -21,6 +21,8 @@ const UploadRedirect = (props) => {
     case 'Edge':
       openText = 'Open'
       break;
+    case 'Safari':
+      openText = 'Allow'
     default:
       break;
   }

--- a/app/pages/uploadredirect/uploadredirect.js
+++ b/app/pages/uploadredirect/uploadredirect.js
@@ -6,11 +6,13 @@ import { Redirect } from 'react-router-dom';
 import { Subheading, Title } from '../../components/elements/FontStyles';
 import Button from '../../components/elements/Button';
 import UAParser from 'ua-parser-js';
+import { useIsFirstRender } from '../../core/hooks';
 
 let launched = false;
 
 const UploadRedirect = (props) => {
   const { t } = props;
+  const isFirstRender = useIsFirstRender();
   const linkUrl = `tidepooluploader://localhost/keycloak-redirect${props.location.hash}`;
   const ua = new UAParser().getResult();
   let openText = 'Open Tidepool Uploader';
@@ -31,7 +33,7 @@ const UploadRedirect = (props) => {
     return <Redirect to="/login" />;
   }
 
-  if (!launched) {
+  if (!launched && isFirstRender) {
     if (props.location.hash) {
       customProtocolCheck(
         linkUrl,


### PR DESCRIPTION
to take care of [UPLOAD-999] and [UPLOAD-1000] - adds Safari-specific launch dialog text and a couple preventative measures to keep the launch link from trying to open on a re-render/redirect that seems to only happen on Safari

[UPLOAD-999]: https://tidepool.atlassian.net/browse/UPLOAD-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UPLOAD-1000]: https://tidepool.atlassian.net/browse/UPLOAD-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ