### PR TITLE
[WEB-3500] Abbott alternating accounts bugfix

### DIFF
--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -13,6 +13,7 @@ import keys from 'lodash/keys';
 import map from 'lodash/map';
 import max from 'lodash/max';
 import noop from 'lodash/noop';
+import orderBy from 'lodash/orderBy';
 import reduce from 'lodash/reduce';
 import { utils as vizUtils } from '@tidepool/viz';
 
@@ -268,7 +269,7 @@ export const getDataConnectionProps = (patient, isLoggedInUser, selectedClinicId
   let connectState;
 
   const connectStateUI = getConnectStateUI(patient, isLoggedInUser, providerName);
-  const dataSource = find(patient?.dataSources, { providerName: providerName });
+  const dataSource = find(orderBy(patient?.dataSources, 'modifiedTime', 'desc'), { providerName: providerName });
   const inviteExpired = dataSource?.expirationTime < moment.utc().toISOString();
 
   if (dataSource?.state) {
@@ -343,7 +344,6 @@ export const DataConnections = (props) => {
   const [patientUpdates, setPatientUpdates] = useState({});
   const [activeHandler, setActiveHandler] = useState(null);
   const dataConnectionProps = getDataConnectionProps(patient, isLoggedInUser, selectedClinicId, setActiveHandler);
-
 
   const {
     sendingPatientDataProviderConnectRequest,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.0-rc.16",
+  "version": "1.84.0-rc.17",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-3500]

The issue was that in cases where there were connections to multiple accounts for the same data source provider, the first one in the list of matching data sources was used.  Now, we order by modified time, so the latest matching data source that was interacted with gets chosen for display in the data connections UI

[WEB-3500]: https://tidepool.atlassian.net/browse/WEB-3500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ