### PR TITLE
[WEB-3460] Use provider displayName in OAuth connection banners

### DIFF
--- a/app/pages/oauth/OAuthConnection.js
+++ b/app/pages/oauth/OAuthConnection.js
@@ -12,18 +12,20 @@ import { components as vizComponents } from '@tidepool/viz';
 import Banner from '../../components/elements/Banner';
 import Button from '../../components/elements/Button';
 import { Title, Subheading, Body1 } from '../../components/elements/FontStyles';
-import { activeProviders } from '../../components/datasources/DataConnections';
+import { activeProviders, providers } from '../../components/datasources/DataConnections';
 
 const { Loader } = vizComponents;
 
 export const OAuthConnection = (props) => {
   const { t, trackMetric } = props;
   const { providerName, status } = useParams();
+  const { displayName } = providers[providerName] || {};
   const { search } = useLocation();
   const queryParams = new URLSearchParams(search)
   const dispatch = useDispatch();
   const [isCustodial, setIsCustodial] = useState();
   const [authStatus, setAuthStatus] = useState();
+
 
   const statusContent = {
     authorized: {
@@ -31,9 +33,7 @@ export const OAuthConnection = (props) => {
       subheading: t('Thank you for connecting with Tidepool!'),
       message: t('We hope you enjoy your Tidepool experience.'),
       banner: {
-        message: t('You have successfully connected your {{providerName}} account to Tidepool.', {
-          providerName: capitalize(providerName),
-        }),
+        message: t('You have successfully connected your {{displayName}} data to Tidepool.', { displayName }),
         variant: 'success',
       },
     },
@@ -42,9 +42,7 @@ export const OAuthConnection = (props) => {
       subheading: t('You can always decide to connect at a later time.'),
       message: t('We hope you enjoy your Tidepool experience.'),
       banner: {
-        message: t('You have declined connecting your {{providerName}} account to Tidepool.', {
-          providerName: capitalize(providerName),
-        }),
+        message: t('You have declined connecting your {{displayName}} data to Tidepool.', { displayName }),
         variant: 'info',
       },
     },
@@ -52,9 +50,7 @@ export const OAuthConnection = (props) => {
       status: 'error',
       subheading: t('Hmm... That didn\'t work. Please try again.'),
       banner: {
-        message: t('We were unable to determine your {{providerName}} connection status.', {
-          providerName: capitalize(providerName),
-        }),
+        message: t('We were unable to determine your {{displayName}} connection status.', { displayName }),
         variant: 'danger',
       },
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.0-rc.9",
+  "version": "1.84.0-rc.10",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/pages/OAuthConnection.test.js
+++ b/test/unit/pages/OAuthConnection.test.js
@@ -87,7 +87,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-authorized').hostNodes().text()).to.equal('You have successfully connected your Dexcom account to Tidepool.');
+      expect(wrapper.find('#banner-oauth-authorized').hostNodes().text()).to.equal('You have successfully connected your Dexcom data to Tidepool.');
     });
 
     it('should render the appropriate heading and subheading', () => {
@@ -144,7 +144,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-declined').hostNodes().text()).to.equal('You have declined connecting your Dexcom account to Tidepool.');
+      expect(wrapper.find('#banner-oauth-declined').hostNodes().text()).to.equal('You have declined connecting your Dexcom data to Tidepool.');
     });
 
     it('should render the appropriate heading and subheading', () => {
@@ -242,7 +242,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-authorized').hostNodes().text()).to.equal('You have successfully connected your Abbott account to Tidepool.');
+      expect(wrapper.find('#banner-oauth-authorized').hostNodes().text()).to.equal('You have successfully connected your FreeStyle Libre data to Tidepool.');
     });
 
     it('should render the appropriate heading and subheading', () => {
@@ -299,7 +299,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-declined').hostNodes().text()).to.equal('You have declined connecting your Abbott account to Tidepool.');
+      expect(wrapper.find('#banner-oauth-declined').hostNodes().text()).to.equal('You have declined connecting your FreeStyle Libre data to Tidepool.');
     });
 
     it('should render the appropriate heading and subheading', () => {
@@ -356,7 +356,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-error').hostNodes().text()).to.equal('We were unable to determine your Abbott connection status.');
+      expect(wrapper.find('#banner-oauth-error').hostNodes().text()).to.equal('We were unable to determine your FreeStyle Libre connection status.');
     });
 
     it('should render the appropriate heading and subheading', () => {


### PR DESCRIPTION
[WEB-3460]

[WEB-3460]: https://tidepool.atlassian.net/browse/WEB-3460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ