### PR TITLE
[WEB-2853] Use latest datum timezone offset to determine ideal timezone for display

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -292,7 +292,7 @@ utils.roundBgTarget = (value, units) => {
   return parseFloat((nearest * Math.round(value / nearest)).toFixed(precision));
 }
 
-utils.getTimePrefsForDataProcessing = (latestUpload, queryParams) => {
+utils.getTimePrefsForDataProcessing = (latestUpload, latestDiabetesDatum, queryParams) => {
   var timePrefsForTideline;
   var browserTimezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
 
@@ -331,22 +331,33 @@ utils.getTimePrefsForDataProcessing = (latestUpload, queryParams) => {
     setNewTimePrefs(queryParams.timezone, false);
     console.log('Displaying in timezone from query params:', queryParams.timezone);
   }
-  else if (!_.isEmpty(latestUpload) && (!_.isEmpty(latestUpload.timezone) || _.isFinite(latestUpload.timezoneOffset))) {
-    let timezone = latestUpload.timezone;
-
-    // If timezone is empty, set to the nearest Etc/GMT timezone using the timezoneOffset
-    if (_.isEmpty(timezone)) {
+  else if (_.isFinite(latestDiabetesDatum?.timezoneOffset)) {
+    // If the timeone on the latest upload record at the time of the latest diabetes datum has the
+    // same UTC offset, we use that, since it will also have DST changeover info available.
+    if (!_.isEmpty(latestUpload?.timezone)) {
+      const uploadTimezoneOffsetAtLatestDiabetesTime = moment.utc(latestDiabetesDatum.normalTime).tz(latestUpload.timezone).utcOffset();
+      if (uploadTimezoneOffsetAtLatestDiabetesTime === latestDiabetesDatum.timezoneOffset) {
+        setNewTimePrefs(latestUpload.timezone)
+        console.log('Defaulting to display in timezone of most recent upload at', latestUpload.normalTime, latestUpload.timezone);
+      }
+    }
+    // Otherwise, we calculate the nearest 'Etc/GMT' timezone from the timezone offset of the latest diabetes datum.
+    if(!timePrefsForTideline) {
       // GMT offsets signs in Etc/GMT timezone names are reversed from the actual offset
-      const offsetSign = Math.sign(latestUpload.timezoneOffset) === -1 ? '+' : '-';
-      const offsetDuration = moment.duration(Math.abs(latestUpload.timezoneOffset), 'minutes');
+      const offsetSign = Math.sign(latestDiabetesDatum.timezoneOffset) === -1 ? '+' : '-';
+      const offsetDuration = moment.duration(Math.abs(latestDiabetesDatum.timezoneOffset), 'minutes');
       let offsetHours = offsetDuration.hours();
       const offsetMinutes = offsetDuration.minutes();
       if (offsetMinutes >= 30) offsetHours += 1;
-      timezone = `Etc/GMT${offsetSign}${offsetHours}`;
+      const nearestTimezone = `Etc/GMT${offsetSign}${offsetHours}`;
+      setNewTimePrefs(nearestTimezone);
+      console.log('Defaulting to display in the nearest timezone of most recent diabetes datum timezone offset at', latestDiabetesDatum.normalTime, nearestTimezone);
     }
-
-    setNewTimePrefs(timezone);
-    console.log('Defaulting to display in timezone of most recent upload at', latestUpload.normalTime, timezone);
+  }
+  // Fallback to latest upload timezone if there is no diabetes data with timezone offsets
+  else if (!_.isEmpty(latestUpload) && (!_.isEmpty(latestUpload.timezone))) {
+    setNewTimePrefs(latestUpload.timezone);
+    console.log('Defaulting to display in timezone of most recent upload at', latestUpload.normalTime, latestUpload.timezone);
   }
   else if (browserTimezone) {
     setNewTimePrefs(browserTimezone);

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -59,6 +59,7 @@ import { Box, Flex } from 'theme-ui';
 import Checkbox from '../../components/elements/Checkbox';
 import PopoverLabel from '../../components/elements/PopoverLabel';
 import { Paragraph2 } from '../../components/elements/FontStyles';
+import { DIABETES_DATA_TYPES } from '../../core/constants';
 
 const { Loader } = vizComponents;
 const { getLocalizedCeiling, getTimezoneFromTimePrefs } = vizUtils.datetime;
@@ -1704,7 +1705,16 @@ export const PatientDataClass = createReactClass({
       let timePrefs = this.state.timePrefs;
       if (_.isEmpty(timePrefs)) {
         const latestUpload = _.get(nextProps, 'data.metaData.latestDatumByType.upload');
-        timePrefs = utils.getTimePrefsForDataProcessing(latestUpload, this.props.queryParams);
+
+        const latestDiabetesDatum = _.maxBy(
+          _.filter(
+            _.values(_.get(nextProps, 'data.metaData.latestDatumByType', {})),
+            ({ type }) => _.includes(DIABETES_DATA_TYPES, type)
+          ),
+          'time'
+        );
+
+        timePrefs = utils.getTimePrefsForDataProcessing(latestUpload, latestDiabetesDatum, this.props.queryParams);
         stateUpdates.timePrefs = timePrefs;
       }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.81.0-rc.3",
+  "version": "1.81.0-rc.4",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/utils/utils.test.js
+++ b/test/unit/utils/utils.test.js
@@ -397,14 +397,15 @@ describe('utils', () => {
   });
 
   describe('getTimePrefsForDataProcessing', () => {
-    const latestUpload = { type: 'upload', time: '2018-02-02T00:00:00.000Z', timezone: 'US/Pacific' };
+    const latestUpload = { type: 'upload', normalTime: '2018-02-02T00:00:00.000Z', timezone: 'US/Pacific' };
+    const latestDiabetesDatum = { type: 'cbg', normalTime: '2018-02-02T01:00:00.000Z', timezoneOffset: -480 }; // US/Pacific will have an 8 hour offset (480 mins) at this time of year
 
     const queryParams = {};
 
     context('Timezone provided from queryParam', () => {
       it('should set a valid timezone from a query param', () => {
         const queryParamsWithValidTimezone = _.assign({}, queryParams, { timezone: 'UTC' });
-        expect(utils.getTimePrefsForDataProcessing(latestUpload, queryParamsWithValidTimezone)).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(latestUpload, latestDiabetesDatum, queryParamsWithValidTimezone)).to.eql({
           timezoneAware: true,
           timezoneName: 'UTC',
         });
@@ -419,23 +420,7 @@ describe('utils', () => {
 
         const queryParamsWithInvalidTimezone = _.assign({}, queryParams, { timezone: 'invalid' });
 
-        expect(utils.getTimePrefsForDataProcessing(latestUpload, queryParamsWithInvalidTimezone)).to.eql({
-          timezoneAware: false,
-        });
-
-        DateTimeFormatStub.restore();
-      });
-
-      it('should fall back to timezone-naive display time when given an invalid timezone and cannot determine timezone from browser', () => {
-        const DateTimeFormatStub = sinon.stub(Intl, 'DateTimeFormat').returns({
-          resolvedOptions: () => {
-            return { timeZone: undefined };
-          },
-        });
-
-        const queryParamsWithInvalidTimezone = _.assign({}, queryParams, { timezone: 'invalid' });
-
-        expect(utils.getTimePrefsForDataProcessing(latestUpload, queryParamsWithInvalidTimezone)).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(latestUpload, latestDiabetesDatum, queryParamsWithInvalidTimezone)).to.eql({
           timezoneAware: false,
         });
 
@@ -444,8 +429,22 @@ describe('utils', () => {
     });
 
     context('Timezone provided from most recent upload', () => {
-      it('should set a valid timezone from `latestUpload.timezone`', () => {
-        expect(utils.getTimePrefsForDataProcessing(latestUpload, queryParams)).to.eql({
+      it('should set a valid timezone from `latestUpload.timezone` if latest diabetes datum is undefined', () => {
+        expect(utils.getTimePrefsForDataProcessing(latestUpload, undefined, queryParams)).to.eql({
+          timezoneAware: true,
+          timezoneName: 'US/Pacific',
+        });
+      });
+
+      it('should set a valid timezone from `latestUpload.timezone` if latest diabetes datum does not have a timezoneOffset', () => {
+        expect(utils.getTimePrefsForDataProcessing(latestUpload, { ...latestDiabetesDatum, timezoneOffset: undefined }, queryParams)).to.eql({
+          timezoneAware: true,
+          timezoneName: 'US/Pacific',
+        });
+      });
+
+      it('should set a valid timezone from `latestUpload.timezone` if latest diabetes datum has a timezoneOffset that matches that of the latest upload timezone', () => {
+        expect(utils.getTimePrefsForDataProcessing(latestUpload, latestDiabetesDatum, queryParams)).to.eql({
           timezoneAware: true,
           timezoneName: 'US/Pacific',
         });
@@ -454,7 +453,7 @@ describe('utils', () => {
       it('should fall back to browser time when given an invalid timezone', () => {
         const dataWithInvalidTimezone = {
           type: 'upload',
-          time: '2018-02-10T00:00:00.000Z',
+          normalTime: '2018-02-10T00:00:00.000Z',
           timezone: 'invalid',
         };
 
@@ -464,7 +463,7 @@ describe('utils', () => {
           },
         });
 
-        expect(utils.getTimePrefsForDataProcessing(dataWithInvalidTimezone, queryParams)).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(dataWithInvalidTimezone, {}, queryParams)).to.eql({
           timezoneAware: true,
           timezoneName: 'Europe/Budapest',
         });
@@ -475,7 +474,7 @@ describe('utils', () => {
       it('should fall back to timezone-naive display time when given an invalid timezone and cannot determine timezone from browser', () => {
         const dataWithInvalidTimezone = {
           type: 'upload',
-          time: '2018-02-10T00:00:00.000Z',
+          normalTime: '2018-02-10T00:00:00.000Z',
           timezone: 'invalid',
         };
 
@@ -485,7 +484,7 @@ describe('utils', () => {
           },
         });
 
-        expect(utils.getTimePrefsForDataProcessing(dataWithInvalidTimezone, queryParams)).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(dataWithInvalidTimezone, undefined, queryParams)).to.eql({
           timezoneAware: false,
         });
 
@@ -493,11 +492,13 @@ describe('utils', () => {
       });
     });
 
-    context('Timezone offset provided from most recent upload', () => {
-      it('should set a valid timezone from `latestUpload.timezoneOffset`', () => {
+    context('Timezone offset provided from most recent diabetes datum', () => {
+      it('should set a valid timezone from `latestDiabetesDatum.timezoneOffset`', () => {
         expect(utils.getTimePrefsForDataProcessing({
           ...latestUpload,
           timezone: undefined,
+        }, {
+          ...latestDiabetesDatum,
           timezoneOffset: -420,
         }, queryParams)).to.eql({
           timezoneAware: true,
@@ -508,6 +509,8 @@ describe('utils', () => {
         expect(utils.getTimePrefsForDataProcessing({
           ...latestUpload,
           timezone: undefined,
+        }, {
+          ...latestDiabetesDatum,
           timezoneOffset: -(420 + 29),
         }, queryParams)).to.eql({
           timezoneAware: true,
@@ -517,6 +520,8 @@ describe('utils', () => {
         expect(utils.getTimePrefsForDataProcessing({
           ...latestUpload,
           timezone: undefined,
+        }, {
+          ...latestDiabetesDatum,
           timezoneOffset: -(420 + 30),
         }, queryParams)).to.eql({
           timezoneAware: true,
@@ -524,10 +529,10 @@ describe('utils', () => {
         });
       });
 
-      it('should fall back to browser time when given an invalid timezone', () => {
-        const dataWithInvalidTimezone = {
-          type: 'upload',
-          time: '2018-02-10T00:00:00.000Z',
+      it('should fall back to browser time when given an invalid timezone offset', () => {
+        const datumWithInvalidTimezoneOffset = {
+          type: 'cbg',
+          normalTime: '2018-02-10T00:00:00.000Z',
           timezoneOffset: -1000, // Too large: will not match an Etc/GMT timezone
         };
 
@@ -537,7 +542,7 @@ describe('utils', () => {
           },
         });
 
-        expect(utils.getTimePrefsForDataProcessing(dataWithInvalidTimezone, queryParams)).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(undefined, datumWithInvalidTimezoneOffset, queryParams)).to.eql({
           timezoneAware: true,
           timezoneName: 'Europe/Budapest',
         });
@@ -545,10 +550,10 @@ describe('utils', () => {
         DateTimeFormatStub.restore();
       });
 
-      it('should fall back to timezone-naive display time when given an invalid timezone and cannot determine timezone from browser', () => {
-        const dataWithInvalidTimezone = {
-          type: 'upload',
-          time: '2018-02-10T00:00:00.000Z',
+      it('should fall back to timezone-naive display time when given an invalid timezone offset and cannot determine timezone from browser', () => {
+        const datumWithInvalidTimezoneOffset = {
+          type: 'cbg',
+          normalTime: '2018-02-10T00:00:00.000Z',
           timezoneOffset: -1000, // Too large: will not match an Etc/GMT timezone
         };
 
@@ -558,7 +563,7 @@ describe('utils', () => {
           },
         });
 
-        expect(utils.getTimePrefsForDataProcessing(dataWithInvalidTimezone, queryParams)).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(undefined, datumWithInvalidTimezoneOffset, queryParams)).to.eql({
           timezoneAware: false,
         });
 
@@ -574,7 +579,7 @@ describe('utils', () => {
           },
         });
 
-        expect(utils.getTimePrefsForDataProcessing([], {})).to.eql({
+        expect(utils.getTimePrefsForDataProcessing(undefined, undefined, {})).to.eql({
           timezoneAware: true,
           timezoneName: 'Europe/Budapest',
         });
@@ -589,7 +594,7 @@ describe('utils', () => {
           },
         });
 
-        expect(utils.getTimePrefsForDataProcessing([], {})).to.be.undefined;
+        expect(utils.getTimePrefsForDataProcessing(undefined, undefined, {})).to.be.undefined;
 
         DateTimeFormatStub.restore();
       });


### PR DESCRIPTION
[WEB-2853]

New PR to address a change to the done criteria (bullet pt 2)

We want to use the timezone offset of the latest diabetes datum to determine the ideal timezone for display, and only use the latest upload timezone as a fallback for that.

[WEB-2853]: https://tidepool.atlassian.net/browse/WEB-2853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ