### PR TITLE
[WEB-2428] use Redux state instead of location state for selected clinic

### DIFF
--- a/app/pages/clinicadmin/clinicadmin.js
+++ b/app/pages/clinicadmin/clinicadmin.js
@@ -257,7 +257,7 @@ export const ClinicAdmin = (props) => {
 
   function handleInviteNewMember() {
     trackMetric('Clinic - Invite new clinic team member', { clinicId: selectedClinicId });
-    dispatch(push('/clinic-invite', { clinicId: selectedClinicId }));
+    dispatch(push('/clinic-invite'));
   }
 
   function handleEdit(userId) {

--- a/app/pages/clinicinvite/clinicinvite.js
+++ b/app/pages/clinicinvite/clinicinvite.js
@@ -5,7 +5,6 @@ import { translate } from 'react-i18next';
 import { Box, Flex } from 'rebass/styled-components';
 import { useFormik } from 'formik';
 import { push } from 'connected-react-router';
-import { useLocation } from 'react-router-dom';
 import get from 'lodash/get';
 import map from 'lodash/map';
 import * as yup from 'yup';
@@ -43,8 +42,6 @@ export const ClinicInvite = (props) => {
   const { set: setToast } = useToasts();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [permissionsDialogOpen, setPermissionsDialogOpen] = useState(false);
-  const location = useLocation();
-  const selectedClinic = get(location, 'state.clinicId', false);
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const { sendingClinicianInvite } = useSelector((state) => state.blip.working);
 
@@ -102,7 +99,7 @@ export const ClinicInvite = (props) => {
         metricProperties.access = 'PRESCRIBER';
       }
 
-      dispatch(actions.async.sendClinicianInvite(api, selectedClinic, { email, roles }))
+      dispatch(actions.async.sendClinicianInvite(api, selectedClinicId, { email, roles }))
       trackMetric('Clinic - Invite member', metricProperties);
     },
     validationSchema,
@@ -115,7 +112,7 @@ export const ClinicInvite = (props) => {
     values,
   } = formikContext;
 
-  if (!selectedClinic) {
+  if (!selectedClinicId) {
     dispatch(push('/clinic-admin'));
   }
 

--- a/test/unit/pages/clinicadmin.test.js
+++ b/test/unit/pages/clinicadmin.test.js
@@ -259,9 +259,6 @@ describe('ClinicAdmin', () => {
           payload: {
             args: [
               '/clinic-invite',
-              {
-                clinicId: 'clinicID456',
-              },
             ],
             method: 'push',
           },


### PR DESCRIPTION
for [WEB-2428], uses the (already present) Redux state for `selectedClinicId` instead of the passing it in through the location state

[WEB-2428]: https://tidepool.atlassian.net/browse/WEB-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ