### PR TITLE
[WEB-2431] handle selecting clinic a patient is a member of in all cases

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2081,19 +2081,21 @@ export function getFetchers(dispatchProps, ownProps, stateProps, api, options) {
 
   // if is clinician user viewing a patient's data with no selected clinic
   // we need to check clinics for patient and then select the relevant clinic
+
+  let clinicToSelect = null;
+  _.forEach(stateProps.clinics, (clinic, clinicId) => {
+    let patient = _.get(clinic.patients, ownProps.match.params.id, null);
+    if (patient) {
+      clinicToSelect = clinicId;
+    }
+  });
+
   if (
     personUtils.isClinicianAccount(stateProps.user) &&
     stateProps.user.userid !== ownProps.match.params.id &&
-    !stateProps.selectedClinicId &&
+    (!stateProps.selectedClinicId || stateProps.selectedClinicId !== clinicToSelect) &&
     !stateProps.fetchingPatientFromClinic.inProgress
   ) {
-    let clinicToSelect = null;
-    _.forEach(stateProps.clinics, (clinic, clinicId) => {
-      let patient = _.get(clinic.patients, ownProps.match.params.id, null);
-      if (patient) {
-        clinicToSelect = clinicId;
-      }
-    });
     if (clinicToSelect) {
       dispatchProps.selectClinic(clinicToSelect);
     } else {


### PR DESCRIPTION
for [WEB-2431], expands selecting a clinic to handle cases where there _is_ a selected clinic, but it's not a clinic that the current patient-in-view is a member of instead of only handling the case where there is no selected clinic

[WEB-2431]: https://tidepool.atlassian.net/browse/WEB-2431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ