### PR TITLE
[WEB-2392] Only fetch required data types for patients

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -66,6 +66,18 @@ export const DIABETES_DATA_TYPES = [
   'food',
 ];
 
+export const ALL_FETCHED_DATA_TYPES = [
+  ...DIABETES_DATA_TYPES,
+  'cgmSettings',
+  'deviceEvent',
+  'insulin',
+  'physicalActivity',
+  'pumpSettings',
+  'reportedState',
+  'upload',
+  'water',
+];
+
 export const MGDL_UNITS = t('mg/dL');
 export const MMOLL_UNITS = t('mmol/L');
 export const MGDL_PER_MMOLL = 18.01559;

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2127,11 +2127,11 @@ export function mapStateToProps(state, props) {
     }
 
     if (state.blip.currentPatientInViewId) {
-      patient = _.get(
+      patient = _.cloneDeep(_.get(
         state.blip.allUsersMap,
         state.blip.currentPatientInViewId,
         null
-      );
+      ));
 
       permissions = _.get(
         state.blip.permissionsOfMembersInTargetCareTeam,

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -6,7 +6,7 @@ import { checkCacheValid } from 'redux-cache';
 
 import * as ErrorMessages from '../constants/errorMessages';
 import * as UserMessages from '../constants/usrMessages';
-import { DIABETES_DATA_TYPES } from '../../core/constants';
+import { ALL_FETCHED_DATA_TYPES, DIABETES_DATA_TYPES } from '../../core/constants';
 import * as sync from './sync.js';
 import update from 'immutability-helper';
 import personUtils from '../../core/personutils';
@@ -1030,6 +1030,7 @@ export function fetchPatientData(api, options, id) {
     returnData: false,
     useCache: true,
     initial: true,
+    type: ALL_FETCHED_DATA_TYPES.join(','),
   });
 
   let latestUpload;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.67.0-web-2383-kissmetrics-clinicid.1",
+  "version": "1.68.0-web-2392-fetch-only-required-data-types.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/test/unit/app/core/constants.test.js
+++ b/test/unit/app/core/constants.test.js
@@ -98,6 +98,25 @@ describe('constants', function() {
     ]);
   });
 
+  it('should define the list of all fetched data types', function() {
+    expect(Constants.ALL_FETCHED_DATA_TYPES).to.eql([
+      'cbg',
+      'smbg',
+      'basal',
+      'bolus',
+      'wizard',
+      'food',
+      'cgmSettings',
+      'deviceEvent',
+      'insulin',
+      'physicalActivity',
+      'pumpSettings',
+      'reportedState',
+      'upload',
+      'water',
+    ]);
+  });
+
   it('should define url for dexcom connect info', function() {
     expect(Constants.URL_DEXCOM_CONNECT_INFO).to.equal('http://support.tidepool.org/article/73-connecting-dexcom-account-to-tidepool');
   });

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -21,7 +21,7 @@ import initialState from '../../../../app/redux/reducers/initialState';
 import * as ErrorMessages from '../../../../app/redux/constants/errorMessages';
 import * as UserMessages from '../../../../app/redux/constants/usrMessages';
 
-import { TIDEPOOL_DATA_DONATION_ACCOUNT_EMAIL, MMOLL_UNITS } from '../../../../app/core/constants';
+import { TIDEPOOL_DATA_DONATION_ACCOUNT_EMAIL, MMOLL_UNITS, ALL_FETCHED_DATA_TYPES } from '../../../../app/core/constants';
 
 // need to require() async in order to rewire utils inside
 const async = require('../../../../app/redux/actions/async');
@@ -4315,6 +4315,7 @@ describe('Actions', () => {
             ...options,
             startDate: '2017-12-31T00:00:00.000Z',
             endDate: '2018-06-02T00:00:00.000Z',
+            type: ALL_FETCHED_DATA_TYPES.join(','),
           }).callCount).to.equal(1);
         });
       });


### PR DESCRIPTION
Addresses [WEB-2392]
List of fetched data types corresponds to the [expected list in the data util validation in viz](https://github.com/tidepool-org/viz/blob/907c7824f9dd4b6ed13ff8bd56ddeaf9c3478ecf/src/utils/validation/schema.js#L72-L88)

Also includes a small race condition fix for a state mutation error that was happening for me locally, but not on QA2 on the same build.

[WEB-2392]: https://tidepool.atlassian.net/browse/WEB-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ