### PR TITLE
[WEB-2444] allow clinic profile route for new clinician signups

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -180,6 +180,7 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
         ) {
           const currentPathname = routerState?.location?.pathname;
           const isClinicianAccount = personUtils.isClinicianAccount(user);
+          const hasClinicProfile = !!_.get(user, ['profile', 'clinic'], false);
 
           const unrestrictedClinicUIRoutes = [routes.workspaces];
 
@@ -195,6 +196,11 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
           const isCreateNewClinicRoute = _.startsWith(
             currentPathname,
             '/clinic-details/new'
+          );
+
+          const isClinicProfileRoute = _.startsWith(
+            currentPathname,
+            '/clinic-details/profile'
           );
 
           const isClinicUIRoute = _.some(
@@ -214,7 +220,7 @@ export const requireAuth = (api, cb = _.noop) => (dispatch, getState) => {
               isRestrictedClinicUIRoute &&
               !(
                 state.clinicFlowActive &&
-                (state.selectedClinicId || isCreateNewClinicRoute)
+                (state.selectedClinicId || isCreateNewClinicRoute || (isClinicProfileRoute && !hasClinicProfile))
               )
             ) {
               dispatch(push(routes.workspaces));


### PR DESCRIPTION
For [WEB-2444] allow the `/clinic-details/profile` route even without a selected clinic in the case that the user lacks a clinic profile (for new signups). Mimics logic from the routing when fetching new information on login.

[WEB-2444]: https://tidepool.atlassian.net/browse/WEB-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ