### PR TITLE
Only call generateAGPImagesSucces if no errors were thrown

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -920,6 +920,7 @@ export const PatientDataClass = createReactClass({
 
   generateAGPImages: async function(props = this.props, reportTypes = []) {
     const promises = [];
+    let errored = false
 
     await _.each(reportTypes, async reportType => {
       let images;
@@ -927,6 +928,7 @@ export const PatientDataClass = createReactClass({
       try{
         images = await vizUtils.agp.generateAGPFigureDefinitions({ ...props.pdf.data?.[reportType] });
       } catch(e) {
+        errored = true
         return props.generateAGPImagesFailure(e);
       }
 
@@ -955,7 +957,7 @@ export const PatientDataClass = createReactClass({
       }, {});
 
       props.generateAGPImagesSuccess(processedImages);
-    } else {
+    } else if (!errored) {
       props.generateAGPImagesSuccess(results);
     }
   },


### PR DESCRIPTION
I realized that one of the tests was broken due to firing the generate PDF success handler even if an error was thrown.  Also, the tests weren't always firing in the anticipated order which caused indeterminite results.

Once approved, I'll also back-merge this to `develop` so that we have it in a passing state