### PR TITLE
[WEB-2430] allow create new clinic route without selected clinic

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -192,10 +192,16 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
             '/prescriptions',
           ];
 
+          const isCreateNewClinicRoute = _.startsWith(
+            currentPathname,
+            '/clinic-details/new'
+          );
+
           const isClinicUIRoute = _.some(
             [...unrestrictedClinicUIRoutes, ...requireSelectedClinicUIRoutes],
             (route) => _.startsWith(currentPathname, route)
           );
+
           const isRestrictedClinicUIRoute = _.some(
             requireSelectedClinicUIRoutes,
             (route) => _.startsWith(currentPathname, route)
@@ -206,7 +212,10 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
           } else {
             if (
               isRestrictedClinicUIRoute &&
-              !(state.clinicFlowActive && state.selectedClinicId)
+              !(
+                state.clinicFlowActive &&
+                (state.selectedClinicId || isCreateNewClinicRoute)
+              )
             ) {
               dispatch(push(routes.workspaces));
             }


### PR DESCRIPTION
for [WEB-2430] adds exception to routing rule that allows navigation to `/clinic-details/new` without a selected clinic ID

[WEB-2430]: https://tidepool.atlassian.net/browse/WEB-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ