### PR TITLE
[WEB-2945] Allow any date within 59 days to be selected while start date selector is focused

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -191,7 +191,7 @@ export const RpmReportConfigForm = props => {
             }
             endDate={values.endDate ? moment.utc(values.endDate) : null}
             endDateId="rpm-report-end-date"
-            endDateOffset={(!values.endDate && focusedDatePickerInput === 'startDate')
+            endDateOffset={(focusedDatePickerInput === 'startDate')
               ? day => moment.min([
                 moment.utc(today),
                 moment.utc(getCalendarDate(day)).add(maxDays - 1, 'days'),
@@ -212,12 +212,6 @@ export const RpmReportConfigForm = props => {
               if (!dayIsBlocked && values.startDate && focusedDatePickerInput === 'endDate') {
                 const daysFromStartDate = getCalendarDate(day).diff(getCalendarDate(values.startDate), 'days');
                 dayIsBlocked = daysFromStartDate > maxDays - 1 || daysFromStartDate < 0;
-              }
-
-              // If adjusting the start date, block out all dates 30 days or more prior to, and all dates after, the end date
-              if (!dayIsBlocked && values.endDate && focusedDatePickerInput === 'startDate') {
-                const daysFromEndDate = getCalendarDate(values.endDate).diff(getCalendarDate(day), 'days');
-                dayIsBlocked = daysFromEndDate > maxDays - 1 || daysFromEndDate < 0;
               }
 
               return dayIsBlocked;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.4",
+  "version": "1.78.0-rc.5",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
Small tweak to requirements for [WEB-2945]
Allows any date within the past 59 days to be selected while start date selector is focused.

[WEB-2945]: https://tidepool.atlassian.net/browse/WEB-2945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ