### PR TITLE
[WEB-2995] Fix day prior to start date not always being disabled

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -276,7 +276,7 @@ export const RpmReportConfigForm = props => {
 
               // If adjusting the end date, block out all dates 30 days or more beyond, and all dates prior to, the start date
               if (!dayIsBlocked && values.startDate && focusedDatePickerInput === 'endDate') {
-                const daysFromStartDate = day.diff(values.startDate, 'days');
+                const daysFromStartDate = moment.utc(day).diff(moment.utc(values.startDate), 'days', true);
                 dayIsBlocked = daysFromStartDate > maxDays - 1 || daysFromStartDate < 0;
               }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.13",
+  "version": "1.78.0-rc.14",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2995]

When I removed the `getCalendarDate` method to simplify the code in the previous PR, I missed wrapping this one check in `moment.utc` like I had with all other, and, more importantly, needed the precision set to `true`.

Technically, the `moment.utc` wrapping could be left out, since the global moment should default to UTC while the form is open, but I want it to be consistent with the others, and explicit that we're dealing exclusively with UTC when glancing at the code.

[WEB-2995]: https://tidepool.atlassian.net/browse/WEB-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ