### PR TITLE
[WEB-3465] Set default chart type based only off of diabetes datums

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2147,16 +2147,17 @@ export const PatientDataClass = createReactClass({
   setInitialChartView: function(props = this.props) {
     // Determine default chart type and date from latest data
     const uploads = _.get(props.data, 'data.current.data.upload', []);
-    const latestDatum = _.last(_.sortBy(_.values(_.get(props.data, 'metaData.latestDatumByType')), ['normalTime']));
+    const latestDiabetesDatums = _.filter(_.values(_.get(props.data, 'metaData.latestDatumByType')), d => _.includes(['cbg', 'smbg', 'bolus', 'basal', 'wizard'], d.type));
+    const latestDiabetesDatum = _.last(_.sortBy(latestDiabetesDatums, ['normalTime']));
     const bgSource = this.getMetaData('bgSources.current');
     const excludedDevices = this.getMetaData('excludedDevices', undefined, props);
     const chartTypeFromPath = props.match?.params?.chartType;
 
     let defaultChartTypeForPatient = null;
 
-    if (uploads && latestDatum) {
+    if (uploads && latestDiabetesDatum) {
       let chartType = null;
-      defaultChartTypeForPatient = this.deriveChartTypeFromLatestData(latestDatum, uploads);
+      defaultChartTypeForPatient = this.deriveChartTypeFromLatestData(latestDiabetesDatum, uploads);
 
       // Figure out which chart to show based on the current route
       switch(true) {

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2091,18 +2091,18 @@ export const PatientDataClass = createReactClass({
     }
   },
 
-  deriveChartTypeFromLatestData: function(latestData, uploads) {
+  deriveChartTypeFromLatestData: function(latestDatum, latestDiabetesDatum, uploads) {
     let chartType = 'basics'; // Default to 'basics'
 
-    if (latestData && uploads) {
+    if (latestDatum && uploads) {
       // Ideally, we determine the default view based on the device type
       // so that, for instance, if the latest data type is cgm, but comes from
       // an insulin-pump, we still direct them to the basics view
       const deviceMap = _.keyBy(uploads, 'deviceId');
-      const latestDataDevice = deviceMap[latestData.deviceId];
+      const latestDataDevice = deviceMap[latestDatum.deviceId];
 
       if (latestDataDevice) {
-        const tags = deviceMap[latestData.deviceId].deviceTags;
+        const tags = deviceMap[latestDatum.deviceId].deviceTags;
 
         switch(true) {
           case (_.includes(tags, 'insulin-pump')):
@@ -2120,8 +2120,8 @@ export const PatientDataClass = createReactClass({
       }
       else {
         // If we were unable, for some reason, to get the device tags for the
-        // latest upload, we can fall back to setting the default view by the data type
-        const type = latestData.type;
+        // latest upload, we can fall back to setting the default view by the data type of the latest diabetes datum
+        const type = latestDiabetesDatum.type;
 
         switch(type) {
           case 'bolus':
@@ -2147,6 +2147,7 @@ export const PatientDataClass = createReactClass({
   setInitialChartView: function(props = this.props) {
     // Determine default chart type and date from latest data
     const uploads = _.get(props.data, 'data.current.data.upload', []);
+    const latestDatum = _.last(_.sortBy(_.values(_.get(props.data, 'metaData.latestDatumByType')), ['normalTime']));
     const latestDiabetesDatums = _.filter(_.values(_.get(props.data, 'metaData.latestDatumByType')), d => _.includes(['cbg', 'smbg', 'bolus', 'basal', 'wizard'], d.type));
     const latestDiabetesDatum = _.last(_.sortBy(latestDiabetesDatums, ['normalTime']));
     const bgSource = this.getMetaData('bgSources.current');
@@ -2155,9 +2156,9 @@ export const PatientDataClass = createReactClass({
 
     let defaultChartTypeForPatient = null;
 
-    if (uploads && latestDiabetesDatum) {
+    if (uploads && latestDatum) {
       let chartType = null;
-      defaultChartTypeForPatient = this.deriveChartTypeFromLatestData(latestDiabetesDatum, uploads);
+      defaultChartTypeForPatient = this.deriveChartTypeFromLatestData(latestDatum, latestDiabetesDatum, uploads);
 
       // Figure out which chart to show based on the current route
       switch(true) {

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2121,7 +2121,7 @@ export const PatientDataClass = createReactClass({
       else {
         // If we were unable, for some reason, to get the device tags for the
         // latest upload, we can fall back to setting the default view by the data type of the latest diabetes datum
-        const type = latestDiabetesDatum.type;
+        const type = latestDiabetesDatum?.type;
 
         switch(type) {
           case 'bolus':

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.0-rc.12",
+  "version": "1.84.0-rc.13",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@storybook/react": "7.5.0",
     "@storybook/react-webpack5": "7.5.0",
     "@testing-library/react-hooks": "8.0.1",
-    "@tidepool/viz": "1.45.0-rc.1",
+    "@tidepool/viz": "1.45.0-rc.2",
     "async": "2.6.4",
     "autoprefixer": "10.4.16",
     "babel-core": "7.0.0-bridge.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5278,9 +5278,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tidepool/viz@npm:1.45.0-rc.1":
-  version: 1.45.0-rc.1
-  resolution: "@tidepool/viz@npm:1.45.0-rc.1"
+"@tidepool/viz@npm:1.45.0-rc.2":
+  version: 1.45.0-rc.2
+  resolution: "@tidepool/viz@npm:1.45.0-rc.2"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -5340,7 +5340,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: b208ac10baa367ca390152ea6c80f82ddc895b2ba70f26a45c37bbcbe4e570da61aa5017ffc939f91609c57c67b8960ba9d789a9938822597aafe22a5582be1d
+  checksum: 29cf5e0f53029143385f0e7d585e9f55718e67c147baaa2d3e43ae11af933b698e3a866b6b25d74b374ca841ddb76464fd2b12ff9e8e300f3ed6269ae847b9e5
   languageName: node
   linkType: hard
 
@@ -7251,7 +7251,7 @@ __metadata:
     "@storybook/react": 7.5.0
     "@storybook/react-webpack5": 7.5.0
     "@testing-library/react-hooks": 8.0.1
-    "@tidepool/viz": 1.45.0-rc.1
+    "@tidepool/viz": 1.45.0-rc.2
     async: 2.6.4
     autoprefixer: 10.4.16
     babel-core: 7.0.0-bridge.0


### PR DESCRIPTION
Addresses [WEB-3465]

The issue was that Abbott sends a `cgmSettings` datum that is more recent than the latest `cbg` datum, causing it to default to the Basics view instead of the expected Trends.  I've pared down the list of datum types sent to `deriveChartTypeFromLatestData` to only those that are used to set the default view.

I've also pulled in this viz PR - which could have been handled separately, but it' one less blip PR this way (and I initally thought I'd be fixing this one by adding a device ID in the same section of viz code before I realized the actual issue):
https://github.com/tidepool-org/viz/pull/440

[WEB-3465]: https://tidepool.atlassian.net/browse/WEB-3465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ