### PR TITLE
[WEB-2995] Small tweak to blocked end date range when end date input is selected

### DIFF
--- a/app/components/clinic/RpmReportConfigForm.js
+++ b/app/components/clinic/RpmReportConfigForm.js
@@ -172,6 +172,7 @@ export const RpmReportConfigForm = props => {
     values,
     setValues,
     validateForm,
+    resetForm,
   } = formikContext;
 
   // Set to default state when dialog is newly opened
@@ -187,6 +188,7 @@ export const RpmReportConfigForm = props => {
     } else {
       // Reset global moment to use local/browser timezone when config modal closes
       setMomentToLocal();
+      resetForm();
     }
   }, [open]);
 
@@ -277,7 +279,7 @@ export const RpmReportConfigForm = props => {
               // If adjusting the end date, block out all dates 30 days or more beyond, and all dates prior to, the start date
               if (!dayIsBlocked && values.startDate && focusedDatePickerInput === 'endDate') {
                 const daysFromStartDate = moment.utc(day).diff(moment.utc(values.startDate), 'days', true);
-                dayIsBlocked = daysFromStartDate > maxDays - 1 || daysFromStartDate < 0;
+                dayIsBlocked = daysFromStartDate >= maxDays || daysFromStartDate < 0;
               }
 
               return dayIsBlocked;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.78.0-rc.14",
+  "version": "1.78.0-rc.15",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-2995] Noticed that there was a similar intermittent error on the end date.

Also, resetting the form whenever the modal closes so it will automatically reset the default dates when it next opens (fixes a very remote UI edge case where a user can change timezone that allows a future date to be selected, then closes the modal, and reopens it in a non-future-date time zone).

[WEB-2995]: https://tidepool.atlassian.net/browse/WEB-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ