### PR TITLE
[WEB-2383] Add `clinicId` to kissmetrics whenever available

### DIFF
--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -41,11 +41,11 @@ export let appContext = {
   config: config
 };
 
-// This anonymous function must remain in ES5 format because
-// the argument parameter used is not bound when using arrow functions
-// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
-appContext.trackMetric = function() {
-  const args = Array.prototype.slice.call(arguments);
+appContext.trackMetric = (...args) => {
+  let selectedClinicId = appContext.store?.getState()?.blip?.selectedClinicId;
+  if (selectedClinicId) {
+    _.defaultsDeep(args, [, { clinicId: selectedClinicId }]);
+  }
   return appContext.api.metrics.track.apply(appContext.api.metrics, args);
 };
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ const testWebpackConf = _.assign({}, webpackConf, {
       __TEST__: true,
       __PROD__: false,
       __I18N_ENABLED__: 'false',
+      __DEV_TOOLS__: false,
     }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.67.0-web-2334-sso-clinician-account-linking.1",
+  "version": "1.67.0-web-2383-kissmetrics-clinicid.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/test/unit/bootstrap.test.js
+++ b/test/unit/bootstrap.test.js
@@ -1,0 +1,61 @@
+/* global chai */
+/* global sinon */
+/* global describe */
+/* global it */
+/* global beforeEach */
+/* global afterEach */
+/* global before */
+/* global after */
+
+const expect = chai.expect;
+import appContext from '../../app/bootstrap';
+
+describe('appContext', () => {
+  before(() => {
+    appContext.api = {
+      metrics: {
+        track: sinon.stub(),
+      },
+    };
+    appContext.store = {
+      getState: sinon.stub().returns({ blip: {} }),
+    };
+  });
+
+  afterEach(() => {
+    appContext.api.metrics.track.resetHistory();
+  });
+
+  it('should call appContext.api.metrics.track with arguments when selectedClinicId is not present', () => {
+    appContext.trackMetric('someMetric');
+
+    expect(appContext.api.metrics.track.calledOnce).to.be.true;
+    expect(appContext.api.metrics.track.calledWith('someMetric')).to.be.true;
+  });
+
+  it('should call appContext.api.metrics.track with clinicId defaulted to selectedClinicId when it is present', () => {
+    const selectedClinicId = 'clinic123';
+
+    appContext.store.getState.returns({ blip: { selectedClinicId } });
+
+    appContext.trackMetric('someMetric2');
+
+    expect(appContext.api.metrics.track.calledOnce).to.be.true;
+    expect(
+      appContext.api.metrics.track.calledWith('someMetric2', {
+        clinicId: 'clinic123',
+      })
+    ).to.be.true;
+
+    appContext.api.metrics.track.resetHistory();
+
+    appContext.trackMetric('someMetric2', { clinicId: 'anotherClinic' });
+
+    expect(appContext.api.metrics.track.calledOnce).to.be.true;
+    expect(
+      appContext.api.metrics.track.calledWith('someMetric2', {
+        clinicId: 'anotherClinic',
+      })
+    ).to.be.true;
+  });
+});


### PR DESCRIPTION
For [WEB-2383], taking some inspiration from how uploader handles adding some metric properties that should always be included if available (including `clinicId`)

[WEB-2383]: https://tidepool.atlassian.net/browse/WEB-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ