### PR TITLE
[WEB-2958,WEB-2964] Send active patient filters to RPM report generation endpoint

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import includes from 'lodash/includes';
 import isNull from 'lodash/isNull';
 import map from 'lodash/map';
+import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { useFormik } from 'formik';
 import moment from 'moment-timezone';
@@ -70,7 +71,7 @@ export const exportRpmReport = ({ config, results }) => {
 };
 
 export const RpmReportConfigForm = props => {
-  const { t, api, onFormChange, open, trackMetric, ...boxProps } = props;
+  const { t, api, onFormChange, open, patientFetchOptions, trackMetric, ...boxProps } = props;
   const dispatch = useDispatch();
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const loggedInUserId = useSelector((state) => state.blip.loggedInUserId);
@@ -138,6 +139,15 @@ export const RpmReportConfigForm = props => {
         rawConfig: values,
         startDate: start.join(''),
         endDate: end.join(''),
+
+        // Set any currently applied patient filters so that RPM report patient list matches current view
+        patientFilters: omit(patientFetchOptions, [
+          'offset',
+          'sort',
+          'sortType',
+          'period',
+          'limit',
+        ]),
       };
 
       dispatch(async.fetchRpmReportPatients(api, selectedClinicId, queryOptions));
@@ -271,6 +281,7 @@ RpmReportConfigForm.propTypes = {
   api: PropTypes.object.isRequired,
   onFormChange: PropTypes.func.isRequired,
   open: PropTypes.bool,
+  patientFetchOptions: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   trackMetric: PropTypes.func.isRequired,
 };

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -473,7 +473,7 @@ export const ClinicPatients = (props) => {
   const [tideDashboardConfig] = useLocalStorage('tideDashboardConfig', {});
   const localConfigKey = [loggedInUserId, selectedClinicId].join('|');
   const { showSummaryDashboard, showTideDashboard, showRpmReport } = useFlags();
-  let showSummaryData = showSummaryDashboard || clinic?.entitlements?.summaryDashboard;
+  const showSummaryData = showSummaryDashboard || clinic?.entitlements?.summaryDashboard;
   const showRpmReportUI = showSummaryData && (showRpmReport || clinic?.entitlements?.rpmReport);
   const showTideDashboardUI = showSummaryData && (showTideDashboard || clinic?.entitlements?.tideDashboard);
 
@@ -2556,6 +2556,7 @@ export const ClinicPatients = (props) => {
         <DialogContent sx={{ width: '609px' }} divider>
           <RpmReportConfigForm
             api={api}
+            patientFetchOptions={patientFetchOptions}
             trackMetric={trackMetric}
             onFormChange={handleRpmReporConfigFormChange}
             open={showRpmReportConfigDialog}
@@ -2582,6 +2583,7 @@ export const ClinicPatients = (props) => {
     api,
     fetchingRpmReportPatients.inProgress,
     handleConfigureRpmReportConfirm,
+    patientFetchOptions,
     rpmReportFormContext?.values,
     showRpmReportConfigDialog,
     t,

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -2954,8 +2954,6 @@ export function selectClinic(api, clinicId) {
     const clinic = clinics[clinicId];
 
     if (clinic) {
-      dispatch(sync.setClinicUIDetails(clinicId, clinicUIDetails({ ...clinic })));
-
       const fetchers = {};
 
       if (_.isNil(clinics[clinicId].patientCount)) {

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -2904,12 +2904,25 @@ export function deleteClinicPatientTag(api, clinicId, patientTagId) {
  * @param {String} [options.rawConfig.startDate] - ISO date for first day of the report range
  * @param {String} [options.rawConfig.endDate] - ISO date for last day of the report range
  * @param {String} [options.rawConfig.timezone] - Timezone to use for the report
+ * @param {Object} [options.patientFilters] - Filters used to generate the patient list
+ * @param {String} [options.patientFilters.search] - Search query string
+ * @param {Array} [options.patientFilters.tags] - Array of clinic patient tag IDs
+ * @param {String} [options.patientFilters.cgm.lastUploadDateFrom] - UTC ISO datetime for minimum date of the last cgm upload
+ * @param {String} [options.patientFilters.cgm.lastUploadDateTo] - UTC ISO datetime for maximum date of the last cgm upload
+ * @param {String} [options.patientFilters.cgm.timeInLowPercent] - Comparator and value for time in low percent
+ * @param {String} [options.patientFilters.cgm.timeInHighPercent] - Comparator and value for time in high percent
+ * @param {String} [options.patientFilters.cgm.timeInVeryLowPercent] - Comparator and value for time in very low percent
+ * @param {String} [options.patientFilters.cgm.timeInTargetPercent] - Comparator and value for time in target percent
+ * @param {String} [options.patientFilters.cgm.timeInVeryHighPercent] - Comparator and value for time in very high percent
+ * @param {String} [options.patientFilters.cgm.timeCGMUsePercent] - Comparator and value for time of cgm use percent
+ * @param {String} [options.patientFilters.bgm.lastUploadDateFrom] - UTC ISO datetime for minimum date of the last bgm upload
+ * @param {String} [options.patientFilters.bgm.lastUploadDateTo] - UTC ISO datetime for maximum date of the last bgm upload
  */
 export function fetchRpmReportPatients(api, clinicId, options) {
   return (dispatch) => {
     dispatch(sync.fetchRpmReportPatientsRequest());
 
-    const apiConfigOptions = _.pick(options, ['startDate', 'endDate']);
+    const apiConfigOptions = _.pick(options, ['startDate', 'endDate', 'patientFilters']);
 
     api.clinics.getPatientsForRpmReport(clinicId, apiConfigOptions, (err, results) => {
       if (err) {
@@ -2931,7 +2944,7 @@ export function fetchRpmReportPatients(api, clinicId, options) {
  * then fetches additional clinic metadata asynchronously.
  *
  * @param {Object} api - an instance of the API wrapper
- * @param {String | null} clinicId - Id of the clinic, or null do unset
+ * @param {String | null} clinicId - Id of the clinic, or null to unset
  */
 export function selectClinic(api, clinicId) {
   return (dispatch, getState) => {
@@ -2941,6 +2954,8 @@ export function selectClinic(api, clinicId) {
     const clinic = clinics[clinicId];
 
     if (clinic) {
+      dispatch(sync.setClinicUIDetails(clinicId, clinicUIDetails({ ...clinic })));
+
       const fetchers = {};
 
       if (_.isNil(clinics[clinicId].patientCount)) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.8",
+  "version": "1.78.0-rc.9",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "terser-webpack-plugin": "5.3.9",
     "theme-ui": "0.16.1",
     "tideline": "1.28.0",
-    "tidepool-platform-client": "0.58.0-rc.1",
+    "tidepool-platform-client": "0.58.0-rc.2",
     "tidepool-standard-action": "0.1.1",
     "ua-parser-js": "1.0.36",
     "url-loader": "4.1.1",

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -3348,6 +3348,31 @@ describe('ClinicPatients', () => {
               </Provider>
             );
 
+            // We'll start by filtering the patiet list, to make sure the filters are passed correctly to the RPM report api call
+            const cgmUseFilterTrigger = wrapper.find('#cgm-use-filter-trigger').hostNodes();
+            expect(cgmUseFilterTrigger).to.have.lengthOf(1);
+
+            const cgmUsePopover = () => wrapper.find('#cgmUseFilters').hostNodes();
+            expect(cgmUsePopover().props().style.visibility).to.equal('hidden');
+
+            // Open filters cgmUsePopover
+            cgmUseFilterTrigger.simulate('click');
+            expect(cgmUsePopover().props().style.visibility).to.be.undefined;
+
+            // Ensure filter options present
+            const cgmUseFilterOptions = cgmUsePopover().find('#cgm-use').find('label').hostNodes();
+            expect(cgmUseFilterOptions).to.have.lengthOf(2);
+            expect(cgmUseFilterOptions.at(0).text()).to.equal('Less than 70%');
+            expect(cgmUseFilterOptions.at(0).find('input').props().value).to.equal('<0.7');
+
+            expect(cgmUseFilterOptions.at(1).text()).to.equal('70% or more');
+            expect(cgmUseFilterOptions.at(1).find('input').props().value).to.equal('>=0.7');
+
+            // Apply button disabled until selection made
+            const cgmUseApplyButton = cgmUsePopover().find('#apply-cgm-use-filter').hostNodes();
+            cgmUseFilterOptions.at(1).find('input').last().simulate('change', { target: { name: 'cgm-use', value: '<0.7' } });
+            cgmUseApplyButton.simulate('click');
+
             const rpmReportButton = wrapper.find('#open-rpm-report-config').hostNodes();
             const dialog = () => wrapper.find('Dialog#rpmReportConfig');
 
@@ -3423,6 +3448,7 @@ describe('ClinicPatients', () => {
                 {
                   startDate: sinon.match(value => isString(value)),
                   endDate: sinon.match(value => isString(value)),
+                  patientFilters: { 'cgm.timeCGMUsePercent': '<0.7' },
                 }
               );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -228,6 +228,7 @@ const resolve = {
     lodash: path.resolve('node_modules/lodash'),
     moment: path.resolve('node_modules/moment'),
     'moment-timezone': path.resolve('node_modules/moment-timezone'),
+    process: path.resolve('node_modules/process'),
     react: path.resolve('node_modules/react'),
     'react-addons-update': path.resolve('node_modules/react-addons-update'),
     'react-redux': path.resolve('node_modules/react-redux'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7553,7 +7553,7 @@ __metadata:
     terser-webpack-plugin: 5.3.9
     theme-ui: 0.16.1
     tideline: 1.28.0
-    tidepool-platform-client: 0.58.0-rc.1
+    tidepool-platform-client: 0.58.0-rc.2
     tidepool-standard-action: 0.1.1
     ua-parser-js: 1.0.36
     url-loader: 4.1.1
@@ -23018,15 +23018,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tidepool-platform-client@npm:0.58.0-rc.1":
-  version: 0.58.0-rc.1
-  resolution: "tidepool-platform-client@npm:0.58.0-rc.1"
+"tidepool-platform-client@npm:0.58.0-rc.2":
+  version: 0.58.0-rc.2
+  resolution: "tidepool-platform-client@npm:0.58.0-rc.2"
   dependencies:
     async: 0.9.0
     lodash: 4.17.21
     superagent: 5.2.2
     uuid: 3.1.0
-  checksum: e73469255a173825dab5c374679bf3f13427d18367532303759184e4612436e493df1dba02c1a6fd4c9df64555587b17a937e6fd442011fcdd6d7d28db572125
+  checksum: f4d41072d1c6ef10e60fe1e03a56873e68862463020236aaa52e202bfb6f5551b46258e3eef2ed550ac6bdeb74033a2bf1bec986bfec5908d3c41207184acbad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[WEB-2958] [WEB-2964]

While working on passing the relevant active patient filters to the RPM report endpoint, I noticed it wasn't sending them on initial load.  

This was due to a separate bug/regression [WEB-2964], that has been addressed here as well.

[WEB-2958]: https://tidepool.atlassian.net/browse/WEB-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-2964]: https://tidepool.atlassian.net/browse/WEB-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ