### PR TITLE
[WEB-2551] Percentage rounding tweaks around thresholds

### DIFF
--- a/app/components/clinic/BgRangeSummary.js
+++ b/app/components/clinic/BgRangeSummary.js
@@ -15,6 +15,7 @@ import Popover from '../elements/Popover';
 import { space, shadows, radii } from '../../themes/baseTheme';
 
 import utils from '../../core/utils';
+import { DEFAULT_FILTER_THRESHOLDS } from '../../core/constants';
 import { utils as vizUtils } from '@tidepool/viz';
 const { reshapeBgClassesToBgBounds, generateBgRangeLabels } = vizUtils.bg;
 
@@ -94,7 +95,7 @@ export const BgRangeSummary = React.memo(props => {
               <Flex key={key} flexDirection="column" justifyContent="center" alignItems="center">
                 <Flex className={`range-summary-value-${key}`} mb={1} textAlign="center" alignItems="flex-end" key={key} color={`bg.${key}`} flexWrap="nowrap">
                   <Text fontWeight="bold" lineHeight={0} fontSize={1}>
-                    {utils.customRoundedPercentage(value, key)}
+                    {utils.thresholdRound(value, ...DEFAULT_FILTER_THRESHOLDS[key])}
                   </Text>
                   <Text color="inherit" fontSize="9px" fontWeight="bold">%</Text>
                 </Flex>
@@ -107,7 +108,7 @@ export const BgRangeSummary = React.memo(props => {
             <Text className={'range-summary-bg-units'} lineHeight={0} color="grays.4" fontSize="10px">{t('Units in {{bgUnits}}', { bgUnits: formattedBgUnits })}</Text>
             <Flex className={'range-summary-cgm-use'} alignItems="flex-end" justifyContent="flex-start" flexWrap="nowrap" sx={{ gap: 1}}>
               <Text lineHeight={0} color="text.primary" fontSize="10px" fontWeight="medium">{t('% CGM Use: ')}</Text>
-              <Text lineHeight="10px" color="text.primary" fontSize="12px" fontWeight="bold">{t('{{cgmUsePercent}} %', utils.customRoundedPercentage(cgmUsePercent, 'cgmUse'))}</Text>
+              <Text lineHeight="10px" color="text.primary" fontSize="12px" fontWeight="bold">{t('{{cgmUsePercent}} %', utils.thresholdRound(cgmUsePercent, ...DEFAULT_FILTER_THRESHOLDS.cgmUse))}</Text>
             </Flex>
           </Flex>
         </Box>

--- a/app/components/clinic/BgRangeSummary.js
+++ b/app/components/clinic/BgRangeSummary.js
@@ -95,7 +95,7 @@ export const BgRangeSummary = React.memo(props => {
               <Flex key={key} flexDirection="column" justifyContent="center" alignItems="center">
                 <Flex className={`range-summary-value-${key}`} mb={1} textAlign="center" alignItems="flex-end" key={key} color={`bg.${key}`} flexWrap="nowrap">
                   <Text fontWeight="bold" lineHeight={0} fontSize={1}>
-                    {utils.thresholdRound(value, ...DEFAULT_FILTER_THRESHOLDS[key])}
+                    {utils.formatThresholdPercentage(value, ...DEFAULT_FILTER_THRESHOLDS[key])}
                   </Text>
                   <Text color="inherit" fontSize="9px" fontWeight="bold">%</Text>
                 </Flex>
@@ -108,7 +108,7 @@ export const BgRangeSummary = React.memo(props => {
             <Text className={'range-summary-bg-units'} lineHeight={0} color="grays.4" fontSize="10px">{t('Units in {{bgUnits}}', { bgUnits: formattedBgUnits })}</Text>
             <Flex className={'range-summary-cgm-use'} alignItems="flex-end" justifyContent="flex-start" flexWrap="nowrap" sx={{ gap: 1}}>
               <Text lineHeight={0} color="text.primary" fontSize="10px" fontWeight="medium">{t('% CGM Use: ')}</Text>
-              <Text lineHeight="10px" color="text.primary" fontSize="12px" fontWeight="bold">{t('{{cgmUsePercent}} %', utils.thresholdRound(cgmUsePercent, ...DEFAULT_FILTER_THRESHOLDS.cgmUse))}</Text>
+              <Text lineHeight="10px" color="text.primary" fontSize="12px" fontWeight="bold">{t('{{cgmUsePercent}} %', { cgmUsePercent: utils.formatThresholdPercentage(cgmUsePercent, ...DEFAULT_FILTER_THRESHOLDS.cgmUse) })}</Text>
             </Flex>
           </Flex>
         </Box>

--- a/app/components/clinic/BgRangeSummary.js
+++ b/app/components/clinic/BgRangeSummary.js
@@ -107,7 +107,7 @@ export const BgRangeSummary = React.memo(props => {
             <Text className={'range-summary-bg-units'} lineHeight={0} color="grays.4" fontSize="10px">{t('Units in {{bgUnits}}', { bgUnits: formattedBgUnits })}</Text>
             <Flex className={'range-summary-cgm-use'} alignItems="flex-end" justifyContent="flex-start" flexWrap="nowrap" sx={{ gap: 1}}>
               <Text lineHeight={0} color="text.primary" fontSize="10px" fontWeight="medium">{t('% CGM Use: ')}</Text>
-              <Text lineHeight="10px" color="text.primary" fontSize="12px" fontWeight="bold">{t('{{cgmUsePercent}} %', { cgmUsePercent })}</Text>
+              <Text lineHeight="10px" color="text.primary" fontSize="12px" fontWeight="bold">{t('{{cgmUsePercent}} %', utils.customRoundedPercentage(cgmUsePercent, 'cgmUse'))}</Text>
             </Flex>
           </Flex>
         </Box>

--- a/app/components/clinic/BgSummaryCell.js
+++ b/app/components/clinic/BgSummaryCell.js
@@ -56,7 +56,7 @@ export const BgSummaryCell = ({ summary, config, clinicBgUnits, activeSummaryPer
         <BgRangeSummary
           striped={cgmUsePercent < minCgmPercent}
           data={data}
-          cgmUsePercent={utils.formatDecimal(cgmUsePercent * 100)}
+          cgmUsePercent={cgmUsePercent}
           targetRange={targetRange}
           bgUnits={clinicBgUnits}
         />

--- a/app/components/elements/DeltaBar.js
+++ b/app/components/elements/DeltaBar.js
@@ -9,7 +9,7 @@ import utils from '../../core/utils';
 import { colors, radii } from '../../themes/baseTheme';
 
 export const DeltaBar = React.memo(props => {
-  const { delta, max, threshold = [], ...themeProps } = props;
+  const { delta, max, threshold, ...themeProps } = props;
   const values = [delta, 0].sort();
   const labelMaxPercentage = 100;
 
@@ -73,7 +73,11 @@ export const DeltaBar = React.memo(props => {
 DeltaBar.propTypes = {
   delta: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
-  threshold: PropTypes.number.isRequired,
+  threshold: PropTypes.array.isRequired,
+};
+
+DeltaBar.defaultProps = {
+  threshold: [],
 };
 
 export default translate()(DeltaBar);

--- a/app/components/elements/DeltaBar.js
+++ b/app/components/elements/DeltaBar.js
@@ -14,7 +14,7 @@ export const DeltaBar = React.memo(props => {
   const labelMaxPercentage = 100;
 
   const labels = map(values, value => (Math.abs(value) <= labelMaxPercentage
-    ? utils.thresholdRound(Math.abs(value / 100), ...threshold)
+    ? utils.formatThresholdPercentage(Math.abs(value / 100), ...threshold)
     : labelMaxPercentage
   ));
 

--- a/app/components/elements/DeltaBar.js
+++ b/app/components/elements/DeltaBar.js
@@ -9,12 +9,12 @@ import utils from '../../core/utils';
 import { colors, radii } from '../../themes/baseTheme';
 
 export const DeltaBar = React.memo(props => {
-  const { delta, max, precision, ...themeProps } = props;
+  const { delta, max, threshold = [], ...themeProps } = props;
   const values = [delta, 0].sort();
   const labelMaxPercentage = 100;
 
   const labels = map(values, value => (Math.abs(value) <= labelMaxPercentage
-    ? utils.formatDecimal(Math.abs(value), precision)
+    ? utils.thresholdRound(Math.abs(value / 100), ...threshold)
     : labelMaxPercentage
   ));
 
@@ -73,11 +73,7 @@ export const DeltaBar = React.memo(props => {
 DeltaBar.propTypes = {
   delta: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
-  precision: PropTypes.number.isRequired,
-};
-
-DeltaBar.defaultProps = {
-  precision: 1,
+  threshold: PropTypes.number.isRequired,
 };
 
 export default translate()(DeltaBar);

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -87,3 +87,14 @@ export const MS_IN_HOUR = 864e5 / 24;
 export const MS_IN_MIN = MS_IN_HOUR / 60;
 
 export const LBS_PER_KG = 2.2046226218;
+
+// [comparator, filter threshold %, default rounding precision = 0]
+export const DEFAULT_FILTER_THRESHOLDS = {
+  veryLow: ['>', 1],
+  low: ['>', 4],
+  target: ['<', 70],
+  high: ['>', 25],
+  veryHigh: ['>', 5],
+  cgmUse: ['<', 70],
+  timeInTargetPercentDelta: ['>', 15, 1],
+};

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -88,7 +88,8 @@ export const MS_IN_MIN = MS_IN_HOUR / 60;
 
 export const LBS_PER_KG = 2.2046226218;
 
-// [comparator, filter threshold %, default rounding precision = 0]
+// Passed as arguments to utils.formatThresholdPercentage
+// [comparator, threshold, defaultPrecision = 0]
 export const DEFAULT_FILTER_THRESHOLDS = {
   veryLow: ['>', 1],
   low: ['>', 4],

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -442,6 +442,11 @@ utils.formatDecimal = (val, precision) => {
   return format(`.${precision}f`)(val);
 };
 
+utils.roundToPrecision = (value, precision = 0) => {
+  let shift = precision > 0 ? 10 ** precision : 1;
+  return Math.round(value * shift) / shift;
+};
+
 utils.roundUp = (value, precision = 1) => {
   let shift = 10 ** precision;
   return Math.ceil(value * shift) / shift;
@@ -452,10 +457,10 @@ utils.roundDown = (value, precision = 1) => {
   return Math.floor(value * shift) / shift;
 };
 
-utils.thresholdRound = (value, comparator, threshold, defaultPrecision = 0) => {
+utils.formatThresholdPercentage = (value, comparator, threshold, defaultPrecision = 0) => {
   let precision = defaultPrecision;
   let percentage = value * 100;
-  let roundingRange;
+  let customRoundingRange;
 
   switch (comparator) {
     case '<':
@@ -463,9 +468,9 @@ utils.thresholdRound = (value, comparator, threshold, defaultPrecision = 0) => {
       // not fine to round up to the threshold
       // fine to round down to the threshold
       // lower than threshold should round down
-      roundingRange = [threshold - 0.5, threshold];
+      customRoundingRange = [threshold - 0.5, threshold];
 
-      if (percentage >= roundingRange[0] && percentage < roundingRange[1]) {
+      if (percentage >= customRoundingRange[0] && percentage < customRoundingRange[1]) {
         precision = 1;
 
         // If natural rounding would round to threshold, force rounding down
@@ -480,9 +485,9 @@ utils.thresholdRound = (value, comparator, threshold, defaultPrecision = 0) => {
       // fine to round up to the threshold
       // not fine to round down to the threshold
       // greater than threshold should round up
-      roundingRange = [threshold, threshold + 0.5];
+      customRoundingRange = [threshold, threshold + 0.5];
 
-      if (percentage > roundingRange[0] && percentage < roundingRange[1]) {
+      if (percentage > customRoundingRange[0] && percentage < customRoundingRange[1]) {
         precision = 1;
 
         // If natural rounding would round to threshold, force rounding up
@@ -500,11 +505,14 @@ utils.thresholdRound = (value, comparator, threshold, defaultPrecision = 0) => {
 
     if (percentage < 0.05) {
       precision = 2;
-      percentage = utils.roundUp(percentage, precision);
+
+      if (percentage < 0.005) {
+        percentage = utils.roundUp(percentage, precision);
+      }
     }
   }
 
-  return format(`.${precision}f`)(percentage);
+  return format(`.${precision}f`)(utils.roundToPrecision(percentage, precision));
 }
 
 export default utils;

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -457,28 +457,21 @@ utils.thresholdRound = (value, comparator, threshold, defaultPrecision = 0) => {
   let percentage = value * 100;
   let roundingRange;
 
-  // For these comments, assume the threshold is 4. Could be any number
-
   switch (comparator) {
     case '<':
     case '>=':
       // not fine to round up to the threshold
       // fine to round down to the threshold
       // lower than threshold should round down
-
-      // 3.499 => 3
-      // 3.5   => 3.5
-      // 3.501 => 3.5
-      // 3.999 => 3.9
-      // 4.001 => 4
-      // 4.499 => 4
-      // 4.5   => 5
-
       roundingRange = [threshold - 0.5, threshold];
 
       if (percentage >= roundingRange[0] && percentage < roundingRange[1]) {
         precision = 1;
-        percentage = utils.roundDown(percentage, precision);
+
+        // If natural rounding would round to threshold, force rounding down
+        if (percentage >= threshold - 0.05) {
+          percentage = utils.roundDown(percentage, precision);
+        }
       }
       break;
 
@@ -487,20 +480,15 @@ utils.thresholdRound = (value, comparator, threshold, defaultPrecision = 0) => {
       // fine to round up to the threshold
       // not fine to round down to the threshold
       // greater than threshold should round up
-
-      // 3.499 => 3
-      // 3.5   => 4
-      // 3.501 => 4
-      // 3.999 => 4
-      // 4.001 => 4.1
-      // 4.499 => 4.5
-      // 4.5   => 5
-
       roundingRange = [threshold, threshold + 0.5];
 
       if (percentage > roundingRange[0] && percentage < roundingRange[1]) {
         precision = 1;
-        percentage = utils.roundUp(percentage, precision);
+
+        // If natural rounding would round to threshold, force rounding up
+        if (percentage < threshold + 0.05) {
+          percentage = utils.roundUp(percentage, precision);
+        }
       }
       break;
   }

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -480,6 +480,7 @@ utils.customRoundedPercentage = (inputValue, key) => {
       }
       break;
     case 'target':
+    case 'cgmUse':
       if (percentage > 69 && percentage < 70) {
         precision = 1;
         percentage = utils.roundDown(percentage, precision);

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -443,17 +443,17 @@ utils.formatDecimal = (val, precision) => {
 };
 
 utils.roundToPrecision = (value, precision = 0) => {
-  let shift = precision > 0 ? 10 ** precision : 1;
+  const shift = precision > 0 ? 10 ** precision : 1;
   return Math.round(value * shift) / shift;
 };
 
-utils.roundUp = (value, precision = 1) => {
-  let shift = 10 ** precision;
+utils.roundUp = (value, precision = 0) => {
+  const shift = precision > 0 ? 10 ** precision : 1;
   return Math.ceil(value * shift) / shift;
 };
 
-utils.roundDown = (value, precision = 1) => {
-  let shift = 10 ** precision;
+utils.roundDown = (value, precision = 0) => {
+  const shift = precision > 0 ? 10 ** precision : 1;
   return Math.floor(value * shift) / shift;
 };
 

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -300,7 +300,7 @@ const TideDashboardSection = React.memo(props => {
     const rawValue = (summary?.[summaryKey]);
 
     let formattedValue = isFinite(rawValue)
-      ? utils.thresholdRound(rawValue, ...DEFAULT_FILTER_THRESHOLDS[formattingKeyMap[summaryKey]])
+      ? utils.formatThresholdPercentage(rawValue, ...DEFAULT_FILTER_THRESHOLDS[formattingKeyMap[summaryKey]])
       : statEmptyText;
 
     return (

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -66,7 +66,7 @@ import {
   tideDashboardConfigSchema,
 } from '../../core/clinicUtils';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../core/constants';
+import { DEFAULT_FILTER_THRESHOLDS, MGDL_UNITS, MMOLL_UNITS } from '../../core/constants';
 import { colors, radii } from '../../themes/baseTheme';
 
 const { Loader } = vizComponents;
@@ -300,7 +300,7 @@ const TideDashboardSection = React.memo(props => {
     const rawValue = (summary?.[summaryKey]);
 
     let formattedValue = isFinite(rawValue)
-      ? utils.customRoundedPercentage(rawValue, formattingKeyMap[summaryKey])
+      ? utils.thresholdRound(rawValue, ...DEFAULT_FILTER_THRESHOLDS[formattingKeyMap[summaryKey]])
       : statEmptyText;
 
     return (
@@ -337,7 +337,12 @@ const TideDashboardSection = React.memo(props => {
     const timeInTargetPercentDelta = (summary?.timeInTargetPercentDelta);
 
     return timeInTargetPercentDelta ? (
-      <DeltaBar fontWeight="medium" delta={timeInTargetPercentDelta * 100} max={30} />
+      <DeltaBar
+        fontWeight="medium"
+        delta={timeInTargetPercentDelta * 100}
+        max={30}
+        threshold={DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta}
+      />
     ) : (
       <Text as="span" fontWeight="medium">{statEmptyText}</Text>
     );

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -291,7 +291,7 @@ const TideDashboardSection = React.memo(props => {
 
   const renderTimeInPercent = useCallback((summaryKey, summary) => {
     const formattingKeyMap = {
-      timeCGMUsePercent: 'target',
+      timeCGMUsePercent: 'cgmUse',
       timeInVeryLowPercent: 'veryLow',
       timeInLowPercent: 'low',
       timeInTargetPercent: 'target',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const optional = require('optional');
 
 const webpackConf = require('./webpack.config.js');
-const mochaConf = optional('./config/mocha.opts.json') || { timeout: 4000 };
+const mochaConf = optional('./config/mocha.opts.json') || { timeout: 8000 };
 
 const watch = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
 const testWebpackConf = _.assign({}, webpackConf, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.70.0-web-2379-tide-mvp.6",
+  "version": "1.70.0-web-2379-tide-mvp.7",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",

--- a/test/unit/components/clinic/BgRangeSummary.test.js
+++ b/test/unit/components/clinic/BgRangeSummary.test.js
@@ -30,7 +30,7 @@ describe('BgRangeSummary', () => {
       veryHigh: .15,
     },
     striped: false,
-    cgmUsePercent: 78,
+    cgmUsePercent: 0.78,
     targetRange: [60, 190],
   };
 

--- a/test/unit/pages/TideDashboard.test.js
+++ b/test/unit/pages/TideDashboard.test.js
@@ -13,7 +13,6 @@ import TideDashboardConfigForm from '../../../app/components/clinic/TideDashboar
 import mockTideDashboardPatients from '../../fixtures/mockTideDashboardPatients.json';
 import LDClientMock from '../../fixtures/LDClientMock';
 import { utils as vizUtils } from '@tidepool/viz';
-const { getLocalizedCeiling } = vizUtils.datetime;
 
 /* global chai */
 /* global sinon */
@@ -611,11 +610,11 @@ describe('TideDashboard', () => {
 
       // Confirm sixth table is sorted appropriately
       expect(getTableRow(5, 0).find('th').at(4).text()).contains('Time below 54');
-      expect(getTableRow(5, 1).find('td').at(3).text()).contains('0.6 %');
-      expect(getTableRow(5, 2).find('td').at(3).text()).contains('0.6 %');
-      expect(getTableRow(5, 3).find('td').at(3).text()).contains('0.26 %');
-      expect(getTableRow(5, 4).find('td').at(3).text()).contains('0.24 %');
-      expect(getTableRow(5, 5).find('td').at(3).text()).contains('0.09 %');
+      expect(getTableRow(5, 1).find('td').at(3).text()).contains('1 %');
+      expect(getTableRow(5, 2).find('td').at(3).text()).contains('1 %');
+      expect(getTableRow(5, 3).find('td').at(3).text()).contains('0.3 %');
+      expect(getTableRow(5, 4).find('td').at(3).text()).contains('0.2 %');
+      expect(getTableRow(5, 5).find('td').at(3).text()).contains('0.1 %');
     });
 
     it('should show empty text for a section without results', () => {

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -568,6 +568,14 @@ describe('utils', () => {
     });
   });
 
+  describe('roundToPrecision', function() {
+    it('should round a float naturally to the provided precision, or 1 decimal place if no precision provided', function() {
+      expect(utils.roundToPrecision(1.23456, 2)).to.equal(1.23);
+      expect(utils.roundToPrecision(1.23456, 3)).to.equal(1.235);
+      expect(utils.roundToPrecision(1.23456)).to.equal(1);
+    });
+  });
+
   describe('roundUp', function() {
     it('should round a float up to the provided precision, or 1 decimal place if no precision provided', function() {
       expect(utils.roundUp(1.23456, 2)).to.equal(1.24);
@@ -584,7 +592,7 @@ describe('utils', () => {
     });
   });
 
-  describe.only('formatThresholdPercentage', () => {
+  describe('formatThresholdPercentage', () => {
     it('should round for `veryLow` between 1 and 1.5 percent with 0.1 precision', () => {
       assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.veryLow, ['>', 1]);
 

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -4,6 +4,8 @@
 /* global context */
 /* global sinon */
 /* global afterEach */
+/* global assert */
+
 
 import _ from 'lodash';
 import utils from '../../../app/core/utils';
@@ -582,55 +584,153 @@ describe('utils', () => {
     });
   });
 
-  describe.only('thresholdRound', () => {
-    it('should round up for `veryLow` between 0 and 0.5 percent with 0.01 precision', () => {
-      expect(utils.thresholdRound(0.00001, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.01');
-      expect(utils.thresholdRound(0.00052, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.06');
-      expect(utils.thresholdRound(0.00242, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.25');
-      expect(utils.thresholdRound(0.00436, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.44');
+  describe.only('formatThresholdPercentage', () => {
+    it('should round for `veryLow` between 1 and 1.5 percent with 0.1 precision', () => {
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.veryLow, ['>', 1]);
+
+      // Should round up to threshold
+      expect(utils.formatThresholdPercentage(0.0099, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1');
+
+      // Should not round down to threshold
+      expect(utils.formatThresholdPercentage(0.0101, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1.1');
+
+      // Values inside custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.0111, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1.1');
+      expect(utils.formatThresholdPercentage(0.0149, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1.5');
+
+      // Values above custom rounding range rounding naturally to integer
+      expect(utils.formatThresholdPercentage(0.005, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1');
+      expect(utils.formatThresholdPercentage(0.0151, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('2');
+
+      // Values above below 0.5 percent rounding with extra precision
+      expect(utils.formatThresholdPercentage(0.000001, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00049, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.05');
+      expect(utils.formatThresholdPercentage(0.0049, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.5');
     });
-    it('should round down for `veryLow` from 0.5 up to 1 percent with 0.1 precision', () => {
-      expect(utils.thresholdRound(0.005, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.5');
-      expect(utils.thresholdRound(0.0068, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.6');
-      expect(utils.thresholdRound(0.0082, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.8');
-      expect(utils.thresholdRound(0.0132, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1');
-      expect(utils.thresholdRound(0.015, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('2');
+
+    it('should round for `low` between 4 and 4.5 percent with 0.1 precision', () => {
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.low, ['>', 4]);
+
+      // Should round up to threshold
+      expect(utils.formatThresholdPercentage(0.0399, ...DEFAULT_FILTER_THRESHOLDS.low)).to.equal('4');
+
+      // Should not round down to threshold
+      expect(utils.formatThresholdPercentage(0.0401, ...DEFAULT_FILTER_THRESHOLDS.low)).to.equal('4.1');
+
+      // Values inside custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.0411, ...DEFAULT_FILTER_THRESHOLDS.low)).to.equal('4.1');
+      expect(utils.formatThresholdPercentage(0.0449, ...DEFAULT_FILTER_THRESHOLDS.low)).to.equal('4.5');
+
+      // Values outside custom rounding range rounding naturally to integer
+      expect(utils.formatThresholdPercentage(0.0349, ...DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3');
+      expect(utils.formatThresholdPercentage(0.045, ...DEFAULT_FILTER_THRESHOLDS.low)).to.equal('5');
     });
-    it('should round down for `low` between 3 and 4 percent with 0.1 precision', () => {
-      expect(utils.thresholdRound(0.0327, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3.2');
-      expect(utils.thresholdRound(0.0384, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3.8');
-      expect(utils.thresholdRound(0.025, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3');
-      expect(utils.thresholdRound(0.0462, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('5');
+
+    it('should round for `target` between 69.5 and 70 percent with 0.1 precision', () => {
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.target, ['<', 70]);
+
+      // Should not round up to threshold
+      expect(utils.formatThresholdPercentage(0.6999, ...DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.9');
+
+      // Should round down to threshold
+      expect(utils.formatThresholdPercentage(0.7001, ...DEFAULT_FILTER_THRESHOLDS.target)).to.equal('70');
+
+      // Values inside custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.6951, ...DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.5');
+      expect(utils.formatThresholdPercentage(0.6989, ...DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.9');
+
+      // Values outside custom rounding range rounding naturally to integer
+      expect(utils.formatThresholdPercentage(0.6949, ...DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69');
+      expect(utils.formatThresholdPercentage(0.705, ...DEFAULT_FILTER_THRESHOLDS.target)).to.equal('71');
     });
-    it('should round down for `target` between 69 and 70 percent with 0.1 precision', () => {
-      expect(utils.thresholdRound(0.6999, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.9');
-      expect(utils.thresholdRound(0.6942, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.4');
-      expect(utils.thresholdRound(0.685, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69');
-      expect(utils.thresholdRound(0.705, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('71');
+
+    it('should round for `high` between 25 and 25.5 percent with 0.1 precision', () => {
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.high, ['>', 25]);
+
+      // Should round up to threshold
+      expect(utils.formatThresholdPercentage(0.2499, ...DEFAULT_FILTER_THRESHOLDS.high)).to.equal('25');
+
+      // Should not round down to threshold
+      expect(utils.formatThresholdPercentage(0.2501, ...DEFAULT_FILTER_THRESHOLDS.high)).to.equal('25.1');
+
+      // Values inside custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.2511, ...DEFAULT_FILTER_THRESHOLDS.high)).to.equal('25.1');
+      expect(utils.formatThresholdPercentage(0.2549, ...DEFAULT_FILTER_THRESHOLDS.high)).to.equal('25.5');
+
+      // Values outside custom rounding range rounding naturally to integer
+      expect(utils.formatThresholdPercentage(0.2449, ...DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24');
+      expect(utils.formatThresholdPercentage(0.255, ...DEFAULT_FILTER_THRESHOLDS.high)).to.equal('26');
     });
-    it('should round down for `high` between 24 and 25 percent with 0.1 precision', () => {
-      expect(utils.thresholdRound(0.2499, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24.9');
-      expect(utils.thresholdRound(0.2442, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24.4');
-      expect(utils.thresholdRound(0.235, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24');
-      expect(utils.thresholdRound(0.255, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('26');
+
+    it('should round for `veryHigh` between 5 and 5.5 percent with 0.1 precision', () => {
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.veryHigh, ['>', 5]);
+
+      // Should round up to threshold
+      expect(utils.formatThresholdPercentage(0.0499, ...DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('5');
+
+      // Should not round down to threshold
+      expect(utils.formatThresholdPercentage(0.0501, ...DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('5.1');
+
+      // Other values in custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.0511, ...DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('5.1');
+      expect(utils.formatThresholdPercentage(0.0549, ...DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('5.5');
+
+      // Values outside custom rounding range rounding naturally to integer
+      expect(utils.formatThresholdPercentage(0.0449, ...DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4');
+      expect(utils.formatThresholdPercentage(0.055, ...DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('6');
     });
-    it('should round down for `veryHigh` between 4 and 5 percent with 0.1 precision', () => {
-      expect(utils.thresholdRound(0.0499, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4.9');
-      expect(utils.thresholdRound(0.0442, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4.4');
-      expect(utils.thresholdRound(0.035, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4');
-      expect(utils.thresholdRound(0.055, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('6');
+
+    it('should round for `cgmUse` between 69.5 and 70 percent with 0.1 precision', () => {
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.cgmUse, ['<', 70]);
+
+      // Should not round up to threshold
+      expect(utils.formatThresholdPercentage(0.6999, ...DEFAULT_FILTER_THRESHOLDS.cgmUse)).to.equal('69.9');
+
+      // Should round down to threshold
+      expect(utils.formatThresholdPercentage(0.7001, ...DEFAULT_FILTER_THRESHOLDS.cgmUse)).to.equal('70');
+
+      // Values inside custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.6951, ...DEFAULT_FILTER_THRESHOLDS.cgmUse)).to.equal('69.5');
+      expect(utils.formatThresholdPercentage(0.6989, ...DEFAULT_FILTER_THRESHOLDS.cgmUse)).to.equal('69.9');
+
+      // Values outside custom rounding range rounding naturally to integer
+      expect(utils.formatThresholdPercentage(0.6949, ...DEFAULT_FILTER_THRESHOLDS.cgmUse)).to.equal('69');
+      expect(utils.formatThresholdPercentage(0.705, ...DEFAULT_FILTER_THRESHOLDS.cgmUse)).to.equal('71');
     });
-    it('should use normal rounding with 1.0 precision for other values over 0.5 percent', () => {
-      expect(utils.thresholdRound(0.26459, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('26');
-      expect(utils.thresholdRound(0.00589, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('1');
+
+    it('should round for `timeInTargetPercentDelta` between with 0.1 precision for all values', () => {
+      // the `1` sets the default precision outside of the custom rounding range to use 0.1 precision instead of nearest integer
+      assert.deepEqual(DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta, ['>', 15, 1]);
+
+      // Should round up to threshold
+      expect(utils.formatThresholdPercentage(0.1499, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('15.0');
+
+      // Should not round down to threshold
+      expect(utils.formatThresholdPercentage(0.1501, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('15.1');
+
+      // Values inside custom rounding range rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.1511, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('15.1');
+      expect(utils.formatThresholdPercentage(0.1549, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('15.5');
+
+      // Values outside custom rounding range also rounding naturally to 0.1 precision
+      expect(utils.formatThresholdPercentage(0.1449, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('14.5');
+      expect(utils.formatThresholdPercentage(0.155, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('15.5');
     });
-    it('should use normal rounding with 0.1 precision for other values under 0.5 and over 0.05', () => {
-      expect(utils.thresholdRound(0.0043, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('0.4');
-      expect(utils.thresholdRound(0.0035, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('0.4');
+
+    it('should round values between 0 and 0.05 percent with 0.01 precision', () => {
+      expect(utils.formatThresholdPercentage(0.0000)).to.equal('0');
+      expect(utils.formatThresholdPercentage(0.00001)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00041)).to.equal('0.04');
+      expect(utils.formatThresholdPercentage(0.00049)).to.equal('0.05');
+      expect(utils.formatThresholdPercentage(0.0005)).to.equal('0.1');
     });
-    it('should use round up with 0.01 precision for values under 0.05', () => {
-      expect(utils.thresholdRound(0.00043, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('0.05');
-      expect(utils.thresholdRound(0.00025, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('0.03');
+
+    it('should round numbers less than 0.005 percent up to 0.01% rather than down to zero', () => {
+      expect(utils.formatThresholdPercentage(0.00001)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00004)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00005)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00014)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00015)).to.equal('0.02');
     });
   });
 });

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -7,7 +7,7 @@
 
 import _ from 'lodash';
 import utils from '../../../app/core/utils';
-import { MMOLL_UNITS, MGDL_UNITS } from '../../../app/core/constants';
+import { DEFAULT_FILTER_THRESHOLDS, MMOLL_UNITS, MGDL_UNITS } from '../../../app/core/constants';
 import releases from '../../fixtures/githubreleasefixture';
 const expect = chai.expect;
 
@@ -582,55 +582,55 @@ describe('utils', () => {
     });
   });
 
-  describe('customRoundedPercentage', () => {
+  describe.only('thresholdRound', () => {
     it('should round up for `veryLow` between 0 and 0.5 percent with 0.01 precision', () => {
-      expect(utils.customRoundedPercentage(0.00001, 'veryLow')).to.equal('0.01');
-      expect(utils.customRoundedPercentage(0.00052, 'veryLow')).to.equal('0.06');
-      expect(utils.customRoundedPercentage(0.00242, 'veryLow')).to.equal('0.25');
-      expect(utils.customRoundedPercentage(0.00436, 'veryLow')).to.equal('0.44');
+      expect(utils.thresholdRound(0.00001, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.01');
+      expect(utils.thresholdRound(0.00052, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.06');
+      expect(utils.thresholdRound(0.00242, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.25');
+      expect(utils.thresholdRound(0.00436, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.44');
     });
     it('should round down for `veryLow` from 0.5 up to 1 percent with 0.1 precision', () => {
-      expect(utils.customRoundedPercentage(0.005, 'veryLow')).to.equal('0.5');
-      expect(utils.customRoundedPercentage(0.0068, 'veryLow')).to.equal('0.6');
-      expect(utils.customRoundedPercentage(0.0082, 'veryLow')).to.equal('0.8');
-      expect(utils.customRoundedPercentage(0.0132, 'veryLow')).to.equal('1');
-      expect(utils.customRoundedPercentage(0.015, 'veryLow')).to.equal('2');
+      expect(utils.thresholdRound(0.005, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.5');
+      expect(utils.thresholdRound(0.0068, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.6');
+      expect(utils.thresholdRound(0.0082, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.8');
+      expect(utils.thresholdRound(0.0132, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1');
+      expect(utils.thresholdRound(0.015, DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('2');
     });
     it('should round down for `low` between 3 and 4 percent with 0.1 precision', () => {
-      expect(utils.customRoundedPercentage(0.0327, 'low')).to.equal('3.2');
-      expect(utils.customRoundedPercentage(0.0384, 'low')).to.equal('3.8');
-      expect(utils.customRoundedPercentage(0.025, 'low')).to.equal('3');
-      expect(utils.customRoundedPercentage(0.0462, 'low')).to.equal('5');
+      expect(utils.thresholdRound(0.0327, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3.2');
+      expect(utils.thresholdRound(0.0384, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3.8');
+      expect(utils.thresholdRound(0.025, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('3');
+      expect(utils.thresholdRound(0.0462, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('5');
     });
     it('should round down for `target` between 69 and 70 percent with 0.1 precision', () => {
-      expect(utils.customRoundedPercentage(0.6999, 'target')).to.equal('69.9');
-      expect(utils.customRoundedPercentage(0.6942, 'target')).to.equal('69.4');
-      expect(utils.customRoundedPercentage(0.685, 'target')).to.equal('69');
-      expect(utils.customRoundedPercentage(0.705, 'target')).to.equal('71');
+      expect(utils.thresholdRound(0.6999, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.9');
+      expect(utils.thresholdRound(0.6942, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69.4');
+      expect(utils.thresholdRound(0.685, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('69');
+      expect(utils.thresholdRound(0.705, DEFAULT_FILTER_THRESHOLDS.target)).to.equal('71');
     });
     it('should round down for `high` between 24 and 25 percent with 0.1 precision', () => {
-      expect(utils.customRoundedPercentage(0.2499, 'high')).to.equal('24.9');
-      expect(utils.customRoundedPercentage(0.2442, 'high')).to.equal('24.4');
-      expect(utils.customRoundedPercentage(0.235, 'high')).to.equal('24');
-      expect(utils.customRoundedPercentage(0.255, 'high')).to.equal('26');
+      expect(utils.thresholdRound(0.2499, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24.9');
+      expect(utils.thresholdRound(0.2442, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24.4');
+      expect(utils.thresholdRound(0.235, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('24');
+      expect(utils.thresholdRound(0.255, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('26');
     });
     it('should round down for `veryHigh` between 4 and 5 percent with 0.1 precision', () => {
-      expect(utils.customRoundedPercentage(0.0499, 'veryHigh')).to.equal('4.9');
-      expect(utils.customRoundedPercentage(0.0442, 'veryHigh')).to.equal('4.4');
-      expect(utils.customRoundedPercentage(0.035, 'veryHigh')).to.equal('4');
-      expect(utils.customRoundedPercentage(0.055, 'veryHigh')).to.equal('6');
+      expect(utils.thresholdRound(0.0499, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4.9');
+      expect(utils.thresholdRound(0.0442, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4.4');
+      expect(utils.thresholdRound(0.035, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('4');
+      expect(utils.thresholdRound(0.055, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('6');
     });
     it('should use normal rounding with 1.0 precision for other values over 0.5 percent', () => {
-      expect(utils.customRoundedPercentage(0.26459, 'veryHigh')).to.equal('26');
-      expect(utils.customRoundedPercentage(0.00589, 'low')).to.equal('1');
+      expect(utils.thresholdRound(0.26459, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('26');
+      expect(utils.thresholdRound(0.00589, DEFAULT_FILTER_THRESHOLDS.low)).to.equal('1');
     });
     it('should use normal rounding with 0.1 precision for other values under 0.5 and over 0.05', () => {
-      expect(utils.customRoundedPercentage(0.0043, 'veryHigh')).to.equal('0.4');
-      expect(utils.customRoundedPercentage(0.0035, 'high')).to.equal('0.4');
+      expect(utils.thresholdRound(0.0043, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('0.4');
+      expect(utils.thresholdRound(0.0035, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('0.4');
     });
-    it('should use normal rounding with 0.01 precision for values under 0.05', () => {
-      expect(utils.customRoundedPercentage(0.00043, 'veryHigh')).to.equal('0.04');
-      expect(utils.customRoundedPercentage(0.00025, 'high')).to.equal('0.03');
+    it('should use round up with 0.01 precision for values under 0.05', () => {
+      expect(utils.thresholdRound(0.00043, DEFAULT_FILTER_THRESHOLDS.veryHigh)).to.equal('0.05');
+      expect(utils.thresholdRound(0.00025, DEFAULT_FILTER_THRESHOLDS.high)).to.equal('0.03');
     });
   });
 });

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -613,7 +613,7 @@ describe('utils', () => {
       expect(utils.formatThresholdPercentage(0.005, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('1');
       expect(utils.formatThresholdPercentage(0.0151, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('2');
 
-      // Values above below 0.5 percent rounding with extra precision
+      // Values below 0.5 percent rounding with extra precision
       expect(utils.formatThresholdPercentage(0.000001, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.01');
       expect(utils.formatThresholdPercentage(0.00049, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.05');
       expect(utils.formatThresholdPercentage(0.0049, ...DEFAULT_FILTER_THRESHOLDS.veryLow)).to.equal('0.5');
@@ -728,9 +728,16 @@ describe('utils', () => {
       expect(utils.formatThresholdPercentage(0.155, ...DEFAULT_FILTER_THRESHOLDS.timeInTargetPercentDelta)).to.equal('15.5');
     });
 
+    it('should round values from 0.05 to 0.5 percent with 0.1 precision', () => {
+      expect(utils.formatThresholdPercentage(0.0005)).to.equal('0.1');
+      expect(utils.formatThresholdPercentage(0.0041)).to.equal('0.4');
+      expect(utils.formatThresholdPercentage(0.0049)).to.equal('0.5');
+      expect(utils.formatThresholdPercentage(0.005)).to.equal('1');
+    });
+
     it('should round values between 0 and 0.05 percent with 0.01 precision', () => {
       expect(utils.formatThresholdPercentage(0.0000)).to.equal('0');
-      expect(utils.formatThresholdPercentage(0.00001)).to.equal('0.01');
+      expect(utils.formatThresholdPercentage(0.00005)).to.equal('0.01');
       expect(utils.formatThresholdPercentage(0.00041)).to.equal('0.04');
       expect(utils.formatThresholdPercentage(0.00049)).to.equal('0.05');
       expect(utils.formatThresholdPercentage(0.0005)).to.equal('0.1');

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -572,6 +572,7 @@ describe('utils', () => {
     it('should round a float naturally to the provided precision, or 1 decimal place if no precision provided', function() {
       expect(utils.roundToPrecision(1.23456, 2)).to.equal(1.23);
       expect(utils.roundToPrecision(1.23456, 3)).to.equal(1.235);
+      expect(utils.roundToPrecision(1.23456, 1)).to.equal(1.2);
       expect(utils.roundToPrecision(1.23456)).to.equal(1);
     });
   });
@@ -580,7 +581,8 @@ describe('utils', () => {
     it('should round a float up to the provided precision, or 1 decimal place if no precision provided', function() {
       expect(utils.roundUp(1.23456, 2)).to.equal(1.24);
       expect(utils.roundUp(1.23456, 3)).to.equal(1.235);
-      expect(utils.roundUp(1.23456)).to.equal(1.3);
+      expect(utils.roundUp(1.23456, 1)).to.equal(1.3);
+      expect(utils.roundUp(1.23456)).to.equal(2);
     });
   });
 
@@ -588,7 +590,8 @@ describe('utils', () => {
     it('should round a float up to the provided precision, or 1 decimal place if no precision provided', function() {
       expect(utils.roundDown(1.23456, 2)).to.equal(1.23);
       expect(utils.roundDown(1.23456, 3)).to.equal(1.234);
-      expect(utils.roundDown(1.23456)).to.equal(1.2);
+      expect(utils.roundDown(1.56456, 1)).to.equal(1.5);
+      expect(utils.roundDown(1.53456)).to.equal(1);
     });
   });
 


### PR DESCRIPTION
[WEB-2551]

This is basically a rewrite of the custom rounding we had applied for the Population Health dashboard to handle small numbers rounding to zero, and numbers rounding naturally to the filter time in range thresholds in a way that didn't comport well with the filters. 

For a more detailed description see the [internal documentaion](https://docs.google.com/document/d/1DaGKoSplCS1-NYDDyoCwv52pZQoIJFEO3H6VWsXsBQE/edit#heading=h.pcw1rfj1h4gl) 

[WEB-2551]: https://tidepool.atlassian.net/browse/WEB-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ