### PR TITLE
[WEB-2429] require selectedClinicId for restricted routes

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -206,7 +206,7 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
           } else {
             if (
               isRestrictedClinicUIRoute &&
-              !(state.clinicFlowActive || state.selectedClinicId)
+              !(state.clinicFlowActive && state.selectedClinicId)
             ) {
               dispatch(push(routes.workspaces));
             }


### PR DESCRIPTION
for [WEB-2429], changes logic to _require_ a `selectedClinicId` for routes that require it

[WEB-2429]: https://tidepool.atlassian.net/browse/WEB-2429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ