### PR TITLE
[WEB-2543,WEB-2542] Clear patient in view state when mounting dashboard

### DIFF
--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -532,6 +532,7 @@ export const TideDashboard = (props) => {
   const { set: setToast } = useToasts();
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const loggedInUserId = useSelector((state) => state.blip.loggedInUserId);
+  const currentPatientInViewId = useSelector((state) => state.blip.currentPatientInViewId);
   const clinic = useSelector(state => state.blip.clinics?.[selectedClinicId]);
   const { config, results: patientGroups } = useSelector((state) => state.blip.tideDashboardPatients);
   const timePrefs = useSelector((state) => state.blip.timePrefs);
@@ -628,6 +629,8 @@ export const TideDashboard = (props) => {
   }, [api, dispatch, localConfig, localConfigKey, selectedClinicId]);
 
   useEffect(() => {
+    dispatch(actions.worker.dataWorkerRemoveDataRequest(null, currentPatientInViewId));
+    dispatch(actions.sync.clearPatientInView());
     setClinicBgUnits((clinic?.preferredBgUnits || MGDL_UNITS));
   }, [clinic]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.70.0-web-2379-tide-mvp.2",
+  "version": "1.70.0-web-2379-tide-mvp.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/test/unit/pages/TideDashboard.test.js
+++ b/test/unit/pages/TideDashboard.test.js
@@ -285,7 +285,7 @@ describe('TideDashboard', () => {
         </Provider>
       );
 
-      expect(store.getActions()[0]).to.eql({
+      expect(store.getActions()[2]).to.eql({
         payload: { args: ['/clinic-workspace'], method: 'push' },
         type: '@@router/CALL_HISTORY_METHOD',
       });
@@ -303,9 +303,44 @@ describe('TideDashboard', () => {
         </Provider>
       );
 
-      expect(store.getActions()[0]).to.eql({
+      expect(store.getActions()[2]).to.eql({
         payload: { args: ['/clinic-workspace'], method: 'push' },
         type: '@@router/CALL_HISTORY_METHOD',
+      });
+    });
+
+    it('should clear the current patient in view', () => {
+      store = mockStore({
+        blip: {
+          ...tier0200ClinicState.blip,
+          currentPatientInViewId: 'patientInViewID',
+        },
+      });
+      store.clearActions();
+
+      wrapper = mount(
+        <Provider store={store}>
+          <ToastProvider>
+            <TideDashboard {...defaultProps} />
+          </ToastProvider>
+        </Provider>
+      );
+
+      expect(store.getActions()[0]).to.eql({
+        meta: {
+          WebWorker: true,
+          origin: 'http://localhost:9876',
+          patientId: 'patientInViewID',
+          worker: 'data',
+        },
+        payload: {
+          predicate: undefined,
+        },
+        type: 'DATA_WORKER_REMOVE_DATA_REQUEST',
+      });
+
+      expect(store.getActions()[1]).to.eql({
+        type: 'CLEAR_PATIENT_IN_VIEW',
       });
     });
 
@@ -322,8 +357,6 @@ describe('TideDashboard', () => {
           </ToastProvider>
         </Provider>
       );
-
-      expect(store.getActions()).to.eql([]);
 
       const dialog = () => wrapper.find('Dialog#tideDashboardConfig');
       expect(dialog()).to.have.length(1);
@@ -351,8 +384,6 @@ describe('TideDashboard', () => {
           </ToastProvider>
         </Provider>
       );
-
-      expect(store.getActions()).to.eql([]);
 
       const dialog = () => wrapper.find('Dialog#tideDashboardConfig');
       expect(dialog()).to.have.length(1);
@@ -383,11 +414,8 @@ describe('TideDashboard', () => {
         </Provider>
       );
 
-      const expectedActions = [
-        { type: 'FETCH_TIDE_DASHBOARD_PATIENTS_REQUEST' },
-      ];
-
-      expect(store.getActions()).to.eql(expectedActions);
+      const expectedAction = { type: 'FETCH_TIDE_DASHBOARD_PATIENTS_REQUEST' };
+      expect(store.getActions()[2]).to.eql(expectedAction);
     });
   });
 


### PR DESCRIPTION
[WEB-2543], [WEB-2542]

Similar to what we do for the clinic and clinician patients lists, we need to clear the currently viewed patient here as well.

While it would be simpler to do it on unmount of the patient data view component, we currently don't because we intentionally retain the currently loaded patient so while the user navigates between the data views and profile/share pages.

[WEB-2543]: https://tidepool.atlassian.net/browse/WEB-2543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-2542]: https://tidepool.atlassian.net/browse/WEB-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ