### PR TITLE
[WEB-2504] Uploaded device discrepancy fix for basics when toggling from BGM data source to CGM

### DIFF
--- a/app/components/chart/basics.js
+++ b/app/components/chart/basics.js
@@ -228,7 +228,7 @@ class Basics extends Component {
 
     const prefs = _.cloneDeep(this.props.chartPrefs);
     prefs.basics.bgSource = bgSource;
-    this.props.updateChartPrefs(prefs, false, true);
+    this.props.updateChartPrefs(prefs, false, true, true);
   };
 
   handleClickBasics = e => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.69.0-rc.3",
+  "version": "1.69.0-rc.4",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
[WEB-2504]

Fixes and edge case where upon switching from BGM to CGM on the basics view, the matched devices list was not including the aggregated fingersticks, becuase they wasn't being queried upon bgSource change.  This is now queried to ensure that those will be included in the matched devices list.

It's a bit redundant to have to query the aggregations again, since they are not expected to change when only the bg source is updated, but it's the only way to ensure the matched devices metadata is correct on this view.

[WEB-2504]: https://tidepool.atlassian.net/browse/WEB-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ