### PR TITLE
[WEB-2928] Ensure clinic details form is populated with latest clinic values when reopening after edit

### DIFF
--- a/app/components/clinic/ClinicProfileFields.js
+++ b/app/components/clinic/ClinicProfileFields.js
@@ -6,12 +6,7 @@ import includes from 'lodash/includes';
 import map from 'lodash/map';
 import sortBy from 'lodash/sortBy';
 import countries from 'i18n-iso-countries';
-import InputMask from 'react-input-mask';
-import { Box, Flex, Text, BoxProps } from 'theme-ui';
-
-import {
-  Body2,
-} from '../../components/elements/FontStyles';
+import { Box, Flex, BoxProps } from 'theme-ui';
 
 import TextInput from '../../components/elements/TextInput';
 import RadioGroup from '../../components/elements/RadioGroup';

--- a/app/pages/clinicadmin/clinicadmin.js
+++ b/app/pages/clinicadmin/clinicadmin.js
@@ -438,6 +438,7 @@ export const ClinicAdmin = (props) => {
   function handleEditClinicProfile() {
     trackMetric('Clinic - Edit clinic profile', { clinicId: selectedClinicId });
     clinicProfileFormContext.resetForm();
+    clinicProfileFormContext.setValues(clinicValuesFromClinic(clinic));
     setShowEditClinicProfileDialog(true);
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.77.0-rc.4",
+  "version": "1.77.0-rc.5",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/pages/clinicadmin.test.js
+++ b/test/unit/pages/clinicadmin.test.js
@@ -820,6 +820,30 @@ describe('ClinicAdmin', () => {
           done();
         }, 0);
       });
+
+      it('should populate updated clinic profile values when re-opening form after edit', done => {
+        expect(profileForm().find('input[name="name"]').prop('value')).to.equal('Test Clinic');
+
+        wrapper.find('input[name="name"]').simulate('change', { persist: noop, target: { name: 'name', value: 'name_updated' } });
+        expect(wrapper.find('input[name="name"]').prop('value')).to.equal('name_updated');
+
+        wrapper.find('#editClinicProfileSubmit').hostNodes().simulate('click');
+
+        setTimeout(() => {
+          expect(defaultProps.api.clinics.update.callCount).to.equal(1);
+
+          sinon.assert.calledWith(
+            defaultProps.api.clinics.update,
+            'clinicID456',
+            sinon.match({
+              name: 'name_updated',
+            })
+          );
+
+          expect(wrapper.find('input[name="name"]').prop('value')).to.equal('name_updated');
+          done();
+        }, 0);
+      });
     });
 
     context('clinic admin team member with clinic timezone', () => {


### PR DESCRIPTION
[WEB-2928]

[WEB-2928]: https://tidepool.atlassian.net/browse/WEB-2928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ