### PR TITLE
[WEB-2500] tide backend integration

### DIFF
--- a/app/components/clinic/TideDashboardConfigForm.js
+++ b/app/components/clinic/TideDashboardConfigForm.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import moment from 'moment';
 import includes from 'lodash/includes';
 import keyBy from 'lodash/keyBy';
 import map from 'lodash/map';
@@ -11,7 +10,6 @@ import reject from 'lodash/reject';
 import without from 'lodash/without';
 import { useFormik } from 'formik';
 import { Box, BoxProps } from 'rebass/styled-components';
-import { utils as vizUtils } from '@tidepool/viz';
 
 import { TagList } from '../../components/elements/Tag';
 import RadioGroup from '../../components/elements/RadioGroup';
@@ -20,10 +18,7 @@ import { getCommonFormikFieldProps, getFieldError } from '../../core/forms';
 import { tideDashboardConfigSchema as validationSchema, summaryPeriodOptions, lastUploadDateFilterOptions } from '../../core/clinicUtils';
 import { Body0, Caption } from '../../components/elements/FontStyles';
 import { borders } from '../../themes/baseTheme';
-import { pick } from 'lodash';
 import { push } from 'connected-react-router';
-
-const { getLocalizedCeiling } = vizUtils.datetime;
 
 function getFormValues(config, clinicPatientTags) {
   return {
@@ -49,7 +44,6 @@ export const TideDashboardConfigForm = props => {
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const loggedInUserId = useSelector((state) => state.blip.loggedInUserId);
   const clinic = useSelector(state => state.blip.clinics?.[selectedClinicId]);
-  const timePrefs = useSelector((state) => state.blip.timePrefs);
   const clinicPatientTags = useMemo(() => keyBy(clinic?.patientTags, 'id'), [clinic?.patientTags]);
   const [config, setConfig] = useLocalStorage('tideDashboardConfig', {});
   const localConfigKey = [loggedInUserId, selectedClinicId].join('|');
@@ -58,10 +52,6 @@ export const TideDashboardConfigForm = props => {
   const formikContext = useFormik({
     initialValues: getFormValues(config?.[localConfigKey], clinicPatientTags),
     onSubmit: values => {
-      const options = pick(values, ['tags', 'period']);
-      // options.mockData = true; // TODO: delete temp mocked data response
-      options.lastUploadDateTo = getLocalizedCeiling(new Date().toISOString(), timePrefs).toISOString();
-      options.lastUploadDateFrom = moment(options.lastUploadDateTo).subtract(values.lastUpload, 'days').toISOString();
       if (!isDashboardPage) dispatch(push('/dashboard/tide'));
 
       setConfig({

--- a/app/components/clinic/TideDashboardConfigForm.js
+++ b/app/components/clinic/TideDashboardConfigForm.js
@@ -59,7 +59,7 @@ export const TideDashboardConfigForm = props => {
     initialValues: getFormValues(config?.[localConfigKey], clinicPatientTags),
     onSubmit: values => {
       const options = pick(values, ['tags', 'period']);
-      options.mockData = true; // TODO: delete temp mocked data response
+      // options.mockData = true; // TODO: delete temp mocked data response
       options.lastUploadDateTo = getLocalizedCeiling(new Date().toISOString(), timePrefs).toISOString();
       options.lastUploadDateFrom = moment(options.lastUploadDateTo).subtract(values.lastUpload, 'days').toISOString();
       if (!isDashboardPage) dispatch(push('/dashboard/tide'));

--- a/app/components/navbar/navbar.js
+++ b/app/components/navbar/navbar.js
@@ -35,8 +35,14 @@ export default translate()(class extends React.Component {
   };
 
   render() {
-    const { t } = this.props;
-    const patientListLink = this.props.clinicFlowActive && this.props.selectedClinicId ? '/clinic-workspace/patients' : '/patients';
+    const { t, query } = this.props;
+    let patientListLink = this.props.clinicFlowActive && this.props.selectedClinicId ? '/clinic-workspace/patients' : '/patients';
+    if (query.dashboard) patientListLink = `/dashboard/${query.dashboard}`;
+
+    const linkText = query.dashboard
+      ? t('Back to Dashboard')
+      : t('Back to Patient List')
+
     const isDashboardView = /^\/dashboard\//.test(this.props.currentPage);
 
     const showPatientListLink = personUtils.isClinicianAccount(this.props.user) && (
@@ -78,7 +84,7 @@ export default translate()(class extends React.Component {
               })}
               sx={{ display: 'inline-flex !important' }}
             >
-              {t('Back to Patient List')}
+              {linkText}
             </Button>
           </Link>
         )}

--- a/app/components/navbar/navbar.js
+++ b/app/components/navbar/navbar.js
@@ -37,11 +37,11 @@ export default translate()(class extends React.Component {
   render() {
     const { t, query } = this.props;
     let patientListLink = this.props.clinicFlowActive && this.props.selectedClinicId ? '/clinic-workspace/patients' : '/patients';
-    if (query.dashboard) patientListLink = `/dashboard/${query.dashboard}`;
+    if (query?.dashboard) patientListLink = `/dashboard/${query.dashboard}`;
 
-    const linkText = query.dashboard
+    const linkText = query?.dashboard
       ? t('Back to Dashboard')
-      : t('Back to Patient List')
+      : t('Back to Patient List');
 
     const isDashboardView = /^\/dashboard\//.test(this.props.currentPage);
 

--- a/app/pages/app/app.js
+++ b/app/pages/app/app.js
@@ -316,6 +316,7 @@ export class AppComponent extends React.Component {
             patient={patient}
             fetchingPatient={this.props.fetchingPatient}
             currentPage={this.props.location}
+            query={this.props.query}
             clinicFlowActive={this.props.clinicFlowActive}
             clinics={this.props.clinics}
             getUploadUrl={getUploadUrl}
@@ -901,6 +902,7 @@ let mergeProps = (stateProps, dispatchProps, ownProps) => {
     fetchDataSources: dispatchProps.fetchDataSources.bind(null, api),
     fetchers: getFetchers(stateProps, dispatchProps, api),
     location: ownProps.location.pathname,
+    query: ownProps.location.query,
     onAcceptTerms: dispatchProps.acceptTerms.bind(null, api),
     onCloseNotification: dispatchProps.onCloseNotification,
     onDismissDonateBanner: dispatchProps.onDismissDonateBanner.bind(null, api),

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -92,7 +92,7 @@ import {
   maxClinicPatientTags
 } from '../../core/clinicUtils';
 
-import { MGDL_UNITS } from '../../core/constants';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../core/constants';
 import { borders, radii, colors, space } from '../../themes/baseTheme';
 import PopoverElement from '../../components/elements/PopoverElement';
 
@@ -475,7 +475,7 @@ export const ClinicPatients = (props) => {
     fullName: 'asc',
     birthDate: 'asc',
     glucoseManagementIndicator: 'desc',
-    averageGlucose: 'desc',
+    averageGlucoseMmol: 'desc',
     lastUploadDate: 'desc',
     timeInVeryLowRecords: 'desc',
     timeInVeryHighRecords: 'desc',
@@ -2627,16 +2627,16 @@ export const ClinicPatients = (props) => {
   }, [clinicBgUnits, activeSummaryPeriod, t]);
 
   const renderAverageGlucose = useCallback(({ summary }) => {
-    const averageGlucose = summary?.bgmStats?.periods?.[activeSummaryPeriod]?.averageGlucose;
+    const averageGlucose = summary?.bgmStats?.periods?.[activeSummaryPeriod]?.averageGlucoseMmol;
     let averageDailyRecords = Math.round(summary?.bgmStats?.periods?.[activeSummaryPeriod]?.averageDailyRecords);
     const averageDailyRecordsUnits = averageDailyRecords > 1 ? 'readings/day' : 'reading/day';
     if (averageDailyRecords === 0) averageDailyRecords = '<1';
     const averageDailyRecordsText = t('{{averageDailyRecords}} {{averageDailyRecordsUnits}}', { averageDailyRecords, averageDailyRecordsUnits });
     const bgPrefs = { bgUnits: clinicBgUnits };
 
-    const formattedAverageGlucose = clinicBgUnits === averageGlucose?.units
-      ? formatBgValue(averageGlucose?.value, bgPrefs)
-      : formatBgValue(utils.translateBg(averageGlucose?.value, clinicBgUnits), bgPrefs);
+    const formattedAverageGlucose = clinicBgUnits === MMOLL_UNITS
+      ? formatBgValue(averageGlucose, bgPrefs)
+      : formatBgValue(utils.translateBg(averageGlucose, clinicBgUnits), bgPrefs);
 
     return averageGlucose ? (
       <Box>
@@ -2830,11 +2830,11 @@ export const ClinicPatients = (props) => {
           },
           {
             title: t('Avg. Glucose ({{bgUnits}})', { bgUnits: clinicBgUnits }),
-            field: 'bgm.averageGlucose',
+            field: 'bgm.averageGlucoseMmol',
             align: 'left',
             sortable: true,
             defaultOrder: defaultSortOrders.averageGlucose,
-            sortBy: 'averageGlucose',
+            sortBy: 'averageGlucoseMmol',
             render: renderAverageGlucose,
             className: 'group-left',
           },

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -1170,7 +1170,7 @@ export const ClinicPatients = (props) => {
                         disabled={!clinic?.patientTags?.length}
                         tagColorPalette={!clinic?.patientTags?.length ? [colors.lightGrey, colors.text.primaryDisabled] : 'greens'}
                         >
-                        {t('Tide Dashboard View')}
+                        {t('TIDE Dashboard View')}
                       </Button>
                     </PopoverElement>
                   )}

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -613,7 +613,7 @@ export const TideDashboard = (props) => {
   const fetchDashboardPatients = useCallback((config) => {
     const options = { ...(config || localConfig?.[localConfigKey]) };
     if (options) {
-      options.mockData = true; // TODO: delete temp mocked data response
+      // options.mockData = true; // TODO: delete temp mocked data response
       setLoading(true);
       dispatch(actions.async.fetchTideDashboardPatients(api, selectedClinicId, options));
     }

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -64,7 +64,7 @@ import {
   tideDashboardConfigSchema,
 } from '../../core/clinicUtils';
 
-import { MGDL_UNITS } from '../../core/constants';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../core/constants';
 import { colors, radii } from '../../themes/baseTheme';
 
 const { Loader } = vizComponents;
@@ -252,12 +252,12 @@ const TideDashboardSection = React.memo(props => {
   ), [handleClickPatient]);
 
   const renderAverageGlucose = useCallback(summary => {
-    const averageGlucose = summary?.averageGlucose;
+    const averageGlucose = summary?.averageGlucoseMmol;
     const bgPrefs = { bgUnits: clinicBgUnits };
 
-    const formattedAverageGlucose = clinicBgUnits === averageGlucose?.units
-      ? formatBgValue(averageGlucose?.value, bgPrefs)
-      : formatBgValue(utils.translateBg(averageGlucose?.value, clinicBgUnits), bgPrefs);
+    const formattedAverageGlucose = clinicBgUnits === MMOLL_UNITS
+      ? formatBgValue(averageGlucose, bgPrefs)
+      : formatBgValue(utils.translateBg(averageGlucose, clinicBgUnits), bgPrefs);
 
     return averageGlucose ? (
       <Box className="patient-average-glucose">
@@ -375,7 +375,7 @@ const TideDashboardSection = React.memo(props => {
       },
       {
         title: t('Avg. Glucose'),
-        field: 'averageGlucose',
+        field: 'averageGlucoseMmol',
         align: 'center',
         render: renderAverageGlucose,
       },

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -520,7 +520,10 @@ const TideDashboardSection = React.memo(props => {
       />
     </Box>
   );
-}, ((prevProps, nextProps) => (prevProps.section.sortDirection === nextProps.section.sortDirection)));
+}, ((prevProps, nextProps) => (
+  prevProps.section.sortDirection === nextProps.section.sortDirection &&
+  prevProps.config === nextProps.config
+)));
 
 export const TideDashboard = (props) => {
   const { t, api, trackMetric } = props;

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -238,7 +238,7 @@ const TideDashboardSection = React.memo(props => {
   const handleClickPatient = useCallback(patient => {
     return () => {
       trackMetric('Selected PwD');
-      dispatch(push(`/patients/${patient?.id}/data?chart=trends`));
+      dispatch(push(`/patients/${patient?.id}/data?chart=trends&dashboard=tide`));
     }
   }, [dispatch, trackMetric]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.68.0-web-2500-tide-backend-integration.1",
+  "version": "1.70.0-web-2500-tide-backend-integration.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.70.0-web-2500-tide-backend-integration.1",
+  "version": "1.70.0-web-2500-tide-backend-integration.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.68.0-web-2498-tide-unhappy-paths.1",
+  "version": "1.68.0-web-2500-tide-backend-integration.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.68.0-web-2348-tide-cohort-tables.1",
+  "version": "1.68.0-web-2498-tide-unhappy-paths.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.70.0-web-2500-tide-backend-integration.2",
+  "version": "1.70.0-web-2500-tide-backend-integration.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "terser": "4.8.1",
     "terser-webpack-plugin": "2.2.1",
     "tideline": "1.26.0",
-    "tidepool-platform-client": "0.53.0-web-2346-tide-cta-modal.1",
+    "tidepool-platform-client": "0.53.0-web-2500-tide-backend-integration.1",
     "tidepool-standard-action": "0.1.1",
     "ua-parser-js": "1.0.33",
     "url-loader": "1.1.1",

--- a/server.js
+++ b/server.js
@@ -104,6 +104,7 @@ app.use(nonceMiddleware, helmet.contentSecurityPolicy({
       'https://app.pendo.io',
       'https://data.pendo.io',
       'https://pendo-static-5707274877534208.storage.googleapis.com',
+      'https://*.launchdarkly.com',
     ]).filter(src => src !== undefined),
     frameAncestors: ['https://app.pendo.io', '*.tidepool.org', 'localhost:*']
   },

--- a/test/fixtures/mockTideDashboardPatients.json
+++ b/test/fixtures/mockTideDashboardPatients.json
@@ -25,10 +25,7 @@
   "results": {
     "timeInVeryLowPercent": [
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 5.4
-        },
+        "averageGlucoseMmol": 5.4,
         "glucoseManagementIndicator": 12.2,
         "timeInVeryLowPercent": 0.0305,
         "timeInLowPercent": 0.16864,
@@ -51,10 +48,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 12.8
-        },
+        "averageGlucoseMmol": 12.8,
         "glucoseManagementIndicator": 13.5,
         "timeInVeryLowPercent": 0.03817,
         "timeInLowPercent": 0.12279,
@@ -74,10 +68,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 7.5
-        },
+        "averageGlucoseMmol": 7.5,
         "glucoseManagementIndicator": 6.6,
         "timeInVeryLowPercent": 0.01134,
         "timeInLowPercent": 0.18651,
@@ -102,10 +93,7 @@
     ],
     "timeInLowPercent": [
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 4.3
-        },
+        "averageGlucoseMmol": 4.3,
         "glucoseManagementIndicator": 6.2,
         "timeInVeryLowPercent": 0.00857,
         "timeInLowPercent": 0.08968,
@@ -128,10 +116,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 6.8
-        },
+        "averageGlucoseMmol": 6.8,
         "glucoseManagementIndicator": 5.2,
         "timeInVeryLowPercent": 0.006,
         "timeInLowPercent": 0.0852,
@@ -151,10 +136,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 8.8
-        },
+        "averageGlucoseMmol": 8.8,
         "glucoseManagementIndicator": 5,
         "timeInVeryLowPercent": 0.00839,
         "timeInLowPercent": 0.05639,
@@ -177,10 +159,7 @@
     ],
     "dropInTimeInTargetPercent": [
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 12.2
-        },
+        "averageGlucoseMmol": 12.2,
         "glucoseManagementIndicator": 9,
         "timeInVeryLowPercent": 0.00678,
         "timeInLowPercent": 0.08231,
@@ -201,10 +180,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 5.5
-        },
+        "averageGlucoseMmol": 5.5,
         "glucoseManagementIndicator": 4.7,
         "timeInVeryLowPercent": 0.00318,
         "timeInLowPercent": 0.04043,
@@ -224,10 +200,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 10.5
-        },
+        "averageGlucoseMmol": 10.5,
         "glucoseManagementIndicator": 7,
         "timeInVeryLowPercent": 0.00585,
         "timeInLowPercent": 0.09144,
@@ -252,10 +225,7 @@
     ],
     "timeInTargetPercent": [
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 13.9
-        },
+        "averageGlucoseMmol": 13.9,
         "glucoseManagementIndicator": 14.2,
         "timeInVeryLowPercent": 0.01048,
         "timeInLowPercent": 0.07943,
@@ -275,10 +245,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 8.3
-        },
+        "averageGlucoseMmol": 8.3,
         "glucoseManagementIndicator": 7.8,
         "timeInVeryLowPercent": 0.00249,
         "timeInLowPercent": 0.07275,
@@ -298,10 +265,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 8.8
-        },
+        "averageGlucoseMmol": 8.8,
         "glucoseManagementIndicator": 4.3,
         "timeInVeryLowPercent": 0.0045,
         "timeInLowPercent": 0.09458,
@@ -326,10 +290,7 @@
     ],
     "timeCGMUsePercent": [
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 11.4
-        },
+        "averageGlucoseMmol": 11.4,
         "glucoseManagementIndicator": 4.5,
         "timeInVeryLowPercent": 0.00451,
         "timeInLowPercent": 0.01583,
@@ -350,10 +311,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 8.8
-        },
+        "averageGlucoseMmol": 8.8,
         "glucoseManagementIndicator": 4.6,
         "timeInVeryLowPercent": 0.01024,
         "timeInLowPercent": 0.00851,
@@ -373,10 +331,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 9.9
-        },
+        "averageGlucoseMmol": 9.9,
         "glucoseManagementIndicator": 9.1,
         "timeInVeryLowPercent": 0.00295,
         "timeInLowPercent": 0.02865,
@@ -401,10 +356,7 @@
     ],
     "meetingTargets": [
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 7.4
-        },
+        "averageGlucoseMmol": 7.4,
         "glucoseManagementIndicator": 8.6,
         "timeInVeryLowPercent": 0.00088,
         "timeInLowPercent": 0.01365,
@@ -426,10 +378,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 5
-        },
+        "averageGlucoseMmol": 5,
         "glucoseManagementIndicator": 12.1,
         "timeInVeryLowPercent": 0.00607,
         "timeInLowPercent": 0.03211,
@@ -450,10 +399,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 7.3
-        },
+        "averageGlucoseMmol": 7.3,
         "glucoseManagementIndicator": 6.9,
         "timeInVeryLowPercent": 0.00253,
         "timeInLowPercent": 0.0209,
@@ -476,10 +422,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 13.8
-        },
+        "averageGlucoseMmol": 13.8,
         "glucoseManagementIndicator": 14.9,
         "timeInVeryLowPercent": 0.00237,
         "timeInLowPercent": 0.02924,
@@ -500,10 +443,7 @@
         }
       },
       {
-        "averageGlucose": {
-          "units": "mmol/L",
-          "value": 12.6
-        },
+        "averageGlucoseMmol": 12.6,
         "glucoseManagementIndicator": 10.6,
         "timeInVeryLowPercent": 0.00679,
         "timeInLowPercent": 0.02242,

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -301,7 +301,7 @@ describe('ClinicPatients', () => {
                     lastUploadDate: moment().subtract(1, 'day').toISOString(),
                   },
                   periods: { '14d': {
-                    averageGlucose: { units: MMOLL_UNITS, value: 10.5 },
+                    averageGlucoseMmol: 10.5,
                     averageDailyRecords: 0.25,
                     timeInVeryLowRecords: 1,
                     timeInVeryHighRecords: 2,
@@ -312,7 +312,6 @@ describe('ClinicPatients', () => {
                     lastUploadDate: moment().toISOString(),
                   },
                   periods: { '14d': {
-                    averageGlucose: { units: MMOLL_UNITS },
                     timeCGMUsePercent: 0.85,
                     timeCGMUseMinutes: 23 * 60,
                     glucoseManagementIndicator: 7.75,
@@ -334,7 +333,7 @@ describe('ClinicPatients', () => {
                     lastUploadDate: moment().subtract(1, 'day').toISOString(),
                   },
                   periods: { '14d': {
-                    averageGlucose: { units: MMOLL_UNITS, value: 11.5 },
+                    averageGlucoseMmol: 11.5,
                     averageDailyRecords: 1.25,
                     timeInVeryLowRecords: 3,
                     timeInVeryHighRecords: 4,
@@ -346,25 +345,21 @@ describe('ClinicPatients', () => {
                   },
                   periods: {
                     '30d': {
-                      averageGlucose: { units: MGDL_UNITS },
                       timeCGMUsePercent: 0.70,
                       timeCGMUseMinutes:  7 * 24 * 60,
                       glucoseManagementIndicator: 7.5,
                     },
                     '14d': {
-                      averageGlucose: { units: MGDL_UNITS },
                       timeCGMUsePercent: 0.70,
                       timeCGMUseMinutes:  7 * 24 * 60,
                       glucoseManagementIndicator: 6.5,
                     },
                     '7d': {
-                      averageGlucose: { units: MGDL_UNITS },
                       timeCGMUsePercent: 0.70,
                       timeCGMUseMinutes:  7 * 24 * 60,
                       glucoseManagementIndicator: 5.5,
                     },
                     '1d': {
-                      averageGlucose: { units: MGDL_UNITS },
                       timeCGMUsePercent: 0.70,
                       timeCGMUseMinutes:  7 * 24 * 60,
                       glucoseManagementIndicator: 4.5,
@@ -386,7 +381,7 @@ describe('ClinicPatients', () => {
                     lastUploadDate: moment().subtract(1, 'day').toISOString(),
                   },
                   periods: { '14d': {
-                    averageGlucose: { units: MMOLL_UNITS, value: 12.5 },
+                    averageGlucoseMmol: 12.5,
                     averageDailyRecords: 1.5,
                     timeInVeryLowRecords: 0,
                     timeInVeryHighRecords: 0,
@@ -397,7 +392,6 @@ describe('ClinicPatients', () => {
                     lastUploadDate: moment().subtract(29, 'days').toISOString(),
                   },
                   periods: { '14d': {
-                    averageGlucose: { units: MMOLL_UNITS },
                     timeCGMUsePercent: 0.69,
                     timeCGMUseMinutes:  7 * 24 * 60,
                     glucoseManagementIndicator: 8.5,
@@ -417,7 +411,6 @@ describe('ClinicPatients', () => {
                     lastUploadDate: moment().subtract(30, 'days').toISOString(),
                   },
                   periods: { '14d': {
-                    averageGlucose: { units: MGDL_UNITS },
                     timeCGMUsePercent: 0.69,
                     timeCGMUseMinutes:  30 * 24 * 60,
                     glucoseManagementIndicator: 8.5,
@@ -1268,7 +1261,7 @@ describe('ClinicPatients', () => {
           assert(columns.at(7).is('#peopleTable-header-bgmTag'));
 
           expect(columns.at(8).text()).to.equal('Avg. Glucose (mg/dL)');
-          assert(columns.at(8).is('#peopleTable-header-bgm-averageGlucose'));
+          assert(columns.at(8).is('#peopleTable-header-bgm-averageGlucoseMmol'));
 
           expect(columns.at(9).text()).to.equal('Lows');
           assert(columns.at(9).is('#peopleTable-header-bgm-timeInVeryLowRecords'));
@@ -1388,15 +1381,15 @@ describe('ClinicPatients', () => {
           gmiHeader.simulate('click');
           sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ sort: '+glucoseManagementIndicator', sortType: 'cgm' }));
 
-          const averageGlucoseHeader = table.find('#peopleTable-header-bgm-averageGlucose .MuiTableSortLabel-root').at(0);
+          const averageGlucoseHeader = table.find('#peopleTable-header-bgm-averageGlucoseMmol .MuiTableSortLabel-root').at(0);
 
           defaultProps.api.clinics.getPatientsForClinic.resetHistory();
           averageGlucoseHeader.simulate('click');
-          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ sort: '-averageGlucose', sortType: 'bgm' }));
+          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ sort: '-averageGlucoseMmol', sortType: 'bgm' }));
 
           defaultProps.api.clinics.getPatientsForClinic.resetHistory();
           averageGlucoseHeader.simulate('click');
-          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ sort: '+averageGlucose', sortType: 'bgm' }));
+          sinon.assert.calledWith(defaultProps.api.clinics.getPatientsForClinic, 'clinicID123', sinon.match({ sort: '+averageGlucoseMmol', sortType: 'bgm' }));
 
           const lowsHeader = table.find('#peopleTable-header-bgm-timeInVeryLowRecords .MuiTableSortLabel-root').at(0);
 
@@ -2030,7 +2023,7 @@ describe('ClinicPatients', () => {
             const columns = table.find('.MuiTableCell-head');
 
             expect(columns.at(8).text()).to.equal('Avg. Glucose (mmol/L)');
-            assert(columns.at(8).is('#peopleTable-header-bgm-averageGlucose'));
+            assert(columns.at(8).is('#peopleTable-header-bgm-averageGlucoseMmol'));
 
             const rows = table.find('tbody tr');
             expect(rows).to.have.lengthOf(5);
@@ -2534,7 +2527,7 @@ describe('ClinicPatients', () => {
                       lastUploadDate: sinon.match.string,
                     },
                     periods: { '14d': {
-                      averageGlucose: { units: MMOLL_UNITS, value: 10.5 },
+                      averageGlucoseMmol: 10.5,
                       averageDailyRecords: 0.25,
                       timeInVeryLowRecords: 1,
                       timeInVeryHighRecords: 2,
@@ -2546,7 +2539,6 @@ describe('ClinicPatients', () => {
                     },
                     periods: {
                       '14d': {
-                        averageGlucose: { units: 'mmol/L' },
                         glucoseManagementIndicator: 7.75,
                         timeCGMUseMinutes: 1380,
                         timeCGMUsePercent: 0.85,

--- a/test/unit/pages/TideDashboard.test.js
+++ b/test/unit/pages/TideDashboard.test.js
@@ -592,7 +592,7 @@ describe('TideDashboard', () => {
       expect(store.getActions()).to.eql([
         {
           type: '@@router/CALL_HISTORY_METHOD',
-          payload: { method: 'push', args: [`/patients/${expectedPatientId}/data?chart=trends`]}
+          payload: { method: 'push', args: [`/patients/${expectedPatientId}/data?chart=trends&dashboard=tide`]}
         },
       ]);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -18824,10 +18824,10 @@ tideline@1.26.0:
     react-sizeme "2.6.12"
     sundial "1.6.0"
 
-tidepool-platform-client@0.53.0-web-2346-tide-cta-modal.1:
-  version "0.53.0-web-2346-tide-cta-modal.1"
-  resolved "https://registry.yarnpkg.com/tidepool-platform-client/-/tidepool-platform-client-0.53.0-web-2346-tide-cta-modal.1.tgz#d845a27a2fd0966dd980754ade3b69742e706755"
-  integrity sha512-EqRD4DhQiPsU4cpFRnKEuZ3deSOADLvbDhcxLNKcUxi7bmTE7C+87z62rU5CQHMvoC+v164uiXNY+v6wDw5QsA==
+tidepool-platform-client@0.53.0-web-2500-tide-backend-integration.1:
+  version "0.53.0-web-2500-tide-backend-integration.1"
+  resolved "https://registry.yarnpkg.com/tidepool-platform-client/-/tidepool-platform-client-0.53.0-web-2500-tide-backend-integration.1.tgz#77d0d507447009e5872adb2a19590b881bc8e17c"
+  integrity sha512-2oINMobnTvzr5KkABT734Rd1d3mxeac+MAMvn3y6SgNe5FF5mrkLwXfRusGvkv5RZfkURnUutKA6ZOCt6jRXeA==
   dependencies:
     async "0.9.0"
     lodash "3.3.1"


### PR DESCRIPTION
[WEB-2500]

Related: https://github.com/tidepool-org/platform-client/pull/152

Includes:
 - Flattening the average glucose summary values to correspond to backend change
 - Updates to navbar 'back' link to return to either patients list, as it currently does, or to the tide dash if that's where the user navigated to the patient view from.

[WEB-2500]: https://tidepool.atlassian.net/browse/WEB-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ