### PR TITLE
[WEB-2479] ssr-pdf

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -924,7 +924,7 @@ export const PatientDataClass = createReactClass({
 
   generateAGPImages: async function(props = this.props) {
     try {
-      const images = await vizUtils.agp.generateAGPSVGDataURLS({ ...props.pdf.data?.agp });
+      const images = await vizUtils.agp.generateAGPFigureDefinitions({ ...props.pdf.data?.agp });
       const promises = _.map(images, async (image, key) => {
         if (_.isArray(image)) {
           const processedArray = await Promise.all(

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.2",
+    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.3",
     "async": "2.6.4",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.69.0-web-2479-ssr-pdf.4",
+  "version": "1.69.0-web-2479-ssr-pdf.5",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express": "4.16.3",
     "helmet": "3.23.3",
     "i18n-iso-countries": "6.1.0",
+    "plotly.js-basic-dist-min": "2.20.0",
     "rollbar": "2.19.3"
   },
   "devDependencies": {
@@ -57,7 +58,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.34.0",
+    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.1",
     "async": "2.6.4",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.68.0",
+  "version": "1.68.0-web-2479-ssr-pdf.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.68.0-web-2479-ssr-pdf.2",
+  "version": "1.68.0-web-2479-ssr-pdf.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.4",
+    "@tidepool/viz": "1.36.0",
     "async": "2.6.4",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.68.0-web-2479-ssr-pdf.1",
+  "version": "1.68.0-web-2479-ssr-pdf.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.1",
+    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.2",
     "async": "2.6.4",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@storybook/addon-viewport": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
-    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.3",
+    "@tidepool/viz": "1.35.0-web-2479-ssr-pdf.4",
     "async": "2.6.4",
     "autoprefixer": "9.8.4",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.69.0-web-2479-ssr-pdf.3",
+  "version": "1.69.0-web-2479-ssr-pdf.4",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -3373,10 +3373,14 @@ describe('PatientData', function () {
             .onSecondCall().rejects(new Error('failed image generation')),
         },
       });
+      PD.__Rewire__('Plotly', {
+        toImage: sinon.stub().returns('stubbed image data')
+      });
     });
 
     after(() => {
       PD.__ResetDependency__('vizUtils');
+      PD.__ResetDependency__('Plotly');
     });
 
     beforeEach(() => {
@@ -3392,7 +3396,9 @@ describe('PatientData', function () {
       setTimeout(() => {
         sinon.assert.callCount(defaultProps.generateAGPImagesFailure, 0);
         sinon.assert.callCount(defaultProps.generateAGPImagesSuccess, 1);
-        sinon.assert.calledWith(defaultProps.generateAGPImagesSuccess, 'stubbed image data');
+        sinon.assert.calledWithMatch(defaultProps.generateAGPImagesSuccess, {
+          0: 'stubbed image data'
+        });
         done();
       });
     });

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -3368,7 +3368,7 @@ describe('PatientData', function () {
     before(() => {
       PD.__Rewire__('vizUtils', {
         agp: {
-          generateAGPSVGDataURLS: sinon.stub()
+          generateAGPFigureDefinitions: sinon.stub()
             .onFirstCall().resolves('stubbed image data')
             .onSecondCall().rejects(new Error('failed image generation')),
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,10 +3044,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.35.0-web-2479-ssr-pdf.3":
-  version "1.35.0-web-2479-ssr-pdf.3"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.3.tgz#c506fa968119f87cf031a2344114dc7cdaad8d6b"
-  integrity sha512-7jXsANYNVngR1PUDlcLWiBvEQcdvvQtMUPZQV8qo9XImev+7TXbyHcdDLDWkx5NPRL+qnzog0Xujbh065dUVNQ==
+"@tidepool/viz@1.35.0-web-2479-ssr-pdf.4":
+  version "1.35.0-web-2479-ssr-pdf.4"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.4.tgz#c952997e39bcddbe5ea3d9eb42b2f96678e6a391"
+  integrity sha512-micECqCCa6Ukepdra5Ch4QbBTYvc/Ua4IewSP0Epecq6INQm719HmsUWBdnuM6CZ2mioKDg31NclKPL1pvDi2g==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,10 +3044,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.35.0-web-2479-ssr-pdf.1":
-  version "1.35.0-web-2479-ssr-pdf.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.1.tgz#a6784cf0ef2cd0b3383c7e77c899582d43388072"
-  integrity sha512-jGbyG/EzwuHOxNpCkdF3fE4ZK6ip7C3+Y1bJr8DbjgDxXembVp1mMLAd20ZzOOA93c8b7C1uzI9yOJLgioasVQ==
+"@tidepool/viz@1.35.0-web-2479-ssr-pdf.2":
+  version "1.35.0-web-2479-ssr-pdf.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.2.tgz#5c67851d2eec968a2b985322679c70a69e4b88b9"
+  integrity sha512-WZbPABSL/hSwV5rFxgPzPGgXLru4k8Ep5rd97LZPR1/dqvjOiIfuFId2K+QOpjmoEJXllVpe/SK+j2sS0k1xYA==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,10 +3044,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.35.0-web-2479-ssr-pdf.2":
-  version "1.35.0-web-2479-ssr-pdf.2"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.2.tgz#5c67851d2eec968a2b985322679c70a69e4b88b9"
-  integrity sha512-WZbPABSL/hSwV5rFxgPzPGgXLru4k8Ep5rd97LZPR1/dqvjOiIfuFId2K+QOpjmoEJXllVpe/SK+j2sS0k1xYA==
+"@tidepool/viz@1.35.0-web-2479-ssr-pdf.3":
+  version "1.35.0-web-2479-ssr-pdf.3"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.3.tgz#c506fa968119f87cf031a2344114dc7cdaad8d6b"
+  integrity sha512-7jXsANYNVngR1PUDlcLWiBvEQcdvvQtMUPZQV8qo9XImev+7TXbyHcdDLDWkx5NPRL+qnzog0Xujbh065dUVNQ==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.2"
@@ -3069,7 +3069,6 @@
     moment "2.29.4"
     moment-timezone "0.5.21"
     parse-svg-path "0.1.2"
-    plotly.js-basic-dist-min "2.20.0"
     prop-types "15.6.2"
     react "16.12.0"
     react-clipboard.js "2.0.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,10 +3044,10 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.35.0-web-2479-ssr-pdf.4":
-  version "1.35.0-web-2479-ssr-pdf.4"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.4.tgz#c952997e39bcddbe5ea3d9eb42b2f96678e6a391"
-  integrity sha512-micECqCCa6Ukepdra5Ch4QbBTYvc/Ua4IewSP0Epecq6INQm719HmsUWBdnuM6CZ2mioKDg31NclKPL1pvDi2g==
+"@tidepool/viz@1.36.0":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.36.0.tgz#c097779b02d6cdaf2b8efb0745fc438515694049"
+  integrity sha512-szP3cDbT074rY/gbhqQxCPrPAtq4ZsOloCgF+2x99ogZp2d1piAPzuu6FIXYQB54FQKDqjs4RRxtA1Rpuo5qGg==
   dependencies:
     bluebird "3.5.2"
     bows "1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,13 +3044,13 @@
     "@types/react" "^16.8.22"
     "@types/react-test-renderer" "^16.8.2"
 
-"@tidepool/viz@1.34.0":
-  version "1.34.0"
-  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.34.0.tgz#1da3249a1e8cdca293ab83e941b2b578d0c5ac74"
-  integrity sha512-SQ+6IpDBOnKFTdaubcecxog5IJcqE4NNOus4GEzvOetuG7z0TioeK1vJxpA3ZJFLBbREMKJNweJ0mu1o988NcA==
+"@tidepool/viz@1.35.0-web-2479-ssr-pdf.1":
+  version "1.35.0-web-2479-ssr-pdf.1"
+  resolved "https://registry.yarnpkg.com/@tidepool/viz/-/viz-1.35.0-web-2479-ssr-pdf.1.tgz#a6784cf0ef2cd0b3383c7e77c899582d43388072"
+  integrity sha512-jGbyG/EzwuHOxNpCkdF3fE4ZK6ip7C3+Y1bJr8DbjgDxXembVp1mMLAd20ZzOOA93c8b7C1uzI9yOJLgioasVQ==
   dependencies:
     bluebird "3.5.2"
-    bows "1.7.0"
+    bows "1.7.2"
     classnames "2.2.6"
     crossfilter2 "1.5.2"
     d3-array "1.2.4"
@@ -3807,7 +3807,7 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-andlog@^1.0.0:
+andlog@^1.0.0, andlog@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/andlog/-/andlog-1.0.2.tgz#0e77a44f62a782be3a78a7527beb5761c183f044"
   integrity sha512-ne6ibcbv3wqZHzbXarG7NfOpU2ai5ao6429ocq1betBBDDx7KE7R6k0IIeaT29JNko0lA88yVzHRRuxX2wpkHQ==
@@ -4924,6 +4924,13 @@ bows@1.7.0:
   integrity sha1-o1mO2c72GnoMqxpyQPKRZUhl7HY=
   dependencies:
     andlog "^1.0.0"
+
+bows@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/bows/-/bows-1.7.2.tgz#4deb95d5b78049794cce925a869155b722d2d516"
+  integrity sha512-AeIQNXbTstXOPjIBol9oTnaaO/2ByuExio0AEIx8vqOIJnAAWFfbWWzh7YPiSKYAxJNTjcy+J+xH2jCRb460Yw==
+  dependencies:
+    andlog "^1.0.2"
 
 bowser@2.9.0:
   version "2.9.0"


### PR DESCRIPTION
For [WEB-2479], moves the SVG generation via Plotly into `blip` instead of `viz`

Associated with https://github.com/tidepool-org/viz/pull/365

[WEB-2479]: https://tidepool.atlassian.net/browse/WEB-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ