### PR TITLE
[WEB-3612] Show twiist as "Connected" instead of "Connecting"

### DIFF
--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -76,7 +76,7 @@ export const providers = {
   },
   twiist: {
     id: 'oauth/twiist',
-    displayName: 'Twiist',
+    displayName: 'twiist',
     restrictedTokenCreate: {
         paths: [
           '/v1/oauth/twiist',
@@ -87,6 +87,7 @@ export const providers = {
       providerName: 'twiist',
     },
     logoImage: twiistLogo,
+    lastImportTimeOptional: true,
   },
 };
 
@@ -183,12 +184,12 @@ export const getConnectStateUI = (patient, isLoggedInUser, providerName) => {
   let patientConnectedIcon;
   let patientConnectedText = t('Connected');
 
-  if (!dataSource?.lastImportTime) {
+  if (!dataSource?.lastImportTime && !providers[providerName]?.lastImportTimeOptional) {
     patientConnectedMessage = t('This can take a few minutes');
     patientConnectedText = t('Connecting');
-  } else if (!dataSource?.latestDataTime) {
+  } else if (!dataSource?.latestDataTime && !providers[providerName]?.lastImportTimeOptional) {
     patientConnectedMessage = t('No data found as of {{timeAgo}}', { timeAgo });
-  } else {
+  } else if (dataSource?.latestDataTime) {
     patientConnectedMessage = t('Last data {{timeAgo}}', { timeAgo });
     patientConnectedIcon = CheckCircleRoundedIcon;
   }

--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -187,9 +187,9 @@ export const getConnectStateUI = (patient, isLoggedInUser, providerName) => {
   if (!dataSource?.lastImportTime && !providers[providerName]?.lastImportTimeOptional) {
     patientConnectedMessage = t('This can take a few minutes');
     patientConnectedText = t('Connecting');
-  } else if (!dataSource?.latestDataTime && !providers[providerName]?.lastImportTimeOptional) {
+  } else if (!dataSource?.latestDataTime) {
     patientConnectedMessage = t('No data found as of {{timeAgo}}', { timeAgo });
-  } else if (dataSource?.latestDataTime) {
+  } else {
     patientConnectedMessage = t('Last data {{timeAgo}}', { timeAgo });
     patientConnectedIcon = CheckCircleRoundedIcon;
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.0-rc.30",
+  "version": "1.84.0-rc.31",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -49,6 +49,7 @@ describe('providers', () => {
     expect(dexcom.dataSourceFilter).to.eql({ providerType: 'oauth', providerName: 'dexcom' });
     expect(dexcom.logoImage).to.be.a('string');
     expect(dexcom.disconnectInstructions).to.be.undefined;
+    expect(dexcom.lastImportTimeOptional).to.be.undefined;
 
     expect(abbott.id).to.equal('oauth/abbott');
     expect(abbott.displayName).to.equal('FreeStyle Libre');
@@ -58,6 +59,7 @@ describe('providers', () => {
     expect(abbott.disconnectInstructions).to.be.an('object');
     expect(abbott.disconnectInstructions.title).to.be.a('string');
     expect(abbott.disconnectInstructions.message).to.be.a('string');
+    expect(abbott.lastImportTimeOptional).to.be.undefined;
 
     expect(twiist.id).to.equal('oauth/twiist');
     expect(twiist.displayName).to.equal('twiist');
@@ -65,6 +67,7 @@ describe('providers', () => {
     expect(twiist.dataSourceFilter).to.eql({ providerType: 'oauth', providerName: 'twiist' });
     expect(twiist.logoImage).to.be.a('string');
     expect(twiist.disconnectInstructions).to.be.undefined;
+    expect(twiist.lastImportTimeOptional).to.be.true;
   });
 });
 
@@ -1086,7 +1089,7 @@ describe('DataConnections', () => {
         const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
         expect(twiistConnection).to.have.lengthOf(1);
         expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
-        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - No data found as of 1 minute ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1136,7 +1139,7 @@ describe('DataConnections', () => {
         const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
         expect(twiistConnection).to.have.lengthOf(1);
         expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
-        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - No data found as of 5 minutes ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -60,7 +60,7 @@ describe('providers', () => {
     expect(abbott.disconnectInstructions.message).to.be.a('string');
 
     expect(twiist.id).to.equal('oauth/twiist');
-    expect(twiist.displayName).to.equal('Twiist');
+    expect(twiist.displayName).to.equal('twiist');
     expect(twiist.restrictedTokenCreate).to.eql({ paths: ['/v1/oauth/twiist'] });
     expect(twiist.dataSourceFilter).to.eql({ providerType: 'oauth', providerName: 'twiist' });
     expect(twiist.logoImage).to.be.a('string');
@@ -573,10 +573,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text')).to.have.lengthOf(0);
         expect(dexcomConnection.find('.state-message')).to.have.lengthOf(0);
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text')).to.have.lengthOf(0);
-        expect(abbottConnection.find('.state-message')).to.have.lengthOf(0);
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text')).to.have.lengthOf(0);
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -592,15 +592,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Email Invite');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Email Invite');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Email Invite');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.clinics.updateClinicPatient, 'clinicID123', 'patient123', sinon.match({ dataSources: [ { providerName: 'dexcom', state: 'pending' } ] }));
@@ -623,10 +623,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Connection Pending');
         expect(dexcomConnection.find('.state-message')).to.have.lengthOf(0);
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Connection Pending');
-        expect(abbottConnection.find('.state-message')).to.have.lengthOf(0);
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connection Pending');
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should render a disabled action buttons with appropriate text', () => {
@@ -643,12 +643,12 @@ describe('DataConnections', () => {
         expect(dexcomActionButton.props().disabled).to.be.true;
         expect(dexcomActionButton.text()).to.equal('Invite Sent');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.props().disabled).to.be.true;
-        expect(abbottActionButton.text()).to.equal('Invite Sent');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.props().disabled).to.be.true;
+        expect(twiistActionButton.text()).to.equal('Invite Sent');
       });
     });
 
@@ -665,10 +665,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Connection Pending');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Invite sent 5 days ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Connection Pending');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Invite sent 5 days ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connection Pending');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Invite sent 5 days ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when confirmed in dialog', () => {
@@ -684,11 +684,11 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Resend Invite');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Resend Invite');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Resend Invite');
 
         // Open and submit the dexcom resend invite confirmation modal
         const resendDialog = () => wrapper.find('#resendDataSourceConnectRequest').at(1);
@@ -730,10 +730,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Invite Sent');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Invite sent 10 days ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Invite Sent');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Invite sent 10 days ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Invite Sent');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Invite sent 10 days ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when confirmed in dialog', () => {
@@ -749,11 +749,11 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Resend Invite');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Resend Invite');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Resend Invite');
 
         // Open and submit the dexcom resend invite confirmation modal
         const resendDialog = () => wrapper.find('#resendDataSourceConnectRequest').at(1);
@@ -795,10 +795,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Invite Expired');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Sent over one month ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Invite Expired');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Sent over one month ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Invite Expired');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Sent over one month ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when confirmed in dialog', () => {
@@ -814,11 +814,11 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Resend Invite');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Resend Invite');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Resend Invite');
 
         // Open and submit the dexcom resend invite confirmation modal
         const resendDialog = () => wrapper.find('#resendDataSourceConnectRequest').at(1);
@@ -860,10 +860,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
         expect(dexcomConnection.find('.state-message')).to.have.lengthOf(0);
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
-        expect(abbottConnection.find('.state-message')).to.have.lengthOf(0);
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should not render an action button', () => {
@@ -878,10 +878,10 @@ describe('DataConnections', () => {
         const dexcomActionButton = dexcomConnection.find('.action').hostNodes();
         expect(dexcomActionButton).to.have.lengthOf(0);
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(0);
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(0);
       });
     });
 
@@ -898,10 +898,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Patient Disconnected');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 7 hours ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Patient Disconnected');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 7 hours ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Patient Disconnected');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 7 hours ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when confirmed in dialog', () => {
@@ -917,11 +917,11 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Resend Invite');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Resend Invite');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Resend Invite');
 
         // Open and submit the dexcom resend invite confirmation modal
         const resendDialog = () => wrapper.find('#resendDataSourceConnectRequest').at(1);
@@ -963,10 +963,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Error Connecting');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 20 minutes ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Error Connecting');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 20 minutes ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Error Connecting');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 20 minutes ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when confirmed in dialog', () => {
@@ -982,11 +982,11 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Resend Invite');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Resend Invite');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Resend Invite');
 
         // Open and submit the dexcom resend invite confirmation modal
         const resendDialog = () => wrapper.find('#resendDataSourceConnectRequest').at(1);
@@ -1030,10 +1030,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text')).to.have.lengthOf(0);
         expect(dexcomConnection.find('.state-message')).to.have.lengthOf(0);
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text')).to.have.lengthOf(0);
-        expect(abbottConnection.find('.state-message')).to.have.lengthOf(0);
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text')).to.have.lengthOf(0);
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1049,15 +1049,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Connect');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Connect');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Connect');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.user.createRestrictedToken, sinon.match({ paths: [ '/v1/oauth/dexcom' ] }));
@@ -1083,10 +1083,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Connecting');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - This can take a few minutes');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Connecting');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - This can take a few minutes');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1102,15 +1102,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Disconnect');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Disconnect');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Disconnect');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.user.deleteOAuthProviderAuthorization, 'dexcom');
@@ -1133,10 +1133,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - No data found as of 5 minutes ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - No data found as of 5 minutes ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1152,15 +1152,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Disconnect');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Disconnect');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Disconnect');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.user.deleteOAuthProviderAuthorization, 'dexcom');
@@ -1183,10 +1183,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Last data 35 minutes ago');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Last data 35 minutes ago');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Connected');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Last data 35 minutes ago');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1202,15 +1202,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Disconnect');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Disconnect');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Disconnect');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.user.deleteOAuthProviderAuthorization, 'dexcom');
@@ -1233,10 +1233,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text')).to.have.lengthOf(0);
         expect(dexcomConnection.find('.state-message')).to.have.lengthOf(0);
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text')).to.have.lengthOf(0);
-        expect(abbottConnection.find('.state-message')).to.have.lengthOf(0);
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text')).to.have.lengthOf(0);
+        expect(twiistConnection.find('.state-message')).to.have.lengthOf(0);
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1252,15 +1252,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Connect');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Connect');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Connect');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.user.createRestrictedToken, sinon.match({ paths: [ '/v1/oauth/dexcom' ] }));
@@ -1286,10 +1286,10 @@ describe('DataConnections', () => {
         expect(dexcomConnection.find('.state-text').hostNodes().text()).to.equal('Error Connecting');
         expect(dexcomConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 6 days ago. Please reconnect your account to keep syncing data.');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        expect(abbottConnection.find('.state-text').hostNodes().text()).to.equal('Error Connecting');
-        expect(abbottConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 6 days ago. Please reconnect your account to keep syncing data.');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        expect(twiistConnection.find('.state-text').hostNodes().text()).to.equal('Error Connecting');
+        expect(twiistConnection.find('.state-message').hostNodes().text()).to.equal(' - Last update 6 days ago. Please reconnect your account to keep syncing data.');
       });
 
       it('should render appropriate buttons and dispatch appropriate actions when clicked', done => {
@@ -1305,15 +1305,15 @@ describe('DataConnections', () => {
         expect(dexcomActionButton).to.have.lengthOf(1);
         expect(dexcomActionButton.text()).to.equal('Reconnect');
 
-        const abbottConnection = wrapper.find('#data-connection-twiist').hostNodes();
-        expect(abbottConnection).to.have.lengthOf(1);
-        const abbottActionButton = abbottConnection.find('.action').hostNodes();
-        expect(abbottActionButton).to.have.lengthOf(1);
-        expect(abbottActionButton.text()).to.equal('Reconnect');
+        const twiistConnection = wrapper.find('#data-connection-twiist').hostNodes();
+        expect(twiistConnection).to.have.lengthOf(1);
+        const twiistActionButton = twiistConnection.find('.action').hostNodes();
+        expect(twiistActionButton).to.have.lengthOf(1);
+        expect(twiistActionButton.text()).to.equal('Reconnect');
 
         store.clearActions();
         dexcomActionButton.simulate('click');
-        abbottActionButton.simulate('click');
+        twiistActionButton.simulate('click');
 
         setTimeout(() => {
           sinon.assert.calledWith(api.user.createRestrictedToken, sinon.match({ paths: [ '/v1/oauth/dexcom' ] }));

--- a/test/unit/pages/OAuthConnection.test.js
+++ b/test/unit/pages/OAuthConnection.test.js
@@ -263,7 +263,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-authorized').hostNodes().text()).to.equal('You have successfully connected your Twiist data to Tidepool.');
+      expect(wrapper.find('#banner-oauth-authorized').hostNodes().text()).to.equal('You have successfully connected your twiist data to Tidepool.');
     });
 
     it('should render the appropriate heading and subheading', () => {
@@ -337,7 +337,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-declined').hostNodes().text()).to.equal('You have declined connecting your Twiist data to Tidepool.');
+      expect(wrapper.find('#banner-oauth-declined').hostNodes().text()).to.equal('You have declined connecting your twiist data to Tidepool.');
     });
 
     it('should render the appropriate heading and subheading', () => {
@@ -394,7 +394,7 @@ describe('OAuthConnection', () => {
     });
 
     it('should render the appropriate banner', () => {
-      expect(wrapper.find('#banner-oauth-error').hostNodes().text()).to.equal('We were unable to determine your Twiist connection status.');
+      expect(wrapper.find('#banner-oauth-error').hostNodes().text()).to.equal('We were unable to determine your twiist connection status.');
     });
 
     it('should render the appropriate heading and subheading', () => {


### PR DESCRIPTION
[WEB-3612]  Makes the lastImportTime check optional for data connection sources such as twiist where we won't have this set.

Also sets the displayName on the twiist data connection definition to lowercase, as it was incorrectly set to "Twiist"

[WEB-3612]: https://tidepool.atlassian.net/browse/WEB-3612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ