### PR TITLE
[WEB-2964] Fix default sort on internal navigation

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -490,7 +490,7 @@ export const ClinicPatients = (props) => {
       // by (unless we already have the showDashboard entitlements figured out).
       // This prevents the a premature patient fetch to begin with an incorrect default sort.
       if (!isFirstRender || (isBoolean(showSummaryDashboard) && isBoolean(clinic?.entitlements?.summaryDashboard))) {
-        options.sort = showSummaryData ? '-lastUploadDate' : '+fullName';
+        options.sort = showSummaryData || showSummaryDashboard || clinic?.entitlements?.summaryDashboard ? '-lastUploadDate' : '+fullName';
         options.sortType = 'cgm';
       }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.12",
+  "version": "1.78.0-rc.13",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2964]

The default sort was not being correctly set when navigating back to the patient list for clinics showing the summary table

[WEB-2964]: https://tidepool.atlassian.net/browse/WEB-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ