### PR TITLE
[WEB-2098] logged out page and 401/403 redirects

### DIFF
--- a/app/pages/loggedout/index.js
+++ b/app/pages/loggedout/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./loggedout')

--- a/app/pages/loggedout/loggedout.js
+++ b/app/pages/loggedout/loggedout.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { translate } from 'react-i18next';
+import { Box, Flex } from 'rebass/styled-components';
+import { keycloak } from '../../keycloak';
+
+import Button from '../../components/elements/Button';
+import { Paragraph1, Paragraph2 } from '../../components/elements/FontStyles';
+import logoSrc from '../../components/navbar/images/tidepool-logo-408x46.png';
+let win = window;
+
+export const LoggedOut = (props) => {
+  const { t } = props;
+
+  const handleClickLogin = () => {
+    keycloak.login({
+      redirectUri: win.location.origin,
+    });
+  };
+
+  return (
+    <Box
+      variant="containers.smallBordered"
+      bg="white"
+      mt={[0, 4, 5, 6]}
+      p={6}
+      pt={5}
+    >
+      <Flex flexDirection={'row'} justifyContent={'center'} mb={5}>
+        <img src={logoSrc} width={227} />
+      </Flex>
+
+      <hr color="lightgrey" />
+
+      <Paragraph2 mt={5} color="text.primary">
+        {t('You have been signed out of your session.')}
+      </Paragraph2>
+
+      <Paragraph1 color="mediumGrey">
+        {t(
+          "For security reasons, we automatically sign you out after a certain period of inactivity, or if you've signed out from another browser tab."
+        )}
+      </Paragraph1>
+
+      <Paragraph1 color="mediumGrey">
+        {t('Please sign in again to continue.')}
+      </Paragraph1>
+
+      <Button onClick={handleClickLogin} width={'100%'}>
+        {t('Return to Login')}
+      </Button>
+    </Box>
+  );
+};
+
+LoggedOut.propTypes = {};
+
+export default translate()(LoggedOut);

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -387,6 +387,23 @@ export function logout(api) {
 }
 
 /**
+ * Logged out Async Action Creator
+ *
+ * @param {Object} api an instance of the API wrapper
+ */
+export function loggedOut(api) {
+  return (dispatch, getState) => {
+    const { blip: { currentPatientInViewId } } = getState();
+    dispatch(sync.logoutRequest());
+    dispatch(worker.dataWorkerRemoveDataRequest(null, currentPatientInViewId));
+    api.user.logout(() => {
+      dispatch(sync.logoutSuccess());
+      dispatch(push('/logged-out'));
+    })
+  }
+}
+
+/**
  * Setup data storage Async Action Creator
  *
  * @param  {Object} api an instance of the API wrapper

--- a/app/routes.js
+++ b/app/routes.js
@@ -28,6 +28,7 @@ import UserProfile from './pages/userprofile';
 import VerificationWithPassword from './pages/verificationwithpassword';
 import Gate from './components/gate';
 import UploadRedirect from './pages/uploadredirect';
+import LoggedOut from './pages/loggedout';
 
 import utils from './core/utils';
 import personUtils from './core/personutils';
@@ -353,6 +354,7 @@ export const getRoutes = (appContext) => {
           <Route path='/verification-with-password' render={routeProps => (<Gate onEnter={boundRequireNoAuth} key={routeProps.match.path}><VerificationWithPassword {...routeProps} {...props} /></Gate>)} />
           <Route path='/browser-warning' render={routeProps => (<BrowserWarning {...routeProps} {...props} />)} />
           <Route path="/upload-redirect" render={routeProps => (<UploadRedirect {...routeProps} {...props} />)} />
+          <Route path="/logged-out" render={routeProps => (<LoggedOut {...routeProps} {...props}/>)} />
           <Route>
             { api.user.isAuthenticated() ? <Redirect to={authenticatedFallbackRoute} /> : <Redirect to='/login' /> }
           </Route>

--- a/test/unit/keycloak.test.js
+++ b/test/unit/keycloak.test.js
@@ -38,6 +38,7 @@ const apiMock = {
 
 const asyncMock = {
   login: sinon.stub().returns(sinon.stub().callsFake(0)),
+  loggedOut: sinon.stub().returns(sinon.stub()),
 };
 
 const keycloakMock = {
@@ -219,6 +220,7 @@ describe('keycloak', () => {
   describe('keycloakMiddleware', () => {
     const keycloakMock = {
       logout: sinon.stub(),
+      updateToken: sinon.stub(),
     };
     const updateKeycloakConfigMock = sinon.stub();
 
@@ -263,6 +265,37 @@ describe('keycloak', () => {
       });
       expect(updateKeycloakConfigMock.callCount).to.equal(0);
       keycloak.__ResetDependency__('_keycloakConfig');
+    });
+
+    it('should call keycloak.updateToken() when action has 401 or 403 error', () => {
+      const action401 = {
+        type: 'SOME_ACTION',
+        error: {
+          status: 401,
+          originalError:{
+            status: 401,
+          },
+        },
+      };
+
+      const action403 = {
+        type: 'SOME_ACTION',
+        error: {
+          status: 403,
+          originalError:{
+            status: 403,
+          },
+        },
+      };
+
+      expect(keycloakMock.updateToken.callCount).to.equal(0);
+      keycloakMiddleware()()(sinon.stub())(action401);
+      expect(keycloakMock.updateToken.callCount).to.equal(1);
+      sinon.assert.calledWithExactly(keycloakMock.updateToken, -1);
+
+      keycloakMiddleware()()(sinon.stub())(action403);
+      expect(keycloakMock.updateToken.callCount).to.equal(2);
+      sinon.assert.calledWithExactly(keycloakMock.updateToken, -1);
     });
   });
 

--- a/test/unit/keycloak.test.js
+++ b/test/unit/keycloak.test.js
@@ -267,7 +267,7 @@ describe('keycloak', () => {
       keycloak.__ResetDependency__('_keycloakConfig');
     });
 
-    it('should call keycloak.updateToken() when action has 401 or 403 error', () => {
+    it('should call keycloak.updateToken() when action has 401 error', () => {
       const action401 = {
         type: 'SOME_ACTION',
         error: {
@@ -278,6 +278,14 @@ describe('keycloak', () => {
         },
       };
 
+      expect(keycloakMock.updateToken.callCount).to.equal(0);
+      keycloakMiddleware()()(sinon.stub())(action401);
+      expect(keycloakMock.updateToken.callCount).to.equal(1);
+      sinon.assert.calledWithExactly(keycloakMock.updateToken, -1);
+      keycloakMock.updateToken.resetHistory();
+    });
+
+    it('should call keycloak.updateToken() when action has 403 error', () => {
       const action403 = {
         type: 'SOME_ACTION',
         error: {
@@ -289,12 +297,8 @@ describe('keycloak', () => {
       };
 
       expect(keycloakMock.updateToken.callCount).to.equal(0);
-      keycloakMiddleware()()(sinon.stub())(action401);
-      expect(keycloakMock.updateToken.callCount).to.equal(1);
-      sinon.assert.calledWithExactly(keycloakMock.updateToken, -1);
-
       keycloakMiddleware()()(sinon.stub())(action403);
-      expect(keycloakMock.updateToken.callCount).to.equal(2);
+      expect(keycloakMock.updateToken.callCount).to.equal(1);
       sinon.assert.calledWithExactly(keycloakMock.updateToken, -1);
     });
   });

--- a/test/unit/pages/loggedout.test.js
+++ b/test/unit/pages/loggedout.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { createMount } from '@material-ui/core/test-utils';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import _ from 'lodash';
+import LoggedOut from '../../../app/pages/loggedout';
+import { Paragraph2 } from '../../../app/components/elements/FontStyles';
+import Button from '../../../app/components/elements/Button';
+
+/* global chai */
+/* global sinon */
+/* global describe */
+/* global it */
+/* global beforeEach */
+/* global before */
+/* global after */
+/* global context */
+
+const expect = chai.expect;
+const mockStore = configureStore([thunk]);
+
+describe('LoggedOut', () => {
+  let mount;
+
+  let wrapper;
+  let defaultProps = {
+    t: sinon.stub().callsFake((string) => string),
+  };
+  let store = mockStore({});
+  let keycloakMock = {
+    login: sinon.stub(),
+  };
+  let winMock = {
+    location: {
+      origin: 'windowOrigin',
+    },
+  };
+
+  before(() => {
+    LoggedOut.__Rewire__('keycloak', keycloakMock);
+    LoggedOut.__Rewire__('win', winMock);
+    mount = createMount();
+  });
+
+  after(() => {
+    LoggedOut.__ResetDependency__('keycloak');
+    LoggedOut.__ResetDependency__('win');
+    mount.cleanUp();
+  });
+
+  beforeEach(() => {
+    wrapper = mount(
+      <Provider store={store}>
+        <LoggedOut {...defaultProps} />
+      </Provider>
+    );
+  });
+
+  it('should render signed out message', () => {
+    expect(wrapper.find(Paragraph2).text()).to.equal(
+      'You have been signed out of your session.'
+    );
+  });
+
+  it('should call keycloak.login when button clicked', () => {
+    expect(keycloakMock.login.callCount).to.equal(0);
+    let button = wrapper.find(Button);
+    button.simulate('click');
+    expect(keycloakMock.login.calledWith({ redirectUri: 'windowOrigin' })).to.be
+      .true;
+  });
+});

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -1856,6 +1856,35 @@ describe('Actions', () => {
       });
     });
 
+    describe('loggedOut', () => {
+      it('should trigger LOGOUT_SUCCESS and it should call logout once for a successful request', () => {
+        let api = {
+          user: {
+            logout: sinon.stub().callsArgWith(0, null)
+          }
+        };
+
+        let expectedActions = [
+          { type: 'LOGOUT_REQUEST' },
+          { type: 'DATA_WORKER_REMOVE_DATA_REQUEST', meta: { WebWorker: true, worker: 'data', origin: 'originStub', patientId: 'abc123' }, payload: { predicate: undefined } },
+          { type: 'LOGOUT_SUCCESS' },
+          { type: '@@router/CALL_HISTORY_METHOD', payload: { args: [ '/logged-out' ], method: 'push' } }
+        ];
+        _.each(expectedActions, (action) => {
+          expect(isTSA(action)).to.be.true;
+        });
+        let store = mockStore({ blip: { ...initialState, currentPatientInViewId: 'abc123' } });
+        store.dispatch(async.loggedOut(api));
+
+        const actions = store.getActions();
+        actions[1].meta.origin = 'originStub';
+
+        expect(actions).to.eql(expectedActions);
+        expect(api.user.logout.callCount).to.equal(1);
+        expect(trackMetric.calledWith('Logged Out')).to.be.true;
+      });
+    });
+
     describe('setupDataStorage', () => {
       it('should trigger SETUP_DATA_STORAGE_SUCCESS and it should call setupDataStorage once for a successful request', () => {
         let loggedInUserId = 500;


### PR DESCRIPTION
for [WEB-2098] creates logged out page which users will be sent to when keycloak token authentication/refresh fails. Additionally triggers a keycloak token refresh whenever any API call returns a 401/403 error to verify session validity.

[WEB-2098]: https://tidepool.atlassian.net/browse/WEB-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ