### PR TITLE
Remove nodejs stable job from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: node_js
+os: linux
 dist: jammy
+language: node_js
 
 node_js:
   - "20.8.0"
-  - "stable"
 
 cache:
   yarn: true
@@ -30,7 +30,3 @@ services:
 script:
   - npm test
   - ./artifact.sh
-
-jobs:
-  allow_failures:
-    - node_js: stable


### PR DESCRIPTION
Also clean up any non-breaking config warnings in the Travis UI