### PR TITLE
[WEB-3476] Refresh leads to infinite loading when datetime query param is in integer timestamp format

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2189,13 +2189,17 @@ export const PatientDataClass = createReactClass({
       const mostRecentDatumTime = this.getMostRecentDatumTimeByChartType(props, chartType);
       const latestDatumDateCeiling = getLocalizedCeiling(mostRecentDatumTime, this.state.timePrefs);
 
-      const datetimeLocation = _.get(props, 'queryParams.datetime', (isDaily || isBgLog)
+      let datetimeLocation = _.get(props, 'queryParams.datetime', (isDaily || isBgLog)
         ? moment.utc(latestDatumDateCeiling.valueOf())
           .tz(isDaily ? getTimezoneFromTimePrefs(this.state.timePrefs) : 'UTC')
           .subtract(12, 'hours')
           .toISOString()
         : moment.utc(latestDatumDateCeiling.valueOf())
           .toISOString());
+
+      if (_.isInteger(_.toNumber(datetimeLocation))) {
+        datetimeLocation = moment.utc(_.toNumber(datetimeLocation)).toISOString();
+      }
 
       const endpoints = this.getChartEndpoints(datetimeLocation, { chartType });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.0-rc.17",
+  "version": "1.84.0-rc.18",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-3476] 

Fixes issue where a datetime query param in the integer timestamp format wasn't playing nice in `setInitialChartView`

[WEB-3476]: https://tidepool.atlassian.net/browse/WEB-3476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ