### PR TITLE
[WEB-3439] Remove "No Pending Connections" text from default data connection state UI

### DIFF
--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -193,7 +193,7 @@ export const getConnectStateUI = (patient, isLoggedInUser, providerName) => {
       handler: isLoggedInUser ? 'connect' : 'sendInvite',
       icon: null,
       message: null,
-      text: isLoggedInUser ? null : t('No Pending Connections'),
+      text: null,
     },
     inviteJustSent: {
       color: colors.grays[5],

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -204,7 +204,7 @@ describe('getConnectStateUI', () => {
       const UIJustSent = getConnectStateUI(clinicPatientJustSent, false, 'provider123');
 
       expect(UI.noPendingConnections.message).to.equal(null);
-      expect(UI.noPendingConnections.text).to.equal('No Pending Connections');
+      expect(UI.noPendingConnections.text).to.equal(null);
       expect(UI.noPendingConnections.handler).to.equal('sendInvite');
 
       expect(UI.inviteJustSent.message).to.equal(null);
@@ -547,12 +547,12 @@ describe('DataConnections', () => {
 
         const dexcomConnection = wrapper.find('#data-connection-dexcom').hostNodes();
         expect(dexcomConnection).to.have.lengthOf(1);
-        expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('No Pending Connections');
+        expect(dexcomConnection.find('.state-text')).to.have.lengthOf(0);
         expect(dexcomConnection.find('.state-message')).to.have.lengthOf(0);
 
         const abbottConnection = wrapper.find('#data-connection-abbott').hostNodes();
         expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('No Pending Connections');
+        expect(abbottConnection.find('.state-text')).to.have.lengthOf(0);
         expect(abbottConnection.find('.state-message')).to.have.lengthOf(0);
       });
 


### PR DESCRIPTION
[WEB-3439]

[WEB-3439]: https://tidepool.atlassian.net/browse/WEB-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ