### PR TITLE
[WEB-2969,WEB-2974] Date range selection fix for certain time zones

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -184,21 +184,21 @@ export const RpmReportConfigForm = props => {
   useEffect(() => {
     if (!isEmpty(values.timezone)) {
       let newUtcDayShift;
-      const utcToday = moment.utc().tz('UTC');
-      const timezoneToday = moment.utc().tz(values.timezone);
+      const utcNow = moment.utc().tz('UTC');
+      const timezoneNow = moment.utc().tz(values.timezone);
 
       // If the current calendar date for the selected timezone has shifted to the next day ahead of
       // UTC, or UTC has shifted ahead for time zones on the other side of UTC, we need to track
       // the day shift so that we can apply it to calendar date availabilty and validation logic
-      if (utcToday.dayOfYear() === timezoneToday.dayOfYear()) {
+      if (utcNow.dayOfYear() === timezoneNow.dayOfYear()) {
         // no date shift needed on available calendar dates
         newUtcDayShift = 0;
-      } else if (utcToday.year() === timezoneToday.year()) {
+      } else if (utcNow.year() === timezoneNow.year()) {
         // same calendar year, so we shift a day in the appropriate direction
-        newUtcDayShift = timezoneToday.dayOfYear() > utcToday.dayOfYear() ? 1 : -1;
+        newUtcDayShift = timezoneNow.dayOfYear() > utcNow.dayOfYear() ? 1 : -1;
       } else {
         // rolled over into new year, so we shift a day in the appropriate direction
-        newUtcDayShift = timezoneToday.year() > utcToday.year() ? 1 : -1;
+        newUtcDayShift = timezoneNow.year() > utcNow.year() ? 1 : -1;
       }
 
       if (utcDayShift !== newUtcDayShift) {

--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -90,6 +90,16 @@ export const RpmReportConfigForm = props => {
   const [utcDayShift, setUtcDayShift] = useState(0);
   const today = moment.utc().startOf('day');
 
+  function setMomentToUTC() {
+    log('Setting moment to default to UTC timezone');
+    moment.tz.setDefault('UTC');
+  }
+
+  function setMomentToLocal() {
+    log('Setting moment back to default local timezone of', browserTimezone)
+    moment.tz.setDefault();
+  }
+
   const defaultDates = () => {
     return {
       startDate: moment.utc(today).subtract(maxDays - 1, 'days').add(utcDayShift, 'days'),
@@ -108,7 +118,6 @@ export const RpmReportConfigForm = props => {
       timezone: includes(map(timezoneOptions, 'value'), config?.timezone) ? config.timezone : fallbackTimezone,
     };
   }
-
 
   const formikContext = useFormik({
     initialValues: defaultFormValues(config?.[localConfigKey]),
@@ -219,16 +228,6 @@ export const RpmReportConfigForm = props => {
       setMomentToLocal();
     };
   }, []);
-
-  function setMomentToUTC() {
-    log('Setting moment to default to UTC timezone');
-    moment.tz.setDefault('UTC');
-  }
-
-  function setMomentToLocal() {
-    log('Setting moment back to default local timezone of', browserTimezone)
-    moment.tz.setDefault();
-  }
 
   function setDates(dates) {
     setFieldValue('startDate', moment.isMoment(dates.startDate) ? moment.utc(dates.startDate).format(dateFormat) : '');

--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -86,6 +86,7 @@ export const RpmReportConfigForm = props => {
   const dateFormat = 'YYYY-MM-DD'
   const maxDays = 30;
   const maxDaysInPast = 59;
+  const browserTimezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   // React-dates automatically assumes the local browser time zone when dealing with dates.
   // We want to grab only the YYYY-MM-DD portion, and construct a UTC date with it.
@@ -109,7 +110,7 @@ export const RpmReportConfigForm = props => {
 
   function defaultFormValues(config) {
     const { startDate, endDate } = defaultDates();
-    let fallbackTimezone = clinic?.timezone || new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let fallbackTimezone = clinic?.timezone || browserTimezone;
     if (!includes(map(timezoneOptions, 'value'), fallbackTimezone)) fallbackTimezone = '';
 
     return {
@@ -210,7 +211,7 @@ export const RpmReportConfigForm = props => {
   }
 
   function setMomentToLocal() {
-    log('Setting moment back to default local timezone of', moment.tz.guess(true), new Intl.DateTimeFormat().resolvedOptions().timeZone)
+    log('Setting moment back to default local timezone of', browserTimezone)
     moment.tz.setDefault();
   }
 

--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import includes from 'lodash/includes';
+import isEmpty from 'lodash/isEmpty';
 import isNull from 'lodash/isNull';
 import map from 'lodash/map';
 import omit from 'lodash/omit';
@@ -149,6 +150,10 @@ export const RpmReportConfigForm = props => {
           'limit',
         ]),
       };
+
+      if (isEmpty(queryOptions.patientFilters.search)) {
+        delete queryOptions.patientFilters.search;
+      }
 
       dispatch(async.fetchRpmReportPatients(api, selectedClinicId, queryOptions));
 

--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -149,7 +149,6 @@ export const RpmReportConfigForm = props => {
           'offset',
           'sort',
           'sortType',
-          'period',
           'limit',
         ]),
       };

--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -271,7 +271,6 @@ export const RpmReportConfigForm = props => {
             minDate={moment.utc(today).add(utcDayShift, 'days').subtract(maxDaysInPast, 'days')}
             isDayBlocked={day => {
               const daysFromToday = moment.utc(today).endOf('day').add(utcDayShift, 'days').diff(moment.utc(day), 'days', true);
-              console.log('day', day.format(dateFormat), daysFromToday);
 
               // By default block all future dates, and all days prior to 59 days ago
               let dayIsBlocked = daysFromToday < 0 || daysFromToday >= maxDaysInPast;

--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -456,7 +456,7 @@ export const rpmReportConfigSchema = yup.object().shape({
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment.utc().subtract(58, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
+    .min(moment.utc().subtract(59, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
     .max(moment.utc().subtract(1, 'day').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
     .required(t('Please select a start date')),
   endDate: yup.date()

--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -450,24 +450,24 @@ export const tideDashboardConfigSchema = yup.object().shape({
     .min(1, t('Please select at least one tag')),
 });
 
-export const rpmReportConfigSchema = yup.object().shape({
+export const rpmReportConfigSchema = (utcDayShift = 0) => yup.object().shape({
   startDate: yup.date()
     .transform((value, originalValue) => {
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment.utc().subtract(59, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
-    .max(moment.utc().subtract(1, 'day').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
+    .min(moment.utc().subtract(58, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
+    .max(moment.utc().subtract(1, 'day').add(utcDayShift, 'days').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
     .required(t('Please select a start date')),
   endDate: yup.date()
     .transform((value, originalValue) => {
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment.utc().subtract(58, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 58 days'))
+    .min(moment.utc().subtract(57, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 58 days'))
     .max(moment.utc().endOf('day').format(dateFormat), t('Please enter an end date no later than today'))
     .when('startDate', ([startDate], schema) => schema
-      .max(moment.min([moment.utc(startDate).add(29, 'days'), moment.utc()]).endOf('day').format(dateFormat), t('End date must be within 30 days of the start date and no later than today'))
+      .max(moment.min([moment.utc(startDate).add(29, 'days'), moment.utc()]).endOf('day').add(utcDayShift, 'days').format(dateFormat), t('End date must be within 30 days of the start date and no later than today'))
     )
     .required(t('Please select an end date')),
   timezone: yup.string().oneOf(map(timezoneOptions, 'value')).required(t('Please select a timezone')),

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -1053,15 +1053,15 @@ export const ClinicPatients = (props) => {
   }, [api, dispatch, prefixPopHealthMetric, selectedClinicId, selectedPatient?.id, trackMetric]);
 
   function handlePatientFormChange(formikContext) {
-    setPatientFormContext({...formikContext});
+    setPatientFormContext({ ...formikContext });
   }
 
   function handleTideDashboardConfigFormChange(formikContext) {
-    setTideDashboardFormContext({...formikContext});
+    setTideDashboardFormContext({ ...formikContext });
   }
 
-  function handleRpmReporConfigFormChange(formikContext) {
-    setRpmReportFormContext({...formikContext});
+  function handleRpmReporConfigFormChange(formikContext, utcDayShift) {
+    setRpmReportFormContext({ ...formikContext, utcDayShift });
   }
 
   function handleSearchChange(event) {
@@ -2603,7 +2603,7 @@ export const ClinicPatients = (props) => {
             variant="primary"
             onClick={handleConfigureRpmReportConfirm}
             processing={fetchingRpmReportPatients.inProgress}
-            disabled={!fieldsAreValid(keys(rpmReportFormContext?.values), rpmReportConfigSchema, rpmReportFormContext?.values)}
+            disabled={!fieldsAreValid(keys(rpmReportFormContext?.values), rpmReportConfigSchema(rpmReportFormContext?.utcDayShift), rpmReportFormContext?.values)}
           >
             {t('Generate Report')}
           </Button>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.10",
+  "version": "1.78.0-rc.11",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/app/core/clinicUtils.test.js
+++ b/test/unit/app/core/clinicUtils.test.js
@@ -699,9 +699,9 @@ describe('clinicUtils', function() {
 
   describe('rpmReportConfigSchema', () => {
     it('should return a yup schema for rpm report config fields', () => {
-      expect(clinicUtils.rpmReportConfigSchema).to.be.an('object');
+      expect(clinicUtils.rpmReportConfigSchema()).to.be.an('object');
 
-      expect(clinicUtils.rpmReportConfigSchema._nodes).to.be.an('array').and.have.members([
+      expect(clinicUtils.rpmReportConfigSchema()._nodes).to.be.an('array').and.have.members([
         'startDate',
         'endDate',
         'timezone',


### PR DESCRIPTION
[WEB-2969]

There were a few timezone-related bugs that surfaced for users ahead of UTC time.  These were addressed in 2 main ways (I've added some comments to sections of code as I saw fit, but wanted to call them out here too):

1. I've set the global `moment` object to default to "UTC" whenever the rpm form modal is open.  It automatically resets to the default whenever the modal is closed, or the component unmounts.  [This issue](https://github.com/react-dates/react-dates/issues/1138#issuecomment-870240972) (among some others I found while debugging how to get `react-dates` to work with UTC internally) is one I came across earlier in development, and had hoped to avoid, but it's necessary to get this working as designed, and has the benefit of removing some workaround code cruft I had in place.
2. We needed the selectable dates to be relative to the timezone chosen in the UI.  What I have is a `utcDayShift` that gets tracked when the timezone changes, and adjusts the available chart dates appropriately, whether it is currently a calendar date ahead or behind of UTC.  This day shift also gets passed to the schema validation whenever the timezone changes.

Also addresses [WEB-2974] by deleting empty `search` string parameters from the report config

[WEB-2969]: https://tidepool.atlassian.net/browse/WEB-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WEB-2974]: https://tidepool.atlassian.net/browse/WEB-2974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ