### PR TITLE
[WEB-2955] fix hardcoded rpm end time

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -130,7 +130,7 @@ export const RpmReportConfigForm = props => {
 
       const end = [
         getCalendarDate(values.endDate).format(dateFormat),
-        'T11:59:59.999',
+        'T23:59:59.999',
         moment(values.endDate).tz(values.timezone).endOf('day').toISOString(true).slice(-6),
       ];
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.6",
+  "version": "1.78.0-rc.7",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2955] 
Had accidentally set it to 11:59:59.999 instead of 23:59:59.999

[WEB-2955]: https://tidepool.atlassian.net/browse/WEB-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ