### PR TITLE
[WEB-2784] fix mrn editing clearing patient information

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -893,7 +893,8 @@ export const ClinicPatients = (props) => {
   // Provide latest patient state for the edit form upon fetch
   useEffect(() => {
     if (fetchingPatientFromClinic.completed && selectedPatient?.id) setSelectedPatient(clinic.patients[selectedPatient.id]);
-  }, [fetchingPatientFromClinic, clinic?.patients, selectedPatient?.id]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchingPatientFromClinic, selectedPatient?.id]);
 
   const renderInfoPopover = () => (
     <Box px={4} py={3} sx={{ maxWidth: '600px' }}>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watchViz": "export NODE_OPTIONS='--max-old-space-size=4096' && cd ${TIDEPOOL_DOCKER_VIZ_DIR:-'../viz'} && npm run start",
     "cleanViz": "yarn rimraf ${TIDEPOOL_DOCKER_VIZ_DIR:-'../viz'}/dist/*",
     "startWithViz": "npm run cleanViz; yarn concurrently --kill-others --names viz,blip \"npm run watchViz\" \"while ! test -f ${TIDEPOOL_DOCKER_VIZ_DIR:-'../viz'}'/dist/index.js'; do sleep 1; done; npm run start\"",
-    "startLocal": "if node -e 'require(\"./config/local\").listLinkedPackages()' | grep -qF '@tidepool/viz'; then npm run startWithViz; else npm run start; fi",
+    "startLocal": "node -e \"require('./config/local')?.linkedPackages?.['@tidepool/viz'] ? require('child_process').spawn('npm', ['run', 'startWithViz'], { stdio: 'inherit' }) : require('child_process').spawn('npm', ['run', 'start'], { stdio: 'inherit' })\"",
     "build": "NODE_OPTIONS='--max-old-space-size=4096' NODE_ENV=production npm run build-app && npm run build-config",
     "build-app": "NODE_ENV=production node buildapp",
     "build-config": "NODE_ENV=production node buildconfig",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,7 +187,7 @@ const plugins = [
 
 if (isDev) {
   plugins.push(new webpack.HotModuleReplacementPlugin());
-  plugins.push(new ReactRefreshWebpackPlugin());
+  plugins.push(new ReactRefreshWebpackPlugin({ overlay: false}));
 } else if (isProd) {
   plugins.push(
     /** Upload sourcemap to Rollbar */
@@ -253,7 +253,17 @@ module.exports = {
     static: { publicPath: output.publicPath },
     historyApiFallback: true,
     hot: isDev,
-    client: { logging: 'info' },
+    client: {
+      logging: 'info',
+      overlay: {
+        runtimeErrors: (error) => {
+          if(error.name === 'LaunchDarklyFlagFetchError') {
+            return false;
+          }
+          return true;
+        }
+      }
+     },
   },
   devtool,
   entry,


### PR DESCRIPTION
for [WEB-2784] - fixes issue with MRN edits clearing the selected patient information during the existing MRN patient search flow

also drops the `if`/`then` shell requirement from the `startLocal` command (which for whatever reason I ran into on zsh on macOS) and adds a filter for launchdarkly network problems showing up in dev overlays that I had to close on nearly every app interaction

[WEB-2784]: https://tidepool.atlassian.net/browse/WEB-2784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ