### PR TITLE
[WEB-2856] Add unique keycloak registration urls for patient and clinician signups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,14 @@ RUN corepack enable \
 
 ### Stage: Development root with Chromium installed for unit tests
 FROM base as development
+ARG LAUNCHDARKLY_CLIENT_TOKEN
 ARG I18N_ENABLED=false
 ARG RX_ENABLED=false
 ARG PENDO_ENABLED=true
 ENV \
   # CHROME_BIN=/usr/bin/chromium-browser \
   # LIGHTHOUSE_CHROMIUM_PATH=/usr/bin/chromium-browser \
+  LAUNCHDARKLY_CLIENT_TOKEN=$LAUNCHDARKLY_CLIENT_TOKEN \
   I18N_ENABLED=$I18N_ENABLED \
   RX_ENABLED=$RX_ENABLED \
   PENDO_ENABLED=$PENDO_ENABLED \

--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -172,16 +172,16 @@ export let Signup = withTranslation()(class extends React.Component {
       let registerUrl = keycloak.createRegisterUrl(options);
       switch (this.state.selected) {
         case 'personal':
-          registerUrl += "&role=patient";
+          registerUrl += '&role=patient';
           break;
-  
+
         case 'clinician':
-          registerUrl += "&role=clinician";
+          registerUrl += '&role=clinician';
           break;
       }
 
       // Assign window location to Keycloak register URL
-      window.location.assign(registerUrl);
+      win.location.assign(registerUrl);
     }
 
     let content = isLoading || keycloakConfig.initialized ? null : (

--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -167,7 +167,21 @@ export let Signup = withTranslation()(class extends React.Component {
       if(inviteEmail){
         options.loginHint = inviteEmail;
       }
-      keycloak.register(options);
+
+      // Build Keycloak register URL with role parameter
+      let registerUrl = keycloak.createRegisterUrl(options);
+      switch (this.state.selected) {
+        case 'personal':
+          registerUrl += "&role=patient";
+          break;
+  
+        case 'clinician':
+          registerUrl += "&role=clinician";
+          break;
+      }
+
+      // Assign window location to Keycloak register URL
+      window.location.assign(registerUrl);
     }
 
     let content = isLoading || keycloakConfig.initialized ? null : (

--- a/test/unit/pages/signup.test.js
+++ b/test/unit/pages/signup.test.js
@@ -264,18 +264,18 @@ describe('Signup', function () {
     const mockStore = configureStore([thunk]);
     let store = mockStore(storeState);
     const keycloakMock = {
-      register: sinon.stub(),
+      createRegisterUrl: sinon.stub(),
     };
     let RewiredSignup;
     let wrapper;
 
     afterEach(() => {
-      keycloakMock.register.reset();
+      keycloakMock.createRegisterUrl.reset();
     });
 
     before(() => {
       Signup.__Rewire__('keycloak', keycloakMock);
-      Signup.__Rewire__('win', { location: { origin: 'testOrigin' } });
+      Signup.__Rewire__('win', { location: { origin: 'testOrigin', assign: sinon.stub() } });
       RewiredSignup = require('../../../app/pages/signup/signup.js').default;
       wrapper = mount(
         createElement(
@@ -297,7 +297,7 @@ describe('Signup', function () {
     });
 
     it('should send the user to keycloak signup if keycloak is initialized', () => {
-      expect(keycloakMock.register.callCount).to.equal(0);
+      expect(keycloakMock.createRegisterUrl.callCount).to.equal(0);
       storeState = merge(storeState, {
         blip: { keycloakConfig: { initialized: true } },
       });
@@ -308,12 +308,12 @@ describe('Signup', function () {
           initialized: true,
         },
       });
-      expect(keycloakMock.register.callCount).to.equal(1);
-      expect(keycloakMock.register.calledWith({ redirectUri: 'testOrigin' })).to.be.true;
+      expect(keycloakMock.createRegisterUrl.callCount).to.equal(1);
+      expect(keycloakMock.createRegisterUrl.calledWith({ redirectUri: 'testOrigin' })).to.be.true;
     });
 
     it('should provide loginHint if inviteEmail is provided', () => {
-      expect(keycloakMock.register.callCount).to.equal(0);
+      expect(keycloakMock.createRegisterUrl.callCount).to.equal(0);
       storeState = merge(storeState, {
         blip: { keycloakConfig: { initialized: true } },
       });
@@ -325,8 +325,8 @@ describe('Signup', function () {
           initialized: true,
         },
       });
-      expect(keycloakMock.register.callCount).to.equal(1);
-      expect(keycloakMock.register.calledWith({loginHint: 'someEmail@provider.com'}));
+      expect(keycloakMock.createRegisterUrl.callCount).to.equal(1);
+      expect(keycloakMock.createRegisterUrl.calledWith({loginHint: 'someEmail@provider.com'}));
     });
 
 


### PR DESCRIPTION
[WEB-2856]

This work was done by Darin.  Will ping you for review, @krystophv, once I get the tests passing, in case you have any qualms with the approach, since you've done most of the keycloak work in `blip` to this point.

[WEB-2856]: https://tidepool.atlassian.net/browse/WEB-2856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ