### PR TITLE
[WEB-3396] Send minimum sample interval parameter for data fetches

### DIFF
--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -6,7 +6,7 @@ import { checkCacheValid } from 'redux-cache';
 
 import * as ErrorMessages from '../constants/errorMessages';
 import * as UserMessages from '../constants/usrMessages';
-import { ALL_FETCHED_DATA_TYPES, DIABETES_DATA_TYPES } from '../../core/constants';
+import { ALL_FETCHED_DATA_TYPES, DIABETES_DATA_TYPES, MS_IN_MIN } from '../../core/constants';
 import * as sync from './sync.js';
 import update from 'immutability-helper';
 import personUtils from '../../core/personutils';
@@ -1040,6 +1040,7 @@ export function fetchPatientData(api, options, id) {
     initial: true,
     type: ALL_FETCHED_DATA_TYPES.join(','),
     forceDataWorkerAddDataRequest: false,
+    sampleIntervalMinimum: 5 * MS_IN_MIN,
   });
 
   let latestUpload;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.83.2-rc.3",
+  "version": "1.83.2-web-3396-exclude-one-minute-cgm-data.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.83.2-web-3396-exclude-one-minute-cgm-data.1",
+  "version": "1.83.2-rc.4",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "terser-webpack-plugin": "5.3.9",
     "theme-ui": "0.16.1",
     "tideline": "1.30.1-rc.1",
-    "tidepool-platform-client": "0.61.0",
+    "tidepool-platform-client": "0.61.1-rc.1",
     "tidepool-standard-action": "0.1.1",
     "ua-parser-js": "1.0.36",
     "url-loader": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7429,7 +7429,7 @@ __metadata:
     terser-webpack-plugin: 5.3.9
     theme-ui: 0.16.1
     tideline: 1.30.1-rc.1
-    tidepool-platform-client: 0.61.0
+    tidepool-platform-client: 0.61.1-rc.1
     tidepool-standard-action: 0.1.1
     ua-parser-js: 1.0.36
     url-loader: 4.1.1
@@ -20184,15 +20184,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tidepool-platform-client@npm:0.61.0":
-  version: 0.61.0
-  resolution: "tidepool-platform-client@npm:0.61.0"
+"tidepool-platform-client@npm:0.61.1-rc.1":
+  version: 0.61.1-rc.1
+  resolution: "tidepool-platform-client@npm:0.61.1-rc.1"
   dependencies:
     async: 0.9.0
     lodash: 4.17.21
     superagent: 5.2.2
     uuid: 3.1.0
-  checksum: 96e221a65b7a003523e03d9ba357b0c1aa371b779ffd363c325ba015b893462955188662587b502193aaf269d6784577c8d24b8c764ba4ad759d4b0ba511c8ae
+  checksum: cc1bd4655dbdb24aa2544aff08d9a52042ee1962bef7b49d444b29c120963033f48a6352769588d8c5ae0eefd99ceae8e5d138adf833f5fa749b6b49d1386233
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[WEB-3396] 
Filters out any cgm data that has a `sampleInterval` value less than 5 minutes

Related PR: https://github.com/tidepool-org/platform-client/pull/186

[WEB-3396]: https://tidepool.atlassian.net/browse/WEB-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ