### PR TITLE
[WEB-3640] twiist just connected banner and toast fix

### DIFF
--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -87,7 +87,7 @@ export const providers = {
       providerName: 'twiist',
     },
     logoImage: twiistLogo,
-    lastImportTimeOptional: true,
+    indeterminateDataImportTime: true,
   },
 };
 
@@ -184,7 +184,7 @@ export const getConnectStateUI = (patient, isLoggedInUser, providerName) => {
   let patientConnectedIcon;
   let patientConnectedText = t('Connected');
 
-  if (!dataSource?.lastImportTime && !providers[providerName]?.lastImportTimeOptional) {
+  if (!dataSource?.lastImportTime && !providers[providerName]?.indeterminateDataImportTime) {
     patientConnectedMessage = t('This can take a few minutes');
     patientConnectedText = t('Connecting');
   } else if (!dataSource?.latestDataTime) {

--- a/app/components/datasources/useProviderConnectionPopup.js
+++ b/app/components/datasources/useProviderConnectionPopup.js
@@ -142,6 +142,12 @@ const useProviderConnectionPopup = ({ popupWatchTimeout = 500, trackMetric = noo
         if (currentUrl.indexOf(authorizedDataSource?.id) !== -1) {
           const status = last(currentPath.split('/'));
 
+          // The initial platorm oauth redirect url is in the format of /v1/oauth/[providerName]/redirect
+          // It then issues the redirect to the /oauth/[providerName]/[status] url that we want to watch for.
+          // Depending on the timing of this interval check, we may get the redirect url
+          // We return early in this case, and wait for the final redirect to happen.
+          if (status === 'redirect') return;
+
           setToast({
             message: toastMessages[status],
             variant: toastVariants[status],

--- a/app/components/elements/Toast.js
+++ b/app/components/elements/Toast.js
@@ -6,6 +6,7 @@ import ErrorRoundedIcon from '@material-ui/icons/ErrorRounded';
 import InfoRoundedIcon from '@material-ui/icons/InfoRounded';
 import WarningRoundedIcon from '@material-ui/icons/WarningRounded';
 import CheckCircleRoundedIcon from '@material-ui/icons/CheckCircleRounded';
+import { isEmpty } from 'lodash';
 import { Flex } from 'theme-ui';
 
 import { Body1 } from './FontStyles';
@@ -33,7 +34,7 @@ export function Toast(props) {
     if (reason !== 'clickaway') onClose();
   };
 
-  return (
+  return message && !isEmpty(message) ? (
     <Snackbar open={open} onClose={handleClose} {...snackbarProps}>
       <Flex
         sx={{ justifyContent: 'space-between', alignItems: 'center' }}
@@ -57,7 +58,7 @@ export function Toast(props) {
         />
       </Flex>
     </Snackbar>
-  );
+  ) : null;
 }
 
 Toast.displayName = 'Toast';

--- a/app/providers/AppBanner/appBanners.js
+++ b/app/providers/AppBanner/appBanners.js
@@ -26,7 +26,9 @@ export const appBanners = [
       ignoreBannerInteractionsBeforeTime: dataSource?.modifiedTime || dataSource?.createdTime,
       interactionId: `${upperFirst(provider?.dataSourceFilter?.providerName)}DataSourceJustConnected`,
       label: t('Data Source Just Connected banner'),
-      title: t('{{displayName}} data is on its way. This usually takes a few minutes but occasionally takes longer. Refresh the page to see data.', provider),
+      title: provider?.indeterminateDataImportTime
+        ? t('If you have connected your {{displayName}} device, data is on its way. This usually takes a few minutes but occassionally takes longer. Refresh the page to see data.', provider)
+        : t('{{displayName}} data is on its way. This usually takes a few minutes but occasionally takes longer. Refresh the page to see data.', provider),
       show: {
         metric: 'Data Source Just Connected banner displayed',
         metricProps: { providerName: provider?.dataSourceFilter?.providerName },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.0-rc.34",
+  "version": "1.84.0-rc.36",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -49,7 +49,7 @@ describe('providers', () => {
     expect(dexcom.dataSourceFilter).to.eql({ providerType: 'oauth', providerName: 'dexcom' });
     expect(dexcom.logoImage).to.be.a('string');
     expect(dexcom.disconnectInstructions).to.be.undefined;
-    expect(dexcom.lastImportTimeOptional).to.be.undefined;
+    expect(dexcom.indeterminateDataImportTime).to.be.undefined;
 
     expect(abbott.id).to.equal('oauth/abbott');
     expect(abbott.displayName).to.equal('FreeStyle Libre');
@@ -59,7 +59,7 @@ describe('providers', () => {
     expect(abbott.disconnectInstructions).to.be.an('object');
     expect(abbott.disconnectInstructions.title).to.be.a('string');
     expect(abbott.disconnectInstructions.message).to.be.a('string');
-    expect(abbott.lastImportTimeOptional).to.be.undefined;
+    expect(abbott.indeterminateDataImportTime).to.be.undefined;
 
     expect(twiist.id).to.equal('oauth/twiist');
     expect(twiist.displayName).to.equal('twiist');
@@ -67,7 +67,7 @@ describe('providers', () => {
     expect(twiist.dataSourceFilter).to.eql({ providerType: 'oauth', providerName: 'twiist' });
     expect(twiist.logoImage).to.be.a('string');
     expect(twiist.disconnectInstructions).to.be.undefined;
-    expect(twiist.lastImportTimeOptional).to.be.true;
+    expect(twiist.indeterminateDataImportTime).to.be.true;
   });
 });
 

--- a/test/unit/components/useProviderConnectionPopup.test.js
+++ b/test/unit/components/useProviderConnectionPopup.test.js
@@ -16,7 +16,7 @@ import { mountWithProviders } from '../../utils/mountWithProviders';
 
 const expect = chai.expect;
 
-describe('useProviderConnectionPopup', function () {
+describe.only('useProviderConnectionPopup', function () {
   let wrapper, store;
 
   const setToast = sinon.stub();
@@ -133,6 +133,18 @@ describe('useProviderConnectionPopup', function () {
         variant: 'danger',
       })).to.be.true;
 
+      done();
+    }, 100);
+  });
+
+  it('should not show a toast message when the authorization status is `redirect`', (done) => {
+    // Simulate interim platform redirect path
+    const authorizedDataSource = { id: 'oauth/testProvider', url: `${window.location.origin}/v1/oauth/testProvider/redirect`};
+    store.dispatch(actions.sync.connectDataSourceSuccess(authorizedDataSource.id, authorizedDataSource.url));
+    wrapper.update();
+
+    setTimeout(() => {
+      expect(setToast.notCalled).to.be.true;
       done();
     }, 100);
   });

--- a/test/unit/components/useProviderConnectionPopup.test.js
+++ b/test/unit/components/useProviderConnectionPopup.test.js
@@ -16,7 +16,7 @@ import { mountWithProviders } from '../../utils/mountWithProviders';
 
 const expect = chai.expect;
 
-describe.only('useProviderConnectionPopup', function () {
+describe('useProviderConnectionPopup', function () {
   let wrapper, store;
 
   const setToast = sinon.stub();


### PR DESCRIPTION
[WEB-3640]

Basically, there is a small period of time where the backend `/v1/oauth/[providerName]/redirect` url can be detected in the oauth window status check interval, so we need to ignore that case.

Also contains the banner copy update for indeterminate intial data import times.