### PR TITLE
[WEB-2749] Pendo clinician visitor role fix

### DIFF
--- a/app/redux/utils/pendoMiddleware.js
+++ b/app/redux/utils/pendoMiddleware.js
@@ -1,12 +1,12 @@
 import get from 'lodash/get';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
-import indexOf from 'lodash/indexOf';
 import isEmpty from 'lodash/isEmpty';
 import isNull from 'lodash/isNull';
 import bows from 'bows';
 import config from '../../config';
 import * as ActionTypes from '../constants/actionTypes';
+import { isClinicianAccount } from '../../core/personutils';
 
 const trackingActions = [
   ActionTypes.LOGIN_SUCCESS,
@@ -85,7 +85,7 @@ const pendoMiddleware = (api, win = window) => (storeAPI) => (next) => (action) 
         }
       }
 
-      const role = indexOf(user?.roles, 'clinic') !== -1 ? 'clinician' : 'personal';
+      const role = isClinicianAccount(user) ? 'clinician' : 'personal';
 
       pendoAction({
         visitor: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.73.0-rc.2",
+  "version": "1.73.0-rc.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
See [WEB-2749] 

Basically, we were only setting `visitor.role` to `clinician` if the user had the legacy `clinic` role assigned.  It will now apply correctly for the `clinician` or `migrated_clinic` roles as well

[WEB-2749]: https://tidepool.atlassian.net/browse/WEB-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ