### PR TITLE
[WEB-2427] `/new` clinic-details redirects on load

### DIFF
--- a/app/pages/clinicdetails/clinicdetails.js
+++ b/app/pages/clinicdetails/clinicdetails.js
@@ -131,8 +131,10 @@ export const ClinicDetails = (props) => {
           // clinic patients have not been migrated, we open the prompt to complete the migration
           openMigrationConfirmationModal();
         } else {
-          // If there is no reason for the user to be here, we redirect them appropriately
-          redirectToWorkspace();
+          if (action !== 'new') {
+            // If there is no reason for the user to be here, we redirect them appropriately
+            redirectToWorkspace();
+          }
         }
       }
     }


### PR DESCRIPTION
For [WEB-2427] to handle the case where a user navigates directly to the new clinic details page, this adds an exception to the redirect logic to prevent the user from being directed instantly back to the workspaces page

[WEB-2427]: https://tidepool.atlassian.net/browse/WEB-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ