### PR TITLE
Add firefox as supported browser

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -69,7 +69,7 @@ utils.getIn = (obj, props, notFound) => {
 
 utils.isSupportedBrowser = () => {
   var userAgent = navigator.userAgent.toLowerCase();
-  return (userAgent.indexOf('chrome') > -1 && userAgent.indexOf('opr') === -1 && userAgent.indexOf('mobi') === -1);
+  return (userAgent.indexOf('chrome') > -1 && userAgent.indexOf('opr') === -1 && userAgent.indexOf('mobi') === -1 && userAgent.indexOf('firefox') === -1);
 };
 
 utils.isMobile = () => {


### PR DESCRIPTION
I recently switched to Firefox as my primary browser and was surprised to see Tidepool blocking browsers without any clear reason. As explained in the mentioned issues, if there are specific functionalities that require Chrome you should use feature testing instead of blocking a complete browser. This is a really dark UX pattern.

This PR adds Firefox to the "supported browsers" list, which obviously is still a hack because Tidepool still blocks browsers for not being Chrome.

Fixes #418 
Fixes #1029