### PR TITLE
[WEB-2534] web worker error reporting

### DIFF
--- a/app/redux/utils/logErrorMiddleware.js
+++ b/app/redux/utils/logErrorMiddleware.js
@@ -20,7 +20,7 @@ import _ from 'lodash';
 export default (api) => {
   return ({ getState }) => (next) => (action) => {
     const err = _.get(action, 'error', {});
-    if (!_.isEmpty(err)) {
+    if (!_.isEmpty(err) || _.isError(err)) {
       api.errors.log(
         err,
         _.get(action, 'meta.apiError.status', null) ? 'API error' : null,

--- a/app/worker/PDFWorker.js
+++ b/app/worker/PDFWorker.js
@@ -43,7 +43,7 @@ export default class PDFWorker {
       case actionTypes.GENERATE_PDF_REQUEST: {
         try {
           const { type, queries, data = {} } = action.payload;
-          const opts = { ...action.payload.opts }
+          const opts = { ...action.payload.opts };
           const { origin } = action.meta;
 
           if (queries) {
@@ -65,13 +65,13 @@ export default class PDFWorker {
                 // Return early if the intent is still to generate the AGP report
                 return this.requestAGPImages(data, opts, queries, postMessage);
               }
-          }
+            }
 
-          _.each(queries, (query, key) => {
-            this.log(key, query);
-            if (!data[key]) data[key] = this.dataUtil.query(query);
+            _.each(queries, (query, key) => {
+              this.log(key, query);
+              if (!data[key]) data[key] = this.dataUtil.query(query);
 
-              switch(key) {
+              switch (key) {
                 case 'basics':
                   opts[key].disabled = isMissingBasicsData(_.get(data, 'basics.data.current.aggregationsByDate'));
                   break;
@@ -112,7 +112,7 @@ export default class PDFWorker {
   }
 
   requestAGPImages(data, opts, queries, postMessage) {
-    postMessage(syncActions.generateAGPImagesRequest(data, opts, queries))
+    postMessage(syncActions.generateAGPImagesRequest(data, opts, queries));
   }
 
   generatePDF(data, opts, origin, type, postMessage) {

--- a/test/unit/redux/utils/logErrorMiddleware.test.js
+++ b/test/unit/redux/utils/logErrorMiddleware.test.js
@@ -1,0 +1,70 @@
+/* global sinon */
+/* global describe */
+/* global it */
+/* global expect */
+/* global beforeEach */
+/* global afterEach */
+
+
+import logErrorMiddleware from '../../../../app/redux/utils/logErrorMiddleware';
+
+describe.only('logErrorMiddleware', () => {
+  let api;
+  let middleware;
+  let getState;
+  let next;
+  let action;
+
+  beforeEach(() => {
+    api = {
+      errors: {
+        log: sinon.spy(),
+      },
+    };
+    middleware = logErrorMiddleware(api);
+    getState = sinon.spy();
+    next = sinon.spy();
+    action = {};
+  });
+
+  it('should call api.errors.log when action has an error', () => {
+    const error = new Error('Test error');
+    action = { error };
+
+    middleware({ getState })(next)(action);
+
+    sinon.assert.calledWith(api.errors.log, error, null, {});
+    sinon.assert.calledWith(next, action);
+  });
+
+  it('should call api.errors.log when action has an error object', () => {
+    const error = new Error('Test error');
+    action = { error: { apiError: error }};
+
+    middleware({ getState })(next)(action);
+
+    sinon.assert.calledWith(api.errors.log, { apiError: error }, null, {});
+    sinon.assert.calledWith(next, action);
+  });
+
+  it('should not call api.errors.log when action does not have an error', () => {
+    action = {};
+
+    middleware({ getState })(next)(action);
+
+    sinon.assert.notCalled(api.errors.log);
+    sinon.assert.calledWith(next, action);
+  });
+
+  it('should call api.errors.log when action has meta.apiError', () => {
+    const error = new Error('Test error');
+    const meta = { apiError: { status: 500 } };
+    action = { error, meta };
+
+    middleware({ getState })(next)(action);
+
+    sinon.assert.calledWith(api.errors.log, error, 'API error', meta.apiError);
+    sinon.assert.calledWith(next, action);
+  });
+
+});

--- a/test/unit/worker/PDFWorker.test.js
+++ b/test/unit/worker/PDFWorker.test.js
@@ -170,6 +170,23 @@ describe('PDFWorker', () => {
     });
   });
 
+  it('should fire a failure action uplon failed query', () => {
+    const postMessage = sinon.stub();
+    dataUtil.query.throws(new Error('query error'));
+
+    Worker = new PDFWorker(dataUtil, importer, renderer);
+
+    const action = actions.generatePDFRequest(type, queries, opts());
+    Worker.handleMessage({ data: action }, postMessage);
+
+    sinon.assert.calledOnce(postMessage);
+    sinon.assert.calledWithExactly(
+      postMessage,
+      actions.generatePDFFailure(new Error('query error'))
+    );
+    dataUtil.query = sinon.stub().callsFake(key => queryResults[key]);
+  });
+
   it('should throw an error if it receives an unhandled action type', () => {
     const action = {
       type: 'unknownAction',


### PR DESCRIPTION
for [WEB-2534], expands our error logging gate check to include unmodified `Error` instances, which `_.isEmpty()` will consider empty due to having no enumerable properties of their own.

[WEB-2534]: https://tidepool.atlassian.net/browse/WEB-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ