### PR TITLE
[WEB-2961] Print range error fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   - corepack enable
   - yarn set version 3.6.4
-  # https://bugs.launchpad.net/ubuntu/+source/docker-buildx/+bug/1968035/comments/23
-  - wget http://ftp.ubuntu.com/ubuntu/pool/universe/d/docker-buildx/docker-buildx_0.11.2-0ubuntu2_amd64.deb
-  - sudo dpkg -i docker-buildx_0.11.2-0ubuntu2_amd64.deb
 
 addons:
   artifacts:

--- a/app/redux/utils/pendoMiddleware.js
+++ b/app/redux/utils/pendoMiddleware.js
@@ -2,6 +2,7 @@ import get from 'lodash/get';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
 import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import isNull from 'lodash/isNull';
 import bows from 'bows';
 import config from '../../config';
@@ -67,7 +68,11 @@ const pendoMiddleware = (api, win = window) => (storeAPI) => (next) => (action) 
     };
 
     log(actionName, updatedData);
-    dispatch(setPendoData(updatedData));
+
+    if (!isEqual(pendoData, updatedData)) {
+      dispatch(setPendoData(updatedData));
+    }
+
     action(updatedData);
   };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.79.0-web-2959-dep-update.1",
+  "version": "1.79.0-web-2961-pdf-range-error.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
for [WEB-2961] - tracked down the issue to a re-render loop that occurs when trying to fetch additional data during the PDF generation, since patientdata will presume that it re-renders during the PDF request (due to the store state changes throughout the process) and pick up on various states to continue the process. The synchronous setting of pendo data in the middleware after data fetch success will cause a re-render prior to the data success action returning, and during the new re-render, patientdata will try to initialize PDF generation again since it sees that new data has arrived, but hasn't been added to the data worker/processed. This process will loop. By just not setting the pendo data if it hasn't changed, we avoid the loop condition.

[WEB-2961]: https://tidepool.atlassian.net/browse/WEB-2961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ