### PR TITLE
[WEB-2138] Hotfix: patient form validation error when Dexcom is in "pendingReconnect" state

### DIFF
--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -160,7 +160,7 @@ export const patientSchema = yup.object().shape({
   dataSources: yup.array().of(
     yup.object().shape({
       providerName: yup.string(),
-      state: yup.string().oneOf(['pending', 'connected', 'error', 'disconnected']),
+      state: yup.string().oneOf(['pending', 'pendingReconnect', 'connected', 'error', 'disconnected']),
     }),
   ),
   tags: yup.array().of(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.63.0",
+  "version": "1.63.1-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.64.1-rc.1",
+  "version": "1.64.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -233,6 +233,15 @@ describe('ClinicPatients', () => {
                 { providerName: 'foo', state: 'connected' },
               ],
             },
+            patient7: {
+              id: 'patient7',
+              email: 'patient7@test.ca',
+              fullName: 'patient7',
+              birthDate: '1999-01-01',
+              dataSources: [
+                { providerName: 'dexcom', state: 'pendingReconnect' },
+              ],
+            },
           },
         },
       },
@@ -979,7 +988,7 @@ describe('ClinicPatients', () => {
 
           getPatientForm(0);
           expect(stateWrapper()).to.have.lengthOf(1);
-          expect(stateWrapper().text()).includes('Pending connection');
+          expect(stateWrapper().text()).includes('Pending connection with');
 
           getPatientForm(1);
           expect(stateWrapper()).to.have.lengthOf(1);
@@ -996,6 +1005,35 @@ describe('ClinicPatients', () => {
           getPatientForm(4);
           expect(stateWrapper()).to.have.lengthOf(1);
           expect(stateWrapper().text()).includes('Unknown connection to');
+
+          getPatientForm(6);
+          expect(stateWrapper()).to.have.lengthOf(1);
+          expect(stateWrapper().text()).includes('Pending reconnection with');
+        });
+
+        it('should have a valid form state for all legitimate dexcom connection states', () => {
+          const stateWrapper = () => patientForm().find('#connectDexcomStatusWrapper').hostNodes();
+          const submitButton = () => wrapper.find('#editPatientConfirm').hostNodes();
+
+          getPatientForm(0);
+          expect(stateWrapper().text()).includes('Pending connection with');
+          expect(submitButton().prop('disabled')).to.be.false;
+
+          getPatientForm(1);
+          expect(stateWrapper().text()).includes('Connected with');
+          expect(submitButton().prop('disabled')).to.be.false;
+
+          getPatientForm(2);
+          expect(stateWrapper().text()).includes('Disconnected from');
+          expect(submitButton().prop('disabled')).to.be.false;
+
+          getPatientForm(3);
+          expect(stateWrapper().text()).includes('Error connecting to');
+          expect(submitButton().prop('disabled')).to.be.false;
+
+          getPatientForm(6);
+          expect(stateWrapper().text()).includes('Pending reconnection with');
+          expect(submitButton().prop('disabled')).to.be.false;
         });
 
         it('should allow resending a pending dexcom connection reminder', () => {


### PR DESCRIPTION
[WEB-2138]

[WEB-2138]: https://tidepool.atlassian.net/browse/WEB-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ