### PR TITLE
[WEB-3258] Ensure accessCode is not used when generating revision hash

### DIFF
--- a/app/pages/prescription/PrescriptionForm.js
+++ b/app/pages/prescription/PrescriptionForm.js
@@ -388,6 +388,7 @@ export const PrescriptionForm = props => {
       setStepAsyncState(asyncStates.pending);
       // Delete fields that we never want to send to the backend
       const fieldsToDelete = [
+        'accessCode',
         'emailConfirm',
         'id',
         'therapySettingsReviewed',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.81.2-rc.1",
+  "version": "1.81.2-rc.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-3258]

[WEB-3258]: https://tidepool.atlassian.net/browse/WEB-3258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ