### PR TITLE
Update pendoMiddleware.js to include missing subdomain of integration environment

### DIFF
--- a/app/redux/utils/pendoMiddleware.js
+++ b/app/redux/utils/pendoMiddleware.js
@@ -28,6 +28,7 @@ const environments = {
   'qa4.development.tidepool.org': 'qa4',
   'qa5.development.tidepool.org': 'qa5',
   'int-app.tidepool.org': 'int',
+  'int-api.tidepool.org': 'int',
   'external.integration.tidepool.org': 'int',
   'app.tidepool.org': 'prd',
   localhost: 'local',


### PR DESCRIPTION
I noticed that logging in to int was not registering in Pendo as the "INT" environment. It appears as if the "int-api" subdomain is missing from the environments defined in pendoMiddleware.js. Adding this URL should fix the issue.