### PR TITLE
[WEB-2932] Fix workspace admin page flicker

### DIFF
--- a/app/pages/clinicadmin/clinicadmin.js
+++ b/app/pages/clinicadmin/clinicadmin.js
@@ -281,7 +281,6 @@ export const ClinicAdmin = (props) => {
   useEffect(() => {
     if (clinic?.clinicians) {
       setClinicianArray(getClinicianArray());
-      setUserRolesInClinic()
     }
   }, [clinic?.clinicians]);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.3",
+  "version": "1.78.0-rc.4",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2932]

Issue was caused by an extra call to `setUserRolesInClinic` in back to back renders

[WEB-2932]: https://tidepool.atlassian.net/browse/WEB-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ