### PR TITLE
[WEB-2285] token refresh

### DIFF
--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -8,10 +8,19 @@ import * as ActionTypes from './redux/constants/actionTypes';
 import { sync, async } from './redux/actions';
 import api from './core/api';
 
-// eslint-disable-next-line new-cap
 export let keycloak = null;
 
 let _keycloakConfig = {};
+let refreshTimeout = null;
+
+export const setTokenRefresh = (keycloak) => {
+  if (refreshTimeout) {
+    clearTimeout(refreshTimeout);
+    refreshTimeout = null;
+  }
+  var expiresIn = (keycloak.tokenParsed['exp'] - new Date().getTime() / 1000 + keycloak.timeSkew) * 1000;
+  refreshTimeout = setTimeout(() => { keycloak.updateToken(-1); }, expiresIn - 10000);
+};
 
 export const updateKeycloakConfig = (info, store) => {
   if (!(isEmpty(info) || isEqual(_keycloakConfig, info))) {
@@ -93,6 +102,7 @@ export const onKeycloakTokens = (store) => (tokens) => {
       },
       () => {}
     );
+    setTokenRefresh(keycloak);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.65.2",
+  "version": "1.65.3-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.65.3-rc.1",
+  "version": "1.65.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
to handle [WEB-2285], preemptively refreshing the auth token 10 seconds prior to expiry as opposed to precisely at time of expiry

Web analog of https://github.com/tidepool-org/uploader/pull/1553

[WEB-2285]: https://tidepool.atlassian.net/browse/WEB-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ