### PR TITLE
[WEB-3022] Implement Palmtree guardrails

### DIFF
--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -617,7 +617,7 @@ export const PrescriptionForm = props => {
     }
   }, [stepAsyncState.complete]);
 
-  const stepperProps = useMemo(() => ({
+  const stepperProps = {
     activeStep,
     activeSubStep,
     'aria-label': t('New Prescription Form'),
@@ -627,7 +627,6 @@ export const PrescriptionForm = props => {
     id: stepperId,
     location: get(window, 'location', location),
     onStepChange: (newStep) => {
-      if (!formPersistReady) return;
       setStepAsyncState(asyncStates.initial);
       if (isSingleStepEdit) {
         setSingleStepEditValues(values)
@@ -649,12 +648,7 @@ export const PrescriptionForm = props => {
         justifyContent: 'center',
       }
     },
-  }), [
-    formPersistReady,
-    activeStep,
-    activeSubStep,
-    steps,
-  ]);
+  };
 
   const title = isNewPrescriptionFlow() ? t('Create New Prescription') : t('Prescription: {{name}}', {
     name: [values.firstName, values.lastName].join(' '),

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import { push } from 'connected-react-router';
 import bows from 'bows';
 import moment from 'moment';
@@ -48,7 +49,7 @@ import i18next from '../../core/language';
 import { useToasts } from '../../providers/ToastProvider';
 import { Headline } from '../../components/elements/FontStyles';
 import { borders } from '../../themes/baseTheme';
-import { useIsFirstRender } from '../../core/hooks';
+import { useIsFirstRender, useLocalStorage } from '../../core/hooks';
 import * as actions from '../../redux/actions';
 import { components as vizComponents } from '@tidepool/viz';
 
@@ -271,17 +272,22 @@ export const PrescriptionForm = props => {
 
   const dispatch = useDispatch();
   const formikContext = useFormikContext();
+  const { id } = useParams();
+  const isNewPrescriptionFlow = () => isEmpty(id);
 
   const {
     handleSubmit,
     resetForm,
     setFieldValue,
+    setValues,
     setStatus,
     status,
     values,
   } = formikContext;
 
   const isFirstRender = useIsFirstRender();
+  const storageKey = 'prescriptionForm';
+  const [storedValues, setStoredValues] = useLocalStorage(storageKey);
   const { set: setToast } = useToasts();
   const loggedInUserId = useSelector((state) => state.blip.loggedInUserId);
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
@@ -325,7 +331,6 @@ export const PrescriptionForm = props => {
   const params = () => new URLSearchParams(location.search);
   const activeStepParamKey = `${stepperId}-step`;
   const activeStepsParam = params().get(activeStepParamKey);
-  const storageKey = 'prescriptionForm';
 
   const [formPersistReady, setFormPersistReady] = useState(false);
   const [stepAsyncState, setStepAsyncState] = useState(asyncStates.initial);
@@ -337,7 +342,6 @@ export const PrescriptionForm = props => {
   const isSingleStepEdit = !!pendingStep.length;
   const validationFields = [ ...stepValidationFields ];
   const isLastStep = () => activeStep === validationFields.length - 1;
-  const isNewPrescription = isEmpty(get(values, 'id'));
 
   const handlers = {
     activeStepUpdate: ([step, subStep], fromStep = [], initialFocusedInput) => {
@@ -424,10 +428,10 @@ export const PrescriptionForm = props => {
         { outputFormat: 'hex' }
       );
 
-      if (isNewPrescription) {
-        dispatch(actions.async.createPrescription(api, selectedClinicId, prescriptionAttributes));
-      } else {
+      if (values.id) {
         dispatch(actions.async.createPrescriptionRevision(api, selectedClinicId, prescriptionAttributes, values.id));
+      } else {
+        dispatch(actions.async.createPrescription(api, selectedClinicId, prescriptionAttributes));
       }
     },
   };
@@ -501,8 +505,25 @@ export const PrescriptionForm = props => {
   }
 
   useEffect(() => {
+    let initialValues = { ...values }
+
+    // Hydrate the locally stored values only in the following cases, allowing us to persist data
+    // entered in form substeps but not yet saved to the database
+    // 1. It's a new prescription and there is no locally stored id, and there aren't step and substep query params
+    // 2. We're editing an existing prescription, and the locally stored id matches the id in the url param
+    if (
+      (isNewPrescriptionFlow() && !storedValues?.id && (!isUndefined(activeStep) || !isUndefined(activeSubStep))) ||
+      (id && id === storedValues?.id)
+    ) {
+      initialValues = { ...values, ...storedValues };
+      setValues(initialValues);
+    }
+
+    // After hydrating any relevant values, we delete the localStorage values so formikPersist has a clean start
+    delete localStorage[storageKey];
+
     // Determine the latest incomplete step, and default to starting there
-    if (isEditable && (isUndefined(activeStep) || isUndefined(activeSubStep))) {
+    if (isEditable) {
       let firstInvalidStep;
       let firstInvalidSubStep;
       let currentStep = 0;
@@ -510,7 +531,7 @@ export const PrescriptionForm = props => {
 
       while (isUndefined(firstInvalidStep) && currentStep < validationFields.length) {
         while (currentSubStep < validationFields[currentStep].length) {
-          if (!fieldsAreValid(validationFields[currentStep][currentSubStep], schema, values)) {
+          if (!fieldsAreValid(validationFields[currentStep][currentSubStep], schema, initialValues)) {
             firstInvalidStep = currentStep;
             firstInvalidSubStep = currentSubStep;
             break;
@@ -526,15 +547,9 @@ export const PrescriptionForm = props => {
       setActiveSubStep(isInteger(firstInvalidSubStep) ? firstInvalidSubStep : 0);
     }
 
-    // When a user comes to this component initially, without the active step and subStep set by the
-    // Stepper component in the url, or when editing an existing prescription,
-    // we delete any persisted state from localStorage.
-    if (status.isPrescriptionEditFlow || (get(localStorage, storageKey) && activeStepsParam === null)) {
-      delete localStorage[storageKey];
-    }
-
-    // Only use the localStorage persistence for new prescriptions - not while editing an existing one.
-    setFormPersistReady(!prescription);
+    // Now that any hydration is complete and we've cleared locally stored values,
+    // we're ready for formikPersist to take over form persistence
+    setFormPersistReady(true);
   }, []);
 
   // Save whether or not we are editing a single step to the formik form status for easy reference
@@ -556,14 +571,13 @@ export const PrescriptionForm = props => {
   // Handle changes to stepper async state for completed prescription creation and revision updates
   useEffect(() => {
     const isRevision = !!get(values, 'id');
-    const isDraft = get(values, 'state') === 'draft';
     const { inProgress, completed, notification, prescriptionId } = isRevision ? creatingPrescriptionRevision : creatingPrescription;
-
-    if (prescriptionId) setFieldValue('id', prescriptionId);
 
     if (!isFirstRender && !inProgress) {
       if (completed) {
         setStepAsyncState(asyncStates.completed);
+        if (prescriptionId) setFieldValue('id', prescriptionId);
+
         if (isLastStep()) {
 
           let messageAction = isRevision ? t('updated') : t('created');
@@ -574,7 +588,13 @@ export const PrescriptionForm = props => {
             variant: 'success',
           });
 
-          history.push('/clinic-workspace/prescriptions');
+          dispatch(push('/clinic-workspace/prescriptions'));
+        } else {
+          if (prescriptionId && isNewPrescriptionFlow()) {
+            // Redirect to normal prescription edit flow once we have a prescription ID
+            setStoredValues({ ...values, id: prescriptionId })
+            dispatch(push(`/prescriptions/${prescriptionId}`));
+          }
         }
       }
 
@@ -631,7 +651,7 @@ export const PrescriptionForm = props => {
     },
   };
 
-  const title = isNewPrescription ? t('Create New Prescription') : t('Prescription: {{name}}', {
+  const title = isNewPrescriptionFlow() ? t('Create New Prescription') : t('Prescription: {{name}}', {
     name: [values.firstName, values.lastName].join(' '),
   });
 

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -264,7 +264,6 @@ export const PrescriptionForm = props => {
     t,
     api,
     devices,
-    history,
     location,
     prescription,
     trackMetric,

--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -420,7 +420,7 @@ export const PrescriptionForm = props => {
       setFieldValue('state', prescriptionAttributes.state);
 
       prescriptionAttributes.revisionHash = await sha512(
-        canonicalize(prescriptionAttributes),
+        canonicalize(omit(prescriptionAttributes, 'createdUserId')),
         { outputFormat: 'hex' }
       );
 

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -100,7 +100,7 @@ export const roundValueToIncrement = (value, increment = 1) => {
 };
 
 export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
-  const isPalmtree = pump.id === deviceIdMap.palmtree;
+  const isPalmtree = pump?.id === deviceIdMap.palmtree;
   const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
 
   const ranges = {
@@ -323,7 +323,7 @@ export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values 
   } else if (isPediatric) {
     bloodGlucoseTarget = {
       low: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
-      high: getBgInTargetUnits(125, MGDL_UNITS, bgUnits),
+      high: getBgInTargetUnits(115, MGDL_UNITS, bgUnits),
     };
   }
 

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -157,8 +157,7 @@ export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) =>
     carbRatio: {
       min: getPumpGuardrail(pump, 'carbohydrateRatio.absoluteBounds.minimum', 2),
       max: getPumpGuardrail(pump, 'carbohydrateRatio.absoluteBounds.maximum', 150),
-      increment: getPumpGuardrail(pump, 'carbohydrateRatio.absoluteBounds.increment', 0.01),
-      inputStep: 1,
+      increment: getPumpGuardrail(pump, 'carbohydrateRatio.absoluteBounds.increment', 0.1),
       schedules: { max: 48, minutesIncrement: 30 },
     },
     insulinSensitivityFactor: {

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -101,6 +101,7 @@ export const roundValueToIncrement = (value, increment = 1) => {
 
 export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
   const isPalmtree = pump.id === deviceIdMap.palmtree;
+  const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
 
   const ranges = {
     basalRate: {
@@ -116,7 +117,10 @@ export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) =>
       ], isFinite)),
       max: min(filter([
         getPumpGuardrail(pump, 'basalRateMaximum.absoluteBounds.maximum', 30),
-        70 / min(map(get(values, 'initialSettings.carbohydrateRatioSchedule'), 'amount')),
+        max([
+          70 / min(map(get(values, 'initialSettings.carbohydrateRatioSchedule'), 'amount')),
+          parseFloat((maxBasalRate * 6.4).toFixed(2))
+        ]),
       ], isFinite)),
       increment: getPumpGuardrail(pump, 'basalRateMaximum.absoluteBounds.increment', 0.05),
     },

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -299,16 +299,31 @@ export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values 
   const maxBasalRate = max(map(get(values, 'initialSettings.basalRateSchedule'), 'rate'));
   const patientAge = moment().diff(moment(get(values, 'birthday'), dateFormat), 'years', true);
   const isPediatric = patientAge < 18;
+  const isPalmtree = pump.id === deviceIdMap.palmtree;
+
+  let bloodGlucoseTarget = {
+    low: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
+    high: getBgInTargetUnits(105, MGDL_UNITS, bgUnits),
+  };
+
+  if (isPalmtree) {
+    bloodGlucoseTarget = {
+      low: getBgInTargetUnits(115, MGDL_UNITS, bgUnits),
+      high: getBgInTargetUnits(125, MGDL_UNITS, bgUnits),
+    };
+  } else if (isPediatric) {
+    bloodGlucoseTarget = {
+      low: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
+      high: getBgInTargetUnits(125, MGDL_UNITS, bgUnits),
+    };
+  }
 
   return {
     basalRate: recommendedBasalRate || 0.05,
     basalRateMaximum: isFinite(maxBasalRate)
       ? parseFloat((maxBasalRate * (isPediatric ? 3 : 3.5)).toFixed(2))
       : getPumpGuardrail(pump, 'basalRateMaximum.defaultValue', 0.05),
-    bloodGlucoseTarget: {
-      low: getBgInTargetUnits(100, MGDL_UNITS, bgUnits),
-      high: getBgInTargetUnits(isPediatric ? 115 : 105, MGDL_UNITS, bgUnits),
-    },
+    bloodGlucoseTarget,
     bloodGlucoseTargetPhysicalActivity: {
       low: getBgInTargetUnits(150, MGDL_UNITS, bgUnits),
       high: getBgInTargetUnits(170, MGDL_UNITS, bgUnits),
@@ -319,7 +334,7 @@ export const defaultValues = (pump, bgUnits = defaultUnits.bloodGlucose, values 
     },
     carbohydrateRatio: recommendedCarbohydrateRatio,
     insulinSensitivity: recommendedInsulinSensitivity,
-    glucoseSafetyLimit: getBgInTargetUnits(isPediatric ? 80 : 75, MGDL_UNITS, bgUnits),
+    glucoseSafetyLimit: getBgInTargetUnits(isPediatric || isPalmtree ? 80 : 75, MGDL_UNITS, bgUnits),
   };
 };
 

--- a/app/pages/prescription/prescriptionFormConstants.js
+++ b/app/pages/prescription/prescriptionFormConstants.js
@@ -100,11 +100,14 @@ export const roundValueToIncrement = (value, increment = 1) => {
 };
 
 export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) => {
+  const isPalmtree = pump.id === deviceIdMap.palmtree;
+
   const ranges = {
     basalRate: {
       min: max([getPumpGuardrail(pump, 'basalRates.absoluteBounds.minimum', 0.05), 0.05]),
       max: min([getPumpGuardrail(pump, 'basalRates.absoluteBounds.maximum', 30), 30]),
       increment: getPumpGuardrail(pump, 'basalRates.absoluteBounds.increment', 0.05),
+      schedules: { max: isPalmtree ? 24 : 48, minutesIncrement: 30 },
     },
     basalRateMaximum: {
       min: max(filter([
@@ -124,6 +127,7 @@ export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) =>
       ], isFinite)),
       max: getBgInTargetUnits(getPumpGuardrail(pump, 'correctionRange.absoluteBounds.maximum', 180), MGDL_UNITS, bgUnits),
       increment: getBgStepInTargetUnits(getPumpGuardrail(pump, 'correctionRange.absoluteBounds.increment', 1), MGDL_UNITS, bgUnits),
+      schedules: { max: 48, minutesIncrement: 30 },
     },
     bloodGlucoseTargetPhysicalActivity: {
       min: max(filter([
@@ -151,11 +155,13 @@ export const pumpRanges = (pump, bgUnits = defaultUnits.bloodGlucose, values) =>
       max: getPumpGuardrail(pump, 'carbohydrateRatio.absoluteBounds.maximum', 150),
       increment: getPumpGuardrail(pump, 'carbohydrateRatio.absoluteBounds.increment', 0.01),
       inputStep: 1,
+      schedules: { max: 48, minutesIncrement: 30 },
     },
     insulinSensitivityFactor: {
       min: getBgInTargetUnits(getPumpGuardrail(pump, 'insulinSensitivity.absoluteBounds.minimum', 10), MGDL_UNITS, bgUnits),
       max: getBgInTargetUnits(getPumpGuardrail(pump, 'insulinSensitivity.absoluteBounds.maximum', 500), MGDL_UNITS, bgUnits),
       increment: getBgStepInTargetUnits(getPumpGuardrail(pump, 'insulinSensitivity.absoluteBounds.increment', 1), MGDL_UNITS, bgUnits),
+      schedules: { max: 48, minutesIncrement: 30 },
     },
     glucoseSafetyLimit: {
       min: getBgInTargetUnits(getPumpGuardrail(pump, 'glucoseSafetyLimit.absoluteBounds.minimum', 67), MGDL_UNITS, bgUnits),

--- a/app/pages/prescription/prescriptionSchema.js
+++ b/app/pages/prescription/prescriptionSchema.js
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 import i18next from '../../core/language';
+import find from 'lodash/find';
 import includes from 'lodash/includes';
 import map from 'lodash/map';
 import moment from 'moment';

--- a/app/pages/prescription/reviewFormStep.js
+++ b/app/pages/prescription/reviewFormStep.js
@@ -290,6 +290,7 @@ const therapySettingsRows = (pump, formikContext) => {
 export const PatientInfo = props => {
   const {
     t,
+    currentStep,
     handlers: { activeStepUpdate },
     isEditable,
     ...themeProps
@@ -298,7 +299,6 @@ export const PatientInfo = props => {
   const initialFocusedInputRef = useInitialFocusedInput();
 
   const nameStep = [0, 1];
-  const currentStep = [4, 0];
   const formikContext = useFormikContext();
 
   const { values } = formikContext;
@@ -352,14 +352,14 @@ PatientInfo.propTypes = fieldsetPropTypes;
 export const TherapySettings = props => {
   const {
     t,
+    currentStep,
     handlers: { activeStepUpdate, generateTherapySettingsOrderText, handleCopyTherapySettingsClicked },
     isEditable,
     pump,
     ...themeProps
   } = props;
 
-  const therapySettingsStep = [3, 0];
-  const currentStep = [4, 0];
+  const therapySettingsStep = [currentStep[0] - 1, 0];
 
   const formikContext = useFormikContext();
   const { values } = formikContext;
@@ -519,6 +519,14 @@ export const TherapySettings = props => {
 TherapySettings.propTypes = fieldsetPropTypes;
 
 export const PrescriptionReview = withTranslation()(props => {
+  const stepperId = 'prescription-form-steps';
+  const params = () => new URLSearchParams(location.search);
+  const activeStepParamKey = `${stepperId}-step`;
+  const activeStepsParam = params().get(activeStepParamKey);
+  const activeStep = activeStepsParam ? parseInt(activeStepsParam.split(',')[0], 10) : undefined;
+  const activeSubStep = activeStepsParam ? parseInt(activeStepsParam.split(',')[1], 10) : undefined;
+  const currentStep = [activeStep, activeSubStep];
+
   const { validateForm, values } = useFormikContext();
 
   // At this point we consider the prescription ready to send so we ensure the values are validated
@@ -549,6 +557,7 @@ export const PrescriptionReview = withTranslation()(props => {
           width: ['100%', null, '45%', '35%'],
           border: 'default',
         }}
+        currentStep={currentStep}
         {...props}
       />
       <TherapySettings
@@ -562,6 +571,7 @@ export const PrescriptionReview = withTranslation()(props => {
           flex: '0 0 auto',
           width: ['100%', null, '55%', '65%'],
         }}
+        currentStep={currentStep}
         {...props}
       />
     </Flex>

--- a/app/pages/prescription/therapySettingsFormStep.js
+++ b/app/pages/prescription/therapySettingsFormStep.js
@@ -145,6 +145,7 @@ export const GlucoseSettings = props => {
   } = formikContext;
 
   const bgUnits = values.initialSettings.bloodGlucoseUnits;
+  const { schedules: bloodGlucoseTargetSchedule, ...bloodGlucoseTargetRange } = ranges.bloodGlucoseTarget;
 
   return (
     <Box {...wideBorderedFieldsetStyles} {...themeProps}>
@@ -203,7 +204,7 @@ export const GlucoseSettings = props => {
                 suffix: bgUnits,
                 threshold: thresholds.bloodGlucoseTarget,
                 type: 'number',
-                ...ranges.bloodGlucoseTarget,
+                ...bloodGlucoseTargetRange,
               },
               {
                 label: t('Upper Target'),
@@ -211,9 +212,10 @@ export const GlucoseSettings = props => {
                 suffix: bgUnits,
                 threshold: thresholds.bloodGlucoseTarget,
                 type: 'number',
-                ...ranges.bloodGlucoseTarget,
+                ...bloodGlucoseTargetRange,
               },
             ]}
+            {...bloodGlucoseTargetSchedule}
             separator="-"
           />
         </Box>
@@ -337,6 +339,9 @@ export const InsulinSettings = props => {
   } = formikContext;
 
   const bgUnits = values.initialSettings.bloodGlucoseUnits;
+  const { schedules: carbRatioSchedule, ...carbRatioRange } = ranges.carbRatio;
+  const { schedules: basalRateSchedule, ...basalRateRange } = ranges.basalRate;
+  const { schedules: insulinSensitivityFactorSchedule, ...insulinSensitivityFactorRange } = ranges.insulinSensitivityFactor;
 
   return (
     <Box {...wideBorderedFieldsetStyles} {...themeProps}>
@@ -366,9 +371,10 @@ export const InsulinSettings = props => {
                 suffix: t('g/U'),
                 threshold: thresholds.carbRatio,
                 type: 'number',
-                ...ranges.carbRatio,
+                ...carbRatioRange,
               },
             ]}
+            {...carbRatioSchedule}
           />
         </Box>
 
@@ -396,9 +402,10 @@ export const InsulinSettings = props => {
                 suffix: t('U/hr'),
                 threshold: thresholds.basalRate,
                 type: 'number',
-                ...ranges.basalRate,
+                ...basalRateRange,
               },
             ]}
+            {...basalRateSchedule}
           />
         </Box>
 
@@ -429,9 +436,10 @@ export const InsulinSettings = props => {
                 suffix: bgUnits,
                 threshold: thresholds.insulinSensitivityFactor,
                 type: 'number',
-                ...ranges.insulinSensitivityFactor,
+                ...insulinSensitivityFactorRange,
               },
             ]}
+            {...insulinSensitivityFactorSchedule}
             useFastField
           />
         </Box>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.81.0-web-3068-default-device-selection.1",
+  "version": "1.81.0-web-3022-palmtree-guardrails.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/pages/prescription/PrescriptionForm.test.js
+++ b/test/unit/pages/prescription/PrescriptionForm.test.js
@@ -316,7 +316,7 @@ describe('PrescriptionForm', () => {
   describe('persistent storage', () => {
     let wrapper;
     let Element;
-    let mockedLocalStorage;
+    let mockedLocalStorage = {};
 
     context('prescription create flow', () => {
       const props = {
@@ -332,6 +332,18 @@ describe('PrescriptionForm', () => {
         status: { hydratedValues: {} },
       };
 
+      before(() => {
+        PF.__Rewire__('useLocalStorage', sinon.stub().callsFake(key => {
+          defaults(mockedLocalStorage, { [key]: {} });
+          return [
+            mockedLocalStorage[key],
+            sinon.stub().callsFake(val => mockedLocalStorage[key] = val)
+          ];
+        }));
+
+        PF.__Rewire__('useFormikContext', sinon.stub().returns(formikContext));
+      });
+
       beforeEach(() => {
         formikContext.setValues.resetHistory();
 
@@ -342,20 +354,10 @@ describe('PrescriptionForm', () => {
           },
         };
 
-        PF.__Rewire__('useLocalStorage', sinon.stub().callsFake(key => {
-          defaults(mockedLocalStorage, { [key]: {} });
-          return [
-            mockedLocalStorage[key],
-            sinon.stub().callsFake(val => mockedLocalStorage[key] = val)
-          ];
-        }));
-
-        PF.__Rewire__('useFormikContext', sinon.stub().returns(formikContext));
-
         Element = withFormik(prescriptionForm())(formikProps => <PrescriptionForm {...props} {...formikProps} />);
       });
 
-      afterEach(() => {
+      after(() => {
         PF.__ResetDependency__('useLocalStorage');
         PF.__ResetDependency__('useFormikContext');
       })
@@ -407,7 +409,6 @@ describe('PrescriptionForm', () => {
 
       const props = {
         ...defaultProps,
-        // location: { search: '?prescription-form-steps-step=0,1' },
         prescription: { state: 'draft', id: prescriptionId },
       };
 
@@ -417,6 +418,18 @@ describe('PrescriptionForm', () => {
         values: props.prescription,
         status: { hydratedValues: {} },
       };
+
+      before(() => {
+        PF.__Rewire__('useLocalStorage', sinon.stub().callsFake(key => {
+          defaults(mockedLocalStorage, { [key]: {} });
+          return [
+            mockedLocalStorage[key],
+            sinon.stub().callsFake(val => mockedLocalStorage[key] = val)
+          ];
+        }));
+
+        PF.__Rewire__('useFormikContext', sinon.stub().returns(formikContext));
+      });
 
       beforeEach(() => {
         formikContext.setValues.resetHistory();
@@ -429,20 +442,10 @@ describe('PrescriptionForm', () => {
           },
         };
 
-        PF.__Rewire__('useLocalStorage', sinon.stub().callsFake(key => {
-          defaults(mockedLocalStorage, { [key]: {} });
-          return [
-            mockedLocalStorage[key],
-            sinon.stub().callsFake(val => mockedLocalStorage[key] = val)
-          ];
-        }));
-
-        PF.__Rewire__('useFormikContext', sinon.stub().returns(formikContext));
-
         Element = withFormik(prescriptionForm())(formikProps => <PrescriptionForm {...props} {...formikProps} />);
       });
 
-      afterEach(() => {
+      after(() => {
         PF.__ResetDependency__('useLocalStorage');
         PF.__ResetDependency__('useFormikContext');
       })

--- a/test/unit/pages/prescription/PrescriptionForm.test.js
+++ b/test/unit/pages/prescription/PrescriptionForm.test.js
@@ -39,7 +39,10 @@ describe('PrescriptionForm', () => {
     t: sinon.stub().callsFake(string => string.replace('{{today}}', today)),
     creatingPrescription: { inProgress: false, completed: false },
     creatingPrescriptionRevision: { inProgress: false, completed: false },
-    devices: {},
+    devices: {
+      cgm: [{ id: deviceIdMap.dexcomG6 }],
+      pumps: [{ id: deviceIdMap.palmtree }],
+    },
     trackMetric: sinon.stub(),
   };
 
@@ -304,7 +307,7 @@ describe('PrescriptionForm', () => {
     let wrapper;
     let reviewStepProps = {
       ...defaultProps,
-      location: { search: '?prescription-form-steps-step=4,0' },
+      location: { search: '?prescription-form-steps-step=3,0' },
     };
 
     beforeEach(() => {

--- a/test/unit/pages/prescription/PrescriptionForm.test.js
+++ b/test/unit/pages/prescription/PrescriptionForm.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import moment from 'moment';
 import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { withFormik } from 'formik';
@@ -89,7 +90,9 @@ describe('PrescriptionForm', () => {
     wrapper = mount(
       <Provider store={defaultState}>
         <ToastProvider>
-          <Element />
+            <MemoryRouter initialEntries={['/prescriptions/new']}>
+              <Route path='/prescriptions/new' children={() => <Element />} />
+            </MemoryRouter>
         </ToastProvider>
       </Provider>
     );
@@ -119,7 +122,9 @@ describe('PrescriptionForm', () => {
     wrapper = mount(
       <Provider store={defaultState}>
         <ToastProvider>
-          <Element />
+            <MemoryRouter initialEntries={['/prescriptions/new']}>
+              <Route path='/prescriptions/new' children={() => <Element />} />
+            </MemoryRouter>
         </ToastProvider>
       </Provider>
     );
@@ -152,7 +157,9 @@ describe('PrescriptionForm', () => {
     wrapper = mount(
       <Provider store={defaultState}>
         <ToastProvider>
-          <Element />
+            <MemoryRouter initialEntries={['/prescriptions/new']}>
+              <Route path='/prescriptions/new' children={() => <Element />} />
+            </MemoryRouter>
         </ToastProvider>
       </Provider>
     );
@@ -308,6 +315,7 @@ describe('PrescriptionForm', () => {
     let reviewStepProps = {
       ...defaultProps,
       location: { search: '?prescription-form-steps-step=3,0' },
+      prescription: { state: 'submitted' }
     };
 
     beforeEach(() => {
@@ -315,7 +323,9 @@ describe('PrescriptionForm', () => {
       wrapper = mount(
         <Provider store={defaultState}>
           <ToastProvider>
-            <Element {...reviewStepProps} />
+            <MemoryRouter initialEntries={['/prescriptions/new']}>
+              <Route path='/prescriptions/new' children={() => <Element {...reviewStepProps} />} />
+            </MemoryRouter>
           </ToastProvider>
         </Provider>
       );

--- a/test/unit/pages/prescription/ScheduleForm.test.js
+++ b/test/unit/pages/prescription/ScheduleForm.test.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { Formik } from 'formik';
+import noop from 'lodash/noop';
 
 import ScheduleForm from '../../../../app/pages/prescription/ScheduleForm';
+import { convertTimeStringToMsPer24 } from '../../../../app/core/datetime';
 
 /* global chai */
 /* global sinon */
@@ -85,7 +87,7 @@ describe('ScheduleForm', () => {
     // Start Time Input
     const startTimeInput = wrapper.find('[id="fooSchedule.0.start"]').hostNodes();
     expect(startTimeInput).to.have.length(1);
-    expect(startTimeInput.prop('type')).to.equal('time');
+    expect(startTimeInput.prop('type')).to.equal('text');
     expect(startTimeInput.prop('value')).to.equal('00:00');
     expect(startTimeInput.prop('readOnly')).to.be.true;
     expect(startTimeInput.hasClass('error')).to.be.true;
@@ -138,11 +140,9 @@ describe('ScheduleForm', () => {
     expect(secondRowlabels).to.have.length(0);
 
     // Start Time Input
-    const startTimeInput = wrapper.find('[id="fooSchedule.1.start"]').hostNodes();
+    const startTimeInput = wrapper.find('select[id="fooSchedule.1.start"]').hostNodes();
     expect(startTimeInput).to.have.length(1);
-    expect(startTimeInput.prop('type')).to.equal('time');
-    expect(startTimeInput.prop('value')).to.equal('00:30');
-    expect(startTimeInput.prop('readOnly')).to.be.false;
+    expect(startTimeInput.prop('value')).to.equal(convertTimeStringToMsPer24('00:30'));
     expect(startTimeInput.hasClass('error')).to.be.false;
 
     // Rate Input
@@ -184,16 +184,16 @@ describe('ScheduleForm', () => {
 
     expect(rows()).to.have.length(2);
 
-    const startTimeInput = () => wrapper.find('[id="fooSchedule.1.start"]').hostNodes();
+    const startTimeInput = () => wrapper.find('select[id="fooSchedule.1.start"]').hostNodes();
     expect(startTimeInput()).to.have.length(1);
-    expect(startTimeInput().prop('value')).to.equal('00:30');
+    expect(startTimeInput().prop('value')).to.equal(convertTimeStringToMsPer24('00:30'));
 
     expect(addButton().prop('disabled')).to.be.false;
 
-    startTimeInput().at(0).simulate('change', { target: { name: 'fooSchedule.1.start', value: '23:30' } });
+    startTimeInput().at(0).simulate('change', { persist: noop, target: { name: 'fooSchedule.1.start', value: convertTimeStringToMsPer24('23:30') } });
     expect(addButton().prop('disabled')).to.be.true;
 
-    startTimeInput().at(0).simulate('change', { target: { name: 'fooSchedule.1.start', value: '23:29' } });
+    startTimeInput().at(0).simulate('change', { persist: noop, target: { name: 'fooSchedule.1.start', value: convertTimeStringToMsPer24('23:00') } });
     expect(addButton().prop('disabled')).to.be.false;
   });
 
@@ -211,8 +211,8 @@ describe('ScheduleForm', () => {
     expect(rows()).to.have.length(3);
 
     const startTimeInput1 = () => wrapper.find('[id="fooSchedule.0.start"]').hostNodes();
-    const startTimeInput2 = () => wrapper.find('[id="fooSchedule.1.start"]').hostNodes();
-    const startTimeInput3 = () => wrapper.find('[id="fooSchedule.2.start"]').hostNodes();
+    const startTimeInput2 = () => wrapper.find('select[id="fooSchedule.1.start"]').hostNodes();
+    const startTimeInput3 = () => wrapper.find('select[id="fooSchedule.2.start"]').hostNodes();
 
     const rateTimeInput1 = () => wrapper.find('[id="fooSchedule.0.rate"]').hostNodes();
     const rateTimeInput2 = () => wrapper.find('[id="fooSchedule.1.rate"]').hostNodes();
@@ -224,21 +224,21 @@ describe('ScheduleForm', () => {
     expect(startTimeInput1().prop('value')).to.equal('00:00');
     expect(rateTimeInput1().prop('value')).to.equal(1);
 
-    expect(startTimeInput2().prop('value')).to.equal('00:30');
+    expect(startTimeInput2().prop('value')).to.equal(convertTimeStringToMsPer24('00:30'));
     expect(rateTimeInput2().prop('value')).to.equal(2);
 
-    expect(startTimeInput3().prop('value')).to.equal('01:00');
+    expect(startTimeInput3().prop('value')).to.equal(convertTimeStringToMsPer24('01:00'));
     expect(rateTimeInput3().prop('value')).to.equal(3);
 
     // Change the middle input time to a later value than the 3rd. The time and rate inputs should move together
-    startTimeInput2().simulate('change', { target: { name: 'fooSchedule.1.start', value: '2:00' } });
+    startTimeInput2().simulate('change', { persist: noop, target: { name: 'fooSchedule.1.start', value: convertTimeStringToMsPer24('2:00') } });
     expect(startTimeInput1().prop('value')).to.equal('00:00');
     expect(rateTimeInput1().prop('value')).to.equal(1);
 
-    expect(startTimeInput2().prop('value')).to.equal('01:00');
+    expect(startTimeInput2().prop('value')).to.equal(convertTimeStringToMsPer24('01:00'));
     expect(rateTimeInput2().prop('value')).to.equal(3);
 
-    expect(startTimeInput3().prop('value')).to.equal('02:00');
+    expect(startTimeInput3().prop('value')).to.equal(convertTimeStringToMsPer24('02:00'));
     expect(rateTimeInput3().prop('value')).to.equal(2);
   });
 

--- a/test/unit/pages/prescription/prescriptionFormConstants.test.js
+++ b/test/unit/pages/prescription/prescriptionFormConstants.test.js
@@ -381,6 +381,7 @@ describe('prescriptionFormConstants', function() {
   describe('pumpRanges', () => {
     it('should export the pump-specific ranges with mg/dL as default bg unit if pump is provided', () => {
       const pump = {
+        id: prescriptionFormConstants.deviceIdMap.palmtree,
         guardRails: {
           basalRates: { absoluteBounds: {
             minimum: { units: 1, nanos: 0 },
@@ -432,12 +433,12 @@ describe('prescriptionFormConstants', function() {
       };
 
       expect(prescriptionFormConstants.pumpRanges(pump)).to.eql({
-        basalRate: { min: 1, max: 11, increment: 1 },
+        basalRate: { min: 1, max: 11, increment: 1, schedules: { max: 24, minutesIncrement: 30 } },
         basalRateMaximum: { min: 2, max: 12, increment: 2 },
-        bloodGlucoseTarget: { min: 3, max: 13, increment: 3 },
+        bloodGlucoseTarget: { min: 3, max: 13, increment: 3, schedules: { max: 48, minutesIncrement: 30 } },
         bolusAmountMaximum: { min: 4, max: 14, increment: 4 },
-        carbRatio: { min: 5, max: 15, increment: 5, inputStep: 1 },
-        insulinSensitivityFactor: { min: 6, max: 16, increment: 6 },
+        carbRatio: { min: 5, max: 15, increment: 5, schedules: { max: 48, minutesIncrement: 30 } },
+        insulinSensitivityFactor: { min: 6, max: 16, increment: 6, schedules: { max: 48, minutesIncrement: 30 } },
         bloodGlucoseTargetPreprandial: { min: 9, max: 17, increment: 7 }, // Uses the glucoseSafetyLimit min since it's higher
         bloodGlucoseTargetPhysicalActivity: { min: 8, max: 18, increment: 8 },
         glucoseSafetyLimit: { min: 9, max: 19, increment: 9 },
@@ -446,12 +447,12 @@ describe('prescriptionFormConstants', function() {
 
     it('should export the default ranges with mg/dL as default bg unit if pump is not provided', () => {
       expect(prescriptionFormConstants.pumpRanges()).to.eql({
-        basalRate: { min: 0.05, max: 30, increment: 0.05 },
+        basalRate: { min: 0.05, max: 30, increment: 0.05, schedules: { max: 48, minutesIncrement: 30 } },
         basalRateMaximum: { min: 0, max: 30, increment: 0.05 },
-        bloodGlucoseTarget: { min: 87, max: 180, increment: 1 },
+        bloodGlucoseTarget: { min: 87, max: 180, increment: 1, schedules: { max: 48, minutesIncrement: 30 } },
         bolusAmountMaximum: { min: 0.05, max: 30, increment: 0.05 },
-        carbRatio: { min: 2, max: 150, increment: 0.01, inputStep: 1 },
-        insulinSensitivityFactor: { min: 10, max: 500, increment: 1 },
+        carbRatio: { min: 2, max: 150, increment: 0.1, schedules: { max: 48, minutesIncrement: 30 } },
+        insulinSensitivityFactor: { min: 10, max: 500, increment: 1, schedules: { max: 48, minutesIncrement: 30 } },
         bloodGlucoseTargetPreprandial: { min: 67, max: 130, increment: 1 },
         bloodGlucoseTargetPhysicalActivity: { min: 87, max: 250, increment: 1 },
         glucoseSafetyLimit: { min: 67, max: 110, increment: 1 },


### PR DESCRIPTION
[WEB-3022]

Implements the guardrails according to the ticket.

Other changes:

- Had to re-implement the time options for the ScheduleForm component as well, since the html5 time field no longer supports the 'step' prop as it had when this was originally developed.
- Also, made the time increment and max number of schedules configurable
- Fixed a navigation error when single-step editing from the review page
- Remove the `createdUserId` from the revision hash to account for a similar backend change.



[WEB-3022]: https://tidepool.atlassian.net/browse/WEB-3022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ