### PR TITLE
[WEB-2969] Apply utc day shifts to each report date check

### DIFF
--- a/app/core/clinicUtils.js
+++ b/app/core/clinicUtils.js
@@ -456,18 +456,18 @@ export const rpmReportConfigSchema = (utcDayShift = 0) => yup.object().shape({
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment.utc().subtract(58, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
-    .max(moment.utc().subtract(1, 'day').add(utcDayShift, 'days').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
+    .min(moment.utc().add(utcDayShift, 'days').subtract(58, 'days').startOf('day').format(dateFormat), t('Please enter a start date within the last 59 days'))
+    .max(moment.utc().add(utcDayShift, 'days').subtract(1, 'day').startOf('day').format(dateFormat), t('Please enter a start date prior to today'))
     .required(t('Please select a start date')),
   endDate: yup.date()
     .transform((value, originalValue) => {
       value = moment(originalValue, dateFormat, true);
       return value.isValid() ? value.toDate() : undefined;
     })
-    .min(moment.utc().subtract(57, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 58 days'))
-    .max(moment.utc().endOf('day').format(dateFormat), t('Please enter an end date no later than today'))
+    .min(moment.utc().add(utcDayShift, 'days').subtract(57, 'days').endOf('day').format(dateFormat), t('Please enter an end date within the last 58 days'))
+    .max(moment.utc().add(utcDayShift, 'days').endOf('day').format(dateFormat), t('Please enter an end date no later than today'))
     .when('startDate', ([startDate], schema) => schema
-      .max(moment.min([moment.utc(startDate).add(29, 'days'), moment.utc()]).endOf('day').add(utcDayShift, 'days').format(dateFormat), t('End date must be within 30 days of the start date and no later than today'))
+      .max(moment.min([moment.utc(startDate).add(29, 'days'), moment.utc().add(utcDayShift, 'days')]).endOf('day').format(dateFormat), t('End date must be within 30 days of the start date and no later than today'))
     )
     .required(t('Please select an end date')),
   timezone: yup.string().oneOf(map(timezoneOptions, 'value')).required(t('Please select a timezone')),

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.11",
+  "version": "1.78.0-rc.12",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2969]
One more small PR - I noticed this evening once ET went a day behind the UTC date that I had missed applying the utc date shift properly to some of the validation fields.

[WEB-2969]: https://tidepool.atlassian.net/browse/WEB-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ