### PR TITLE
[WEB-3649] Hotfix: remove back to tidepool button for mobile custodial users on oauth connection results page

### DIFF
--- a/app/pages/oauth/OAuthConnection.js
+++ b/app/pages/oauth/OAuthConnection.js
@@ -147,7 +147,7 @@ export const OAuthConnection = (props) => {
           </Box>
         )}
 
-        { utils.isMobile() && // on desktop, users can just close the pop-up
+        {!isCustodial && utils.isMobile() && // on desktop, non-custodial users can just close the pop-up
           <Button
             id="oauth-redirect-home-button"
             variant="primary"


### PR DESCRIPTION
[WEB-3649]