### PR TITLE
[WEB-2939] Keep gmt offset in RPM report date params

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -119,10 +119,16 @@ export const RpmReportConfigForm = props => {
   const formikContext = useFormik({
     initialValues: defaultFormValues(config?.[localConfigKey]),
     onSubmit: values => {
+      const startDate = moment(values.startDate).tz(values.timezone).startOf('day');
+      const endDate = moment(values.endDate).tz(values.timezone).endOf('day');
+
+      // We keep the offset when converting to an ISO string to match the expected backend format
+      const keepOffset = true;
+
       const queryOptions = {
         rawConfig: values,
-        startDate: moment(values.startDate).tz(values.timezone).startOf('day').toISOString(),
-        endDate: moment(values.endDate).tz(values.timezone).endOf('day').toISOString(),
+        startDate: startDate.toISOString(keepOffset),
+        endDate: endDate.toISOString(keepOffset),
       };
 
       dispatch(async.fetchRpmReportPatients(api, selectedClinicId, queryOptions));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.2",
+  "version": "1.78.0-rc.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2939] 
Keeping the GMT offset to allow the backend to more accurately calculate the report accross DST changeovers, and produce a valid date count generally for timezones on the 'plus' side of UTC.

[WEB-2939]: https://tidepool.atlassian.net/browse/WEB-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ