### PR TITLE
[WEB-2847] no-date hard limit clinics assigned `base` 

### DIFF
--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -104,6 +104,7 @@ export const clinicTierDetails = (clinic = {}) => {
     patientCountSettings = {},
   } = clinic;
 
+  const hardLimit = patientCountSettings?.hardLimit;
   const hardLimitStartDate = patientCountSettings?.hardLimit?.startDate;
   const hardLimitStartDateIsFuture = hardLimitStartDate && moment(hardLimitStartDate).isValid() && moment(hardLimitStartDate).isAfter();
   const isBaseTier = tier.indexOf('tier01') === 0;
@@ -112,7 +113,7 @@ export const clinicTierDetails = (clinic = {}) => {
   // Handle various base tier clinic states
   if (isBaseTier) {
     const isOUS = country !== 'US';
-    const isInActiveSalesConversation = !isOUS && !hardLimitStartDate;
+    const isInActiveSalesConversation = !isOUS && !hardLimit;
     const isHonoredBaseClinic = !isOUS && hardLimitStartDateIsFuture;
 
     if (isOUS) {

--- a/test/unit/app/core/clinicUtils.test.js
+++ b/test/unit/app/core/clinicUtils.test.js
@@ -88,6 +88,33 @@ describe('clinicUtils', function() {
       });
     });
 
+    it('should set appropriate details for a tier0100 clinic that has a patient count hard limit and no start date', () => {
+      const details = clinicUtils.clinicTierDetails(createClinic({
+        tier: 'tier0100',
+        patientCountSettings: { hardLimit: { patientCount: DEFAULT_CLINIC_PATIENT_COUNT_HARD_LIMIT } }
+      }));
+
+      expect(details.planName).to.equal('base');
+      expect(details.patientLimitEnforced).to.equal(true);
+
+      expect(details.display).to.eql({
+        planName: true,
+        patientCount: true,
+        patientLimit: true,
+        workspacePlan: true,
+        workspaceLimitDescription: false,
+        workspaceLimitFeedback: false,
+        workspaceLimitResolutionLink: false,
+      });
+
+      expect(details.entitlements).to.eql({
+        patientTags: false,
+        rpmReport: false,
+        summaryDashboard: false,
+        tideDashboard: false,
+      });
+    });
+
     it('should set appropriate details for a tier0100 clinic that has a patient count hard limit start date in the past', () => {
       const details = clinicUtils.clinicTierDetails(createClinic({
         tier: 'tier0100',


### PR DESCRIPTION
for [WEB-2847] tweaks logic to ensure that clinics with a hard limit but no start dates are assigned `base` tier

[WEB-2847]: https://tidepool.atlassian.net/browse/WEB-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ