### PR TITLE
[WEB-3582] Prevent temporary display of uploader banner while initial data is loading

### DIFF
--- a/app/providers/AppBanner/AppBannerProvider.js
+++ b/app/providers/AppBanner/AppBannerProvider.js
@@ -12,7 +12,7 @@ import {
   has,
   includes,
   intersection,
-  isEmpty,
+  isFinite,
   keys,
   map,
   max,
@@ -56,9 +56,11 @@ const AppBannerProvider = ({ children }) => {
   const patientDevices = patientMetaData?.devices;
   const userHasData = userIsCurrentPatient && patientMetaData?.size > 0;
   const userHasPumpData = filter(patientDevices, { pump: true }).length > 0;
+  const patientDataFetched = isFinite(patientMetaData?.size);
   const dataSources = useSelector(state => state.blip.dataSources);
   const justConnectedDataSourceProviderName = useSelector(state => state.blip.justConnectedDataSourceProviderName);
   const justConnectedDataSourceProvider = providers[justConnectedDataSourceProviderName];
+  const isInitialProcessing = !patientDataFetched || (userHasData && !patientDevices);
 
   const erroredDataSource = find(
     userIsCurrentPatient ? dataSources : clinic?.patients?.[currentPatientInViewId]?.dataSources,
@@ -101,7 +103,7 @@ const AppBannerProvider = ({ children }) => {
     },
 
     uploader: { // Temporary: hide on mobile until we have a mobile-friendly profile page
-      show: !isMobile && userIsCurrentPatient && dataSources?.length && !userHasPumpData,
+      show: !isMobile && userIsCurrentPatient && dataSources?.length && !isInitialProcessing && !userHasPumpData,
       bannerArgs: [],
     },
 
@@ -155,6 +157,7 @@ const AppBannerProvider = ({ children }) => {
     erroredDataSource,
     formikContext,
     isCustodialPatient,
+    isInitialProcessing,
     justConnectedDataSource,
     justConnectedDataSourceProvider,
     loggedInUserId,


### PR DESCRIPTION
[WEB-3582]

Basically, this particular banner was showing by default for a second or two while data was loading in as the 'show' criteria wasn't waiting until we had the data loaded in order to make the decision to show or not.



[WEB-3582]: https://tidepool.atlassian.net/browse/WEB-3582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ