### PR TITLE
[WEB-224] direct linking support

### DIFF
--- a/app/pages/login/login.js
+++ b/app/pages/login/login.js
@@ -37,6 +37,7 @@ export let Login = translate()(class extends React.Component {
     location: PropTypes.object.isRequired,
     signupEmail: PropTypes.string,
     signupKey: PropTypes.string,
+    routerState: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -70,7 +71,7 @@ export let Login = translate()(class extends React.Component {
   };
 
   render() {
-    const { t, keycloakConfig, fetchingInfo, signupEmail, signupKey } = this.props;
+    const { t, keycloakConfig, fetchingInfo, signupEmail, signupKey, routerState } = this.props;
     var form = this.renderForm();
     var inviteIntro = this.renderInviteIntroduction();
     var loggingIn = this.props.working;
@@ -86,6 +87,12 @@ export let Login = translate()(class extends React.Component {
     ) : (
       <div className="login-simpleform">{form}</div>
     );
+    const dest = routerState?.location?.query?.dest;
+    const hasDest = dest && dest !== '/';
+    let redirectUri = win.location.origin;
+    if (hasDest) {
+      redirectUri += dest;
+    }
 
     // for those accepting an invite, forward to keycloak login when available
     if (
@@ -97,7 +104,7 @@ export let Login = translate()(class extends React.Component {
     ) {
       keycloak.login({
         loginHint: this.props.seedEmail,
-        redirectUri: win.location.origin
+        redirectUri: redirectUri,
       });
     }
 
@@ -112,7 +119,7 @@ export let Login = translate()(class extends React.Component {
       ) || keycloakConfig?.error === 'access_denied'
     ) {
       keycloak.login({
-        redirectUri: win.location.origin,
+        redirectUri: redirectUri,
       });
       return <></>;
     }
@@ -281,6 +288,7 @@ export function mapStateToProps(state) {
     fetchingInfo: state.blip.working.fetchingInfo,
     keycloakConfig: state.blip.keycloakConfig,
     confirmingSignup: state.blip.working.confirmingSignup,
+    routerState: state.router,
   };
 }
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2078,6 +2078,37 @@ export function getFetchers(dispatchProps, ownProps, stateProps, api, options) {
     fetchers.push(dispatchProps.fetchPatientFromClinic.bind(null, api, stateProps.selectedClinicId, ownProps.match.params.id));
   }
 
+  // if is clinician user viewing a patient's data with no selected clinic
+  // we need to check clinics for patient and then select the relevant clinic
+  if (
+    personUtils.isClinicianAccount(stateProps.user) &&
+    stateProps.user.userid !== ownProps.match.params.id &&
+    !stateProps.selectedClinicId &&
+    !stateProps.fetchingPatientFromClinic.inProgress
+  ) {
+    let clinicToSelect = null;
+    _.forEach(stateProps.clinics, (clinic, clinicId) => {
+      let patient = _.get(clinic.patients, ownProps.match.params.id, null);
+      if (patient) {
+        clinicToSelect = clinicId;
+      }
+    });
+    if (clinicToSelect) {
+      dispatchProps.selectClinic(clinicToSelect);
+    } else {
+      _.forEach(stateProps.clinics, (clinic, clinicId) => {
+        fetchers.push(
+          dispatchProps.fetchPatientFromClinic.bind(
+            null,
+            api,
+            clinicId,
+            ownProps.match.params.id
+          )
+        );
+      });
+    }
+  }
+
   return fetchers;
 }
 
@@ -2166,6 +2197,7 @@ export function mapStateToProps(state, props) {
     data: state.blip.data,
     selectedClinicId: state.blip.selectedClinicId,
     clinic: state.blip.clinics?.[state.blip.selectedClinicId],
+    clinics: state.blip.clinics,
   };
 }
 
@@ -2186,6 +2218,7 @@ let mapDispatchToProps = dispatch => bindActionCreators({
   removeGeneratedPDFS: actions.worker.removeGeneratedPDFS,
   generateAGPImagesSuccess: actions.sync.generateAGPImagesSuccess,
   generateAGPImagesFailure: actions.sync.generateAGPImagesFailure,
+  selectClinic: actions.sync.selectClinic,
   updateSettings: actions.async.updateSettings,
 }, dispatch);
 
@@ -2203,6 +2236,7 @@ let mergeProps = (stateProps, dispatchProps, ownProps) => {
     'removeGeneratedPDFS',
     'generateAGPImagesSuccess',
     'generateAGPImagesFailure',
+    'selectClinic',
   ];
 
   return Object.assign({}, _.pick(dispatchProps, assignedDispatchProps), stateProps, {

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -225,7 +225,15 @@ export function login(api, credentials, options, postLoginAction) {
     };
 
     let redirectRoute = routes.patients;
-    let { blip: { selectedClinicId = null } } = getState();
+    let {
+      blip: { selectedClinicId = null },
+      router: routerState,
+    } = getState();
+    let dest = routerState?.location?.query?.dest;
+    let hasDest = dest && dest !== '/';
+    if (hasDest) {
+      redirectRoute = dest;
+    }
 
     api.user.login(credentials, options, (err) => {
       if (err) {
@@ -315,7 +323,7 @@ export function login(api, credentials, options, postLoginAction) {
             });
 
             function setRedirectRoute(route, clinicId = null) {
-              redirectRoute = route;
+              redirectRoute = hasDest ? dest : route;
               if (clinicId) {
                 selectedClinicId = clinicId;
               }

--- a/test/unit/pages/login.test.js
+++ b/test/unit/pages/login.test.js
@@ -44,9 +44,14 @@ describe('Login', function () {
         user: {
           isAuthenticated: sinon.stub().returns(false),
           confirmSignUp: sinon.stub().callsArgWith(1, null),
-        }
+        },
       },
       location: {},
+      routerState: {
+        location: {
+          query: {},
+        },
+      },
     };
 
     it('should render without problems when required props are present', function () {
@@ -110,6 +115,34 @@ describe('Login', function () {
       it('should forward a user to keycloak login when initialized', () => {
         expect(keycloakMock.login.callCount).to.equal(1);
         expect(keycloakMock.login.calledWith({ redirectUri: 'testOrigin' })).to.be.true;
+      });
+
+      it('should include a destination if provided in router state', () => {
+        let destStoreState = {
+          ...storeState,
+          router: {
+            location: {
+              query: {
+                dest: '/a_destination'
+              }
+            }
+          }
+        };
+        let destStore = mockStore(destStoreState);
+
+        wrapper = mount(
+          <Provider store={destStore}>
+            <BrowserRouter>
+              <RewiredLogin {...props} />
+            </BrowserRouter>
+          </Provider>
+        );
+        expect(keycloakMock.login.callCount).to.equal(1);
+        expect(
+          keycloakMock.login.calledWith({
+            redirectUri: 'testOrigin/a_destination',
+          })
+        ).to.be.true;
       });
 
       describe('when error from declining TOS', () => {

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -4761,6 +4761,8 @@ describe('PatientData', function () {
       fetchPatientData: sinon.stub().returns('fetchPatientData'),
       fetchPendingSentInvites: sinon.stub().returns('fetchPendingSentInvites'),
       fetchAssociatedAccounts: sinon.stub().returns('fetchAssociatedAccounts'),
+      fetchPatientFromClinic: sinon.stub().returns('fetchPatientFromClinic'),
+      selectClinic: sinon.stub().returns('selectClinic'),
     };
 
     const api = {};
@@ -4810,6 +4812,80 @@ describe('PatientData', function () {
       expect(completedResult.length).to.equal(2);
       expect(completedResult[0]()).to.equal('fetchPatient');
       expect(completedResult[1]()).to.equal('fetchPatientData');
+    });
+
+    it('should fetch patients from clinics if a clinician is viewing a patient without a selected clinic', () => {
+      const fetchPatientsResult = getFetchers(dispatchProps, ownProps, {
+        user: {
+          userid: 'clinician123',
+          isClinicMember: true,
+        },
+        clinics: {
+          clinic1234: {
+            patients: {},
+          },
+          clinic6789: {
+            patients: {},
+          },
+        },
+        selectedClinicId: null,
+        fetchingPatientFromClinic: {
+          inProgress: false,
+        },
+        fetchingPendingSentInvites: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingAssociatedAccounts: {
+          inProgress: false,
+          completed: true,
+        },
+      });
+
+      expect(fetchPatientsResult.length).to.equal(4);
+      expect(fetchPatientsResult[0]()).to.equal('fetchPatient');
+      expect(fetchPatientsResult[1]()).to.equal('fetchPatientData');
+      expect(fetchPatientsResult[2]()).to.equal('fetchPatientFromClinic');
+      expect(fetchPatientsResult[3]()).to.equal('fetchPatientFromClinic');
+    });
+
+    it('should select a clinic if a matching patient record is found', () => {
+      expect(dispatchProps.selectClinic.callCount).to.equal(0);
+      const selectClinicResult = getFetchers(dispatchProps, ownProps, {
+        user: {
+          userid: 'clinician123',
+          isClinicMember: true,
+        },
+        clinics: {
+          clinic1234: {
+            patients: {},
+          },
+          clinic6789: {
+            patients: {
+              12345: {
+                patient: {},
+              },
+            },
+          },
+        },
+        selectedClinicId: null,
+        fetchingPatientFromClinic: {
+          inProgress: false,
+        },
+        fetchingPendingSentInvites: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingAssociatedAccounts: {
+          inProgress: false,
+          completed: true,
+        },
+      });
+
+      expect(selectClinicResult.length).to.equal(2);
+      expect(selectClinicResult[0]()).to.equal('fetchPatient');
+      expect(selectClinicResult[1]()).to.equal('fetchPatientData');
+      expect(dispatchProps.selectClinic.callCount).to.equal(1);
     });
   });
 

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -1544,6 +1544,57 @@ describe('Actions', () => {
             expect(actions).to.eql(expectedActions);
           });
         });
+
+        it('should trigger LOGIN_SUCCESS and redirect to a destination if one is present', () => {
+          setAPIData({
+            user: { userid: 27, roles: ['clinic'], profile: { clinic: true, patient: undefined }, emailVerified: true },
+            clinics: [
+              { clinic: { id: 'clinic123', name: 'Clinic One' } },
+              { clinic: { id: 'clinic456', name: 'Clinic Two' } },
+            ],
+            patients: [],
+            invites: [],
+          });
+
+          const expectedActions = [
+            { type: 'LOGIN_REQUEST' },
+            { type: 'FETCH_USER_REQUEST' },
+            { type: 'FETCH_USER_SUCCESS', payload: { user: user } },
+            { type: 'GET_CLINICS_FOR_CLINICIAN_REQUEST' },
+            { type: 'GET_CLINICS_FOR_CLINICIAN_SUCCESS', payload: { clinicianId: 27, clinics: [
+              { clinic: { id: 'clinic123', name: 'Clinic One' } },
+              { clinic: { id: 'clinic456', name: 'Clinic Two' } },
+            ] }},
+            { type: 'FETCH_CLINICIAN_INVITES_REQUEST' },
+            { type: 'FETCH_CLINICIAN_INVITES_SUCCESS', payload: { invites: [] }},
+            { type: 'FETCH_ASSOCIATED_ACCOUNTS_REQUEST' },
+            { type: 'FETCH_ASSOCIATED_ACCOUNTS_SUCCESS', payload: { patients: [] }},
+            { type: 'SELECT_CLINIC', payload: { clinicId: 'clinic456' } },
+            { type: 'LOGIN_SUCCESS', payload: { user } },
+            { type: '@@router/CALL_HISTORY_METHOD', payload: { method: 'push', args: ['/newDestination', { selectedClinicId: 'clinic456' }] } }
+          ];
+          _.each(expectedActions, (action) => {
+            expect(isTSA(action)).to.be.true;
+          });
+
+          const store = mockStore(
+            _.extend(
+              {},
+              { blip: initialState },
+              { blip: { selectedClinicId: 'clinic456' } },
+              { router: { location: { query: { dest: '/newDestination' } } } },
+            )
+          );
+
+          store.dispatch(async.login(api, creds));
+
+          const actions = store.getActions();
+
+          expect(actions).to.eql(expectedActions);
+          expect(api.user.login.calledWith(creds)).to.be.true;
+          expect(api.user.get.callCount).to.equal(1);
+          expect(trackMetric.calledWith('Logged In')).to.be.true;
+        });
       });
 
       it('[400] should trigger LOGIN_FAILURE and it should call login once and user.get zero times for a failed login request', () => {


### PR DESCRIPTION
For [WEB-224], provides the ability to navigate directly to a given URL, even through the authentication flow. Adds a bit of logic to try and be smart about clinicians viewing patient data to reverse engineer what clinic should be selected so the interface is congruent with the current experience and restricts certain URLs based on account type (non-clinicians don't get clinician routes) and number of clinics a clinician is a member of (routes requiring a selected clinic go to workspace selection if no clinic is selected).

[WEB-224]: https://tidepool.atlassian.net/browse/WEB-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ