### PR TITLE
[WEB-2248] just use host for rollbar environment

### DIFF
--- a/app/rollbar.js
+++ b/app/rollbar.js
@@ -4,12 +4,17 @@ import Rollbar from 'rollbar';
 let rollbar = {};
 
 if (__PROD__) {
+  let environment = window.location.host;
+  if (__API_HOST__) {
+    const url = new URL(__API_HOST__);
+    environment = url.host;
+  }
   rollbar = new Rollbar({
       accessToken: __ROLLBAR_POST_CLIENT_TOKEN__,
       captureUncaught: true,
       captureUnhandledRejections: true,
       payload: {
-          environment: __API_HOST__ || `${window.location.protocol}//${window.location.host}`,
+          environment,
           client: {
             javascript: {
               /* eslint-disable camelcase */

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const optional = require('optional');
 
 const webpackConf = require('./webpack.config.js');
-const mochaConf = optional('./config/mocha.opts.json') || {};
+const mochaConf = optional('./config/mocha.opts.json') || { timeout: 4000 };
 
 const watch = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
 const testWebpackConf = _.assign({}, webpackConf, {

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -734,7 +734,7 @@ describe('ClinicPatients', () => {
 
           sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', { ...defaultFetchOptions, search: 'Two', sort: '+fullName' });
           done();
-        }, 300);
+        }, 1000);
       });
 
       it('should link to a patient data view when patient name is clicked', () => {


### PR DESCRIPTION
for [WEB-2248], Rollbar has the `environment` as part of their URL structure for some pieces of their application, so using a full protocol+host breaks the URLs for those pieces of the application (and they don't urlencode it...) so we can just use the `host` going forward.

[WEB-2248]: https://tidepool.atlassian.net/browse/WEB-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ