### PR TITLE
[WEB-2541] Use config period for TIDE dash dates

### DIFF
--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -693,48 +693,53 @@ export const TideDashboard = (props) => {
     setTideDashboardFormContext({...formikContext});
   }
 
-  const renderHeader = () => (
-    <Flex
-      mb={3}
-      justifyContent="space-between"
-      alignItems="center"
-      flexWrap="wrap"
-      sx={{ rowGap: 2, columnGap: 3 }}
-    >
-      <Flex sx={{ gap: 3 }}>
-        <Title fontWeight="medium" fontSize="18px">{t('TIDE Dashboard')}</Title>
+  const renderHeader = () => {
+    const periodTo = getLocalizedCeiling(new Date().toISOString(), timePrefs).toISOString();
+    const periodFrom = moment(periodTo).subtract(config?.period.slice(0, -1), 'days').toISOString();
 
-        <Text
-          as={Flex}
-          fontSize={0}
-          fontWeight="medium"
-          height="24px"
-          bg="white"
-          color={loading ? 'white' : 'text.primary'}
-          alignContent="center"
-          flexWrap="wrap"
-          px={2}
-          sx={{ borderRadius: radii.medium }}
-        >
-          {formatDateRange(config?.lastUploadDateFrom, config?.lastUploadDateTo, null, 'MMMM')}
-        </Text>
-      </Flex>
-
-      <Button
-        id="update-dashboard-config"
-        variant="filter"
-        icon={KeyboardArrowDownRoundedIcon}
-        iconLabel="Open dashboard config"
-        onClick={handleConfigureTideDashboard}
-        fontSize={1}
-        lineHeight={5}
-        px={3}
-        sx= {{ border: 'none' }}
+    return (
+      <Flex
+        mb={3}
+        justifyContent="space-between"
+        alignItems="center"
+        flexWrap="wrap"
+        sx={{ rowGap: 2, columnGap: 3 }}
       >
-          {t('Filter Patients')}
-      </Button>
-    </Flex>
-  )
+        <Flex sx={{ gap: 3 }}>
+          <Title fontWeight="medium" fontSize="18px">{t('TIDE Dashboard')}</Title>
+
+          <Text
+            as={Flex}
+            fontSize={0}
+            fontWeight="medium"
+            height="24px"
+            bg="white"
+            color={loading ? 'white' : 'text.primary'}
+            alignContent="center"
+            flexWrap="wrap"
+            px={2}
+            sx={{ borderRadius: radii.medium }}
+          >
+            {formatDateRange(periodFrom, periodTo, null, 'MMMM')}
+          </Text>
+        </Flex>
+
+        <Button
+          id="update-dashboard-config"
+          variant="filter"
+          icon={KeyboardArrowDownRoundedIcon}
+          iconLabel="Open dashboard config"
+          onClick={handleConfigureTideDashboard}
+          fontSize={1}
+          lineHeight={5}
+          px={3}
+          sx= {{ border: 'none' }}
+        >
+            {t('Filter Patients')}
+        </Button>
+      </Flex>
+    )
+  };
 
   const renderTideDashboardConfigDialog = useCallback(() => {
     return (

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -706,9 +706,10 @@ export const TideDashboard = (props) => {
         sx={{ rowGap: 2, columnGap: 3 }}
       >
         <Flex sx={{ gap: 3 }}>
-          <Title fontWeight="medium" fontSize="18px">{t('TIDE Dashboard')}</Title>
+          <Title id="tide-dashboard-header" fontWeight="medium" fontSize="18px">{t('TIDE Dashboard')}</Title>
 
           <Text
+            id="tide-dashboard-dates"
             as={Flex}
             fontSize={0}
             fontWeight="medium"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.70.0-web-2379-tide-mvp.1",
+  "version": "1.70.0-web-2379-tide-mvp.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
[WEB-2541] Currently, was incorrectly using the last upload dates for the dashboard dates.  Changed to use the config period.

[WEB-2541]: https://tidepool.atlassian.net/browse/WEB-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ