### PR TITLE
[WEB-2945] RPM config form range selector tweaks

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -199,20 +199,22 @@ export const RpmReportConfigForm = props => {
             isDayBlocked={day => {
               const daysFromToday = today.diff(getCalendarDate(day), 'days');
 
+              // By default block all future dates, and all days prior to 59 days ago
+              let dayIsBlocked = daysFromToday < 0 || daysFromToday >= maxDaysInPast;
+
               // If adjusting the end date, block out all dates 30 days or more beyond, and all dates prior to, the start date
-              if (values.startDate && focusedDatePickerInput === 'endDate') {
+              if (!dayIsBlocked && values.startDate && focusedDatePickerInput === 'endDate') {
                 const daysFromStartDate = getCalendarDate(day).diff(getCalendarDate(values.startDate), 'days');
-                return daysFromStartDate > maxDays - 1 || daysFromStartDate < 0
+                dayIsBlocked = daysFromStartDate > maxDays - 1 || daysFromStartDate < 0;
               }
 
               // If adjusting the start date, block out all dates 30 days or more prior to, and all dates after, the end date
-              if (values.endDate && focusedDatePickerInput === 'startDate') {
+              if (!dayIsBlocked && values.endDate && focusedDatePickerInput === 'startDate') {
                 const daysFromEndDate = getCalendarDate(values.endDate).diff(getCalendarDate(day), 'days');
-                return daysFromEndDate > maxDays - 1 || daysFromEndDate < 0
+                dayIsBlocked = daysFromEndDate > maxDays - 1 || daysFromEndDate < 0;
               }
 
-              // By default block all future dates, and all days prior to 59 days ago
-              return daysFromToday < 0 || daysFromToday >= maxDaysInPast;
+              return dayIsBlocked;
             }}
             initialVisibleMonth={() => moment().subtract(1, 'month')}
             onFocusChange={input => {

--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -215,7 +215,7 @@ export const RpmReportConfigForm = props => {
         </Box>
       </Element>
       <Box id='rpm-report-timezone-select' mb={3}>
-        <Body0 sx={{ fontWeight: 'medium' }} mb={2}>{t('Confirm your clinic’s timezone')}</Body0>
+        <Body0 sx={{ fontWeight: 'medium' }} mb={2}>{t('Confirm your clinic\'s timezone')}</Body0>
 
         <Select
           {...getCommonFormikFieldProps('timezone', formikContext)}

--- a/app/components/elements/DateRangePicker.js
+++ b/app/components/elements/DateRangePicker.js
@@ -79,9 +79,17 @@ const StyledDateRangePicker = styled(StyledDatePickerBase)`
       border-radius: 0;
     }
 
-    &.CalendarDay__blocked_out_of_range {
+    &.CalendarDay__blocked_out_of_range,
+    &.CalendarDay__blocked_out_of_range:hover {
       background-color: ${colors.lightestGrey};
       color: ${colors.blueGreyLight};
+      border-radius: 0;
+    }
+
+    &.CalendarDay__blocked_calendar,
+    &.CalendarDay__blocked_calendar:hover {
+      background-color: ${colors.lightGrey};
+      color: ${colors.blueGreyMedium};
       border-radius: 0;
     }
   }
@@ -139,10 +147,8 @@ export function DateRangePicker(props) {
         }}
         focusedInput={focusedInput}
         onFocusChange={selectedFocusedInput => {
-          let newFocusedInput = selectedFocusedInput;
-          if (newFocusedInput && !dates.startDate) newFocusedInput = 'startDate';
-          setFocusedInput(newFocusedInput);
-          onFocusChange(newFocusedInput);
+          setFocusedInput(selectedFocusedInput);
+          onFocusChange(selectedFocusedInput);
         }}
         numberOfMonths={2}
         displayFormat="MMM D, YYYY"

--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -456,16 +456,19 @@ export const rpmReportConfigSchema = yup.object().shape({
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment().subtract(59, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 60 days'))
-    .max(moment().subtract(1, 'day').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
+    .min(moment.utc().subtract(58, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
+    .max(moment.utc().subtract(1, 'day').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
     .required(t('Please select a start date')),
   endDate: yup.date()
     .transform((value, originalValue) => {
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment().subtract(59, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 59 days'))
-    .max(moment().endOf('day').format(dateFormat), t('Please enter an end date no later than today'))
+    .min(moment.utc().subtract(58, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 58 days'))
+    .max(moment.utc().endOf('day').format(dateFormat), t('Please enter an end date no later than today'))
+    .when('startDate', ([startDate], schema) => schema
+      .max(moment.utc(startDate).add(29, 'days').endOf('day').format(dateFormat), t('End date must be within 30 days of the start date'))
+    )
     .required(t('Please select an end date')),
   timezone: yup.string().oneOf(map(timezoneOptions, 'value')).required(t('Please select a timezone')),
 });

--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -467,7 +467,7 @@ export const rpmReportConfigSchema = yup.object().shape({
     .min(moment.utc().subtract(58, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 58 days'))
     .max(moment.utc().endOf('day').format(dateFormat), t('Please enter an end date no later than today'))
     .when('startDate', ([startDate], schema) => schema
-      .max(moment.utc(startDate).add(29, 'days').endOf('day').format(dateFormat), t('End date must be within 30 days of the start date'))
+      .max(moment.min([moment.utc(startDate).add(29, 'days'), moment.utc()]).endOf('day').format(dateFormat), t('End date must be within 30 days of the start date and no later than today'))
     )
     .required(t('Please select an end date')),
   timezone: yup.string().oneOf(map(timezoneOptions, 'value')).required(t('Please select a timezone')),

--- a/app/themes/baseTheme.js
+++ b/app/themes/baseTheme.js
@@ -264,7 +264,7 @@ const text = {
 
   caption: {
     ...defaultText,
-    display: 'inline-block',
+    display: 'block',
     fontSize: 0,
     lineHeight: 4,
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.1",
+  "version": "1.78.0-rc.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2945] 

Basically, adjusts the date-blocking logic for the RPM date range UX, and also ignores the browser time zone, and treats all calendar dates as UTC, only converting to the requested time zone on submission, which fixes a few edge case issues that could affect selecting dates at the start of the range for certain time zones.

It also reduces the max days in past to 59 days from 60, since we only generate pop health stats on the backend for the past 60 days in UTC time, leaving some time zones with no data for up to 12 hours on the 60th day back.

[WEB-2945]: https://tidepool.atlassian.net/browse/WEB-2945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ