### PR TITLE
[WEB-2874,WEB-2887] Fix hidden dialog z-index issues

### DIFF
--- a/app/components/elements/Dialog.js
+++ b/app/components/elements/Dialog.js
@@ -112,6 +112,10 @@ DialogActions.propTypes = {
 const StyledDialog = styled(MuiDialog)`
   z-index: ${props => (props.zIndex || '1310')} !important;
 
+  &[aria-hidden] {
+    z-index: -1 !important;
+  }
+
   .MuiBackdrop-root {
     background-color: rgba(66, 90, 112, 0.81);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.76.0-rc.9",
+  "version": "1.76.0-rc.11",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
[WEB-2874] [WEB-2887]

Basically, the z-index was set above the main content, even for closed/hidden dialogs, causing some UI elements to be unreachable by mouse events.

[WEB-2874]: https://tidepool.atlassian.net/browse/WEB-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-2887]: https://tidepool.atlassian.net/browse/WEB-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ