### PR TITLE
[WEB-3251] Move latest time zone determination logic to data worker.

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -302,7 +302,7 @@ utils.roundBgTarget = (value, units) => {
   return utils.roundToNearest(value, nearest);
 }
 
-utils.getTimePrefsForDataProcessing = (latestUpload, latestDiabetesDatum, queryParams) => {
+utils.getTimePrefsForDataProcessing = (latestTimeZone, queryParams) => {
   var timePrefsForTideline;
   var browserTimezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
 
@@ -341,33 +341,9 @@ utils.getTimePrefsForDataProcessing = (latestUpload, latestDiabetesDatum, queryP
     setNewTimePrefs(queryParams.timezone, false);
     console.log('Displaying in timezone from query params:', queryParams.timezone);
   }
-  else if (_.isFinite(latestDiabetesDatum?.timezoneOffset)) {
-    // If the timeone on the latest upload record at the time of the latest diabetes datum has the
-    // same UTC offset, we use that, since it will also have DST changeover info available.
-    if (!_.isEmpty(latestUpload?.timezone)) {
-      const uploadTimezoneOffsetAtLatestDiabetesTime = moment.utc(latestDiabetesDatum.normalTime).tz(latestUpload.timezone).utcOffset();
-      if (uploadTimezoneOffsetAtLatestDiabetesTime === latestDiabetesDatum.timezoneOffset) {
-        setNewTimePrefs(latestUpload.timezone)
-        console.log('Defaulting to display in timezone of most recent upload at', latestUpload.normalTime, latestUpload.timezone);
-      }
-    }
-    // Otherwise, we calculate the nearest 'Etc/GMT' timezone from the timezone offset of the latest diabetes datum.
-    if(!timePrefsForTideline) {
-      // GMT offsets signs in Etc/GMT timezone names are reversed from the actual offset
-      const offsetSign = Math.sign(latestDiabetesDatum.timezoneOffset) === -1 ? '+' : '-';
-      const offsetDuration = moment.duration(Math.abs(latestDiabetesDatum.timezoneOffset), 'minutes');
-      let offsetHours = offsetDuration.hours();
-      const offsetMinutes = offsetDuration.minutes();
-      if (offsetMinutes >= 30) offsetHours += 1;
-      const nearestTimezone = `Etc/GMT${offsetSign}${offsetHours}`;
-      setNewTimePrefs(nearestTimezone);
-      console.log('Defaulting to display in the nearest timezone of most recent diabetes datum timezone offset at', latestDiabetesDatum.normalTime, nearestTimezone);
-    }
-  }
-  // Fallback to latest upload timezone if there is no diabetes data with timezone offsets
-  else if (!_.isEmpty(latestUpload) && (!_.isEmpty(latestUpload.timezone))) {
-    setNewTimePrefs(latestUpload.timezone);
-    console.log('Defaulting to display in timezone of most recent upload at', latestUpload.normalTime, latestUpload.timezone);
+  else if (latestTimeZone?.name) {
+    setNewTimePrefs(latestTimeZone.name);
+    console.log(`${latestTimeZone.message}:`, latestTimeZone.name);
   }
   else if (browserTimezone) {
     setNewTimePrefs(browserTimezone);

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1712,24 +1712,7 @@ export const PatientDataClass = createReactClass({
       // Set timePrefs to state
       let timePrefs = this.state.timePrefs;
       if (_.isEmpty(timePrefs)) {
-        const latestUpload = _.get(nextProps, 'data.metaData.latestDatumByType.upload');
-        const latestDosingDecision = _.get(nextProps, 'data.metaData.latestDatumByType.dosingDecision');
-
-        let latestDiabetesDatum = _.maxBy(
-          _.filter(
-            _.values(_.get(nextProps, 'data.metaData.latestDatumByType', {})),
-            ({ type }) => _.includes(DIABETES_DATA_TYPES, type)
-          ),
-          'time'
-        );
-
-        // Loop diabetes datums do not have the timezoneOffset available, but the dosing decisions do,
-        // so we can pass that instead to derive an appropriate timezone from
-        if (!_.isFinite(latestDiabetesDatum?.timezoneOffset) && _.isFinite(latestDosingDecision?.timezoneOffset)) {
-          latestDiabetesDatum = latestDosingDecision;
-        }
-
-        timePrefs = utils.getTimePrefsForDataProcessing(latestUpload, latestDiabetesDatum, this.props.queryParams);
+        timePrefs = utils.getTimePrefsForDataProcessing(this.getMetaData('latestTimeZone', null, nextProps), this.props.queryParams);
         stateUpdates.timePrefs = timePrefs;
       }
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1713,14 +1713,21 @@ export const PatientDataClass = createReactClass({
       let timePrefs = this.state.timePrefs;
       if (_.isEmpty(timePrefs)) {
         const latestUpload = _.get(nextProps, 'data.metaData.latestDatumByType.upload');
+        const latestDosingDecision = _.get(nextProps, 'data.metaData.latestDatumByType.dosingDecision');
 
-        const latestDiabetesDatum = _.maxBy(
+        let latestDiabetesDatum = _.maxBy(
           _.filter(
             _.values(_.get(nextProps, 'data.metaData.latestDatumByType', {})),
             ({ type }) => _.includes(DIABETES_DATA_TYPES, type)
           ),
           'time'
         );
+
+        // Loop diabetes datums do not have the timezoneOffset available, but the dosing decisions do,
+        // so we can pass that instead to derive an appropriate timezone from
+        if (!_.isFinite(latestDiabetesDatum?.timezoneOffset) && _.isFinite(latestDosingDecision?.timezoneOffset)) {
+          latestDiabetesDatum = latestDosingDecision;
+        }
 
         timePrefs = utils.getTimePrefsForDataProcessing(latestUpload, latestDiabetesDatum, this.props.queryParams);
         stateUpdates.timePrefs = timePrefs;

--- a/app/pages/prescription/prescriptionSchema.js
+++ b/app/pages/prescription/prescriptionSchema.js
@@ -88,7 +88,7 @@ export default (devices, pumpId, bgUnits = defaultUnits.bloodGlucose, values) =>
         return value.isValid() ? value.toDate() : new Date('');
       })
       .min(moment().subtract(130, 'years').format(dateFormat), t('Please enter a date within the last 130 years'))
-      .max(moment().subtract(1, 'day').format(dateFormat), t('Please enter a date prior to today'))
+      .max(moment().endOf('day').format(dateFormat), t('Please enter a date that is not in the future'))
       .required(t('Patient\'s birthday is required')),
     email: yup.string()
       .matches(utils.emailRegex, t('Please enter a valid email address'))

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.81.1-rc.1",
+  "version": "1.81.1-rc.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@storybook/react": "7.5.0",
     "@storybook/react-webpack5": "7.5.0",
     "@testing-library/react-hooks": "8.0.1",
-    "@tidepool/viz": "1.42.1-web-3250-tandem-insulin-duration-fix.1",
+    "@tidepool/viz": "1.42.1-web-3251-use-dosing-decision-timezone-offset.1",
     "async": "2.6.4",
     "autoprefixer": "10.4.16",
     "babel-core": "7.0.0-bridge.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5268,9 +5268,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tidepool/viz@npm:1.42.1-web-3250-tandem-insulin-duration-fix.1":
-  version: 1.42.1-web-3250-tandem-insulin-duration-fix.1
-  resolution: "@tidepool/viz@npm:1.42.1-web-3250-tandem-insulin-duration-fix.1"
+"@tidepool/viz@npm:1.42.1-web-3251-use-dosing-decision-timezone-offset.1":
+  version: 1.42.1-web-3251-use-dosing-decision-timezone-offset.1
+  resolution: "@tidepool/viz@npm:1.42.1-web-3251-use-dosing-decision-timezone-offset.1"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -5330,7 +5330,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: 576152673babf1dd5b4672cd024a5c55b75b659186372fd55f86ea7353558b38ffa6638b5e3ae752af7b1978f9779630104229bda2f1681d4595d71857c4df5c
+  checksum: 5875b6ddd541a3d76c1956838d7692379b3f69d62e52fee43027dc9f5dec469602ad4fab01dcdf2c94b9ddef89413ee47baf1eca3adea968f450e176843ad1c5
   languageName: node
   linkType: hard
 
@@ -7427,7 +7427,7 @@ __metadata:
     "@storybook/react": 7.5.0
     "@storybook/react-webpack5": 7.5.0
     "@testing-library/react-hooks": 8.0.1
-    "@tidepool/viz": 1.42.1-web-3250-tandem-insulin-duration-fix.1
+    "@tidepool/viz": 1.42.1-web-3251-use-dosing-decision-timezone-offset.1
     async: 2.6.4
     autoprefixer: 10.4.16
     babel-core: 7.0.0-bridge.0


### PR DESCRIPTION
[WEB-3251] Will go out as part of `1.81.1` hotfix

Moved the general logic for determining the ideal timezone based on data to the viz data worker.

Related PR: https://github.com/tidepool-org/viz/pull/415

[WEB-3251]: https://tidepool.atlassian.net/browse/WEB-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ