### PR TITLE
[WEB-2933] Consolidate links styles in Limit UI

### DIFF
--- a/app/components/clinic/ClinicWorkspaceHeader.js
+++ b/app/components/clinic/ClinicWorkspaceHeader.js
@@ -202,9 +202,6 @@ export const ClinicWorkspaceHeader = (props) => {
                   sx={{
                     fontSize: 1,
                     fontWeight: 'medium',
-                    textDecoration: 'underline',
-                    color: 'text.link',
-                    '&:hover': { textDecoration: 'underline' },
                   }}
                 >
                   {t('Unlock Plans')}

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -52,7 +52,7 @@ import {
 import {
   MediumTitle,
   Body1,
-  Paragraph0,
+  Paragraph1,
 } from '../../components/elements/FontStyles';
 
 import Button from '../../components/elements/Button';
@@ -1149,8 +1149,8 @@ export const ClinicPatients = (props) => {
                 <>
                   <img alt={t('Patient Limit Reached')} src={LimitReached} />
                   <Box mt={3} sx={{ width: '213px' }}>
-                    <Paragraph0 sx={{ fontWeight: 'bold' }}>{t('Your workspace has reached the maximum number of patient accounts supported by our Base Plan.')}</Paragraph0>
-                    <Paragraph0>
+                    <Paragraph1 sx={{ fontWeight: 'bold' }}>{t('Your workspace has reached the maximum number of patient accounts supported by our Base Plan.')}</Paragraph1>
+                    <Paragraph1>
                       {t('Please reach out to your administrator and')}&nbsp;
                       <Link
                         id="addPatientUnlockPlansLink"
@@ -1158,14 +1158,11 @@ export const ClinicPatients = (props) => {
                         target="_blank"
                         rel="noreferrer noopener"
                         sx={{
-                          fontSize: 0,
+                          fontSize: 1,
                           fontWeight: 'medium',
-                          textDecoration: 'underline',
-                          color: 'text.link',
-                          '&:hover': { textDecoration: 'underline' },
                         }}
-                        >{t('learn more about our plans')}</Link>
-                    </Paragraph0>
+                        >{t('learn more about our plans.')}</Link>
+                    </Paragraph1>
                   </Box>
                 </>
               )}

--- a/app/themes/base/links.js
+++ b/app/themes/base/links.js
@@ -1,11 +1,11 @@
 export default ({ colors, fonts }) => {
   const defaultStyles = {
     fontFamily: fonts.default,
-    textDecoration: 'none',
+    textDecoration: 'underline',
     color: colors.text.link,
     '&:hover, &:active': {
       color: colors.text.link,
-      textDecoration: 'none',
+      textDecoration: 'underline',
     },
     '&:focus': {
       color: colors.text.link,
@@ -19,10 +19,6 @@ export default ({ colors, fonts }) => {
     inverted: {
       ...defaultStyles,
       color: colors.white,
-    },
-    underlined: {
-      ...defaultStyles,
-      textDecoration: 'underline',
     },
   };
 };

--- a/app/themes/baseTheme.js
+++ b/app/themes/baseTheme.js
@@ -168,7 +168,6 @@ const variants = {
   banners: banners({ colors, fonts, fontSizes, fontWeights }),
   icons: icons({ colors, fontSizes, radii, space, shadows }),
   inputs: inputs({ borders, colors, fonts, radii, fontSizes, fontWeights, space }),
-  link: linkVariants.default,
   links: linkVariants,
   lists: lists(),
   paginators: paginators({ colors, fonts, fontSizes, breakpoints }),
@@ -245,10 +244,16 @@ const text = {
     lineHeight: 3,
   },
 
+  paragraph0: {
+    ...paragraphText,
+    fontSize: 0,
+    lineHeight: 2,
+  },
+
   paragraph1: {
     ...paragraphText,
     fontSize: 1,
-    lineHeight: 3,
+    lineHeight: 2,
   },
 
   paragraph2: {
@@ -282,6 +287,10 @@ const text = {
   },
 };
 
+const styles = {
+  a: linkVariants.default,
+};
+
 export default {
   breakpoints,
   buttons: buttons({
@@ -306,6 +315,7 @@ export default {
   radii,
   shadows,
   space,
+  styles,
   text,
   transitions,
   zIndices,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.77.0",
+  "version": "1.77.1-web-2933-text-style-fixes.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2933] 
Some of the link styles stopped working correctly when we switched to theme-ui.
This consolidates them by defining them at the theme level (and in the correct location for theme-ui)