### PR TITLE
[WEB-2922] Fix clinic name in toast after creation

### DIFF
--- a/app/components/clinic/WorkspaceSwitcher.js
+++ b/app/components/clinic/WorkspaceSwitcher.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { push } from 'connected-react-router';
 import { withTranslation } from 'react-i18next';
 import get from 'lodash/get';
@@ -34,6 +35,7 @@ export const WorkspaceSwitcher = props => {
   const membershipInOtherCareTeams = useSelector((state) => state.blip.membershipInOtherCareTeams);
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const hasPatientProfile = !!get(allUsersMap, [loggedInUserId, 'profile', 'patient'], false);
+  const { pathname } = useLocation();
 
   const popupState = usePopupState({
     variant: 'popover',
@@ -43,11 +45,11 @@ export const WorkspaceSwitcher = props => {
 
   const [menuOptions, setMenuOptions] = useState([])
   const [selectedClinic, setSelectedClinic] = useState(menuOptions[0]);
+  const selected = find(menuOptions, {id: selectedClinicId});
 
   useEffect(() => {
-    const selected = find(menuOptions, {id: selectedClinicId});
     if (selected) setSelectedClinic(selected);
-  }, [menuOptions.length, selectedClinicId]);
+  }, [menuOptions.length, selectedClinicId, selected]);
 
   useEffect(() => {
     const userClinics = filter(values(clinics), ({ clinicians }) => has(clinicians, loggedInUserId));
@@ -59,7 +61,7 @@ export const WorkspaceSwitcher = props => {
         metric: ['Clinic - Workspace Switcher - Go to private workspace'],
       };
 
-      const hidePrivateWorkspaceOption = !hasPatientProfile && !membershipInOtherCareTeams.length;
+      const hidePrivateWorkspaceOption = pathname !== '/patients' && (!hasPatientProfile && !membershipInOtherCareTeams.length);
 
       const options = [
         ...map(sortBy(userClinics, clinic => clinic.name.toLowerCase()), clinic => ({
@@ -73,7 +75,7 @@ export const WorkspaceSwitcher = props => {
 
       setMenuOptions(options);
     }
-  }, [clinics, membershipInOtherCareTeams, hasPatientProfile]);
+  }, [clinics, membershipInOtherCareTeams, hasPatientProfile, pathname]);
 
   const handleSelect = option => {
     trackMetric(...option.metric);

--- a/app/pages/clinicdetails/clinicdetails.js
+++ b/app/pages/clinicdetails/clinicdetails.js
@@ -128,7 +128,7 @@ export const ClinicDetails = (props) => {
       firstName: populateProfileFields ? firstName : '',
       lastName: populateProfileFields ? lastName : '',
       role: populateProfileFields ? user?.profile?.clinic?.role || '' : '',
-      ...clinicValuesFromClinic(clinic),
+      ...clinicValuesFromClinic(action === 'new' ? undefined : clinic),
     };
   };
 
@@ -250,6 +250,7 @@ export const ClinicDetails = (props) => {
       inProgress,
       completed,
       notification,
+      clinicId,
     } = working[clinicAction];
 
     const prevInProgress = get(
@@ -272,7 +273,7 @@ export const ClinicDetails = (props) => {
           setSubmitting(false);
 
           setToast({
-            message: t('"{{name}}" clinic created', clinic),
+            message: t('"{{name}}" clinic created', clinics[clinicId]),
             variant: 'success',
           });
         }
@@ -368,7 +369,7 @@ export const ClinicDetails = (props) => {
         trackMetric('Clinic - Account created');
         const clinicValues = pick(values, keys(clinicValuesFromClinic()));
 
-        if (clinic?.id) {
+        if (clinic?.id && action !== 'new') {
           dispatch(actions.async.updateClinic(api, clinic.id, clinicValues));
         } else {
           dispatch(actions.async.createClinic(api, clinicValues, loggedInUserId));

--- a/app/redux/reducers/working.js
+++ b/app/redux/reducers/working.js
@@ -345,7 +345,10 @@ export default (state = initialWorkingState, action) => {
               }
             }
           });
-        } else if (action.type === types.FETCH_CLINIC_SUCCESS) {
+        } else if (_.includes([
+          types.CREATE_CLINIC_SUCCESS,
+          types.FETCH_CLINIC_SUCCESS,
+        ], action.type)) {
           return update(state, {
             [key]: {
               $set: {

--- a/test/unit/components/clinic/WorkspaceSwitcher.test.js
+++ b/test/unit/components/clinic/WorkspaceSwitcher.test.js
@@ -36,10 +36,12 @@ describe('WorkspaceSwitcher', () => {
   };
 
   before(() => {
+    WorkspaceSwitcher.__Rewire__('useLocation', sinon.stub().returns({ pathname: '/clinic-workspace' }));
     mount = createMount();
   });
 
   after(() => {
+    WorkspaceSwitcher.__ResetDependency__('useLocation');
     mount.cleanUp();
   });
 


### PR DESCRIPTION
[WEB-2922]

Also, fixes a few other small issues I spotted:

1. The clinic create form would start pre-populated with the actively-selected clinic if set
2. The workspace switcher wasn't updating the clinic name upon edit
3. The Private Workspace option in the workspace switcher should show on the '/patients' page - otherwise, it's just a blank string with a downward caret beside it.

[WEB-2922]: https://tidepool.atlassian.net/browse/WEB-2922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ