### PR TITLE
[WEB-3663] Fix JS error for mobile users when initial data view is bgLog or daily

### DIFF
--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -94,7 +94,7 @@ class BgLogChart extends Component {
 
   unmountChart = () => {
     this.log('Unmounting...');
-    if (this.chart) this.chart.destroy();
+    if (this.chart) this.chart?.destroy();
   };
 
   remountChart = (updates = {}) => {
@@ -102,15 +102,15 @@ class BgLogChart extends Component {
     this.log('Remounting...');
     this.unmountChart();
     this.mount(chartProps);
-    this.chart.emitter.emit('inTransition', false);
+    this.chart?.emitter.emit('inTransition', false);
   }
 
   rerenderChart = (updates = {}) => {
     const chartProps = { ...this.props, ...updates };
     this.log('Rerendering...');
-    this.chart.clear();
+    this.chart?.clear();
     this.bindEvents();
-    this.chart.load(chartProps.data, chartProps.initialDatetimeLocation);
+    this.chart?.load(chartProps.data, chartProps.initialDatetimeLocation);
     if (chartProps.showingValues) {
       this.showValues();
     } else {
@@ -119,10 +119,10 @@ class BgLogChart extends Component {
   };
 
   bindEvents = () => {
-    this.chart.emitter.on('inTransition', this.props.onTransition);
-    this.chart.emitter.on('navigated', this.handleDatetimeLocationChange);
-    this.chart.emitter.on('mostRecent', this.props.onMostRecent);
-    this.chart.emitter.on('selectSMBG', this.props.onSelectSMBG);
+    this.chart?.emitter.on('inTransition', this.props.onTransition);
+    this.chart?.emitter.on('navigated', this.handleDatetimeLocationChange);
+    this.chart?.emitter.on('mostRecent', this.props.onMostRecent);
+    this.chart?.emitter.on('selectSMBG', this.props.onSelectSMBG);
   };
 
   initializeChart = (data, datetimeLocation, showingValues) => {
@@ -132,14 +132,14 @@ class BgLogChart extends Component {
     }
 
     if (datetimeLocation) {
-      this.chart.load(data, datetimeLocation);
+      this.chart?.load(data, datetimeLocation);
     }
     else {
-      this.chart.load(data);
+      this.chart?.load(data);
     }
 
     if (this.props.isClinicianAccount || showingValues) {
-      this.chart.showValues();
+      this.chart?.showValues();
     }
   };
 
@@ -155,29 +155,29 @@ class BgLogChart extends Component {
   }
 
   getCurrentDay = timePrefs => {
-    return this.chart.getCurrentDay(timePrefs).toISOString();
+    return this.chart?.getCurrentDay(timePrefs).toISOString();
   };
 
   goToMostRecent = () => {
-    this.chart.clear();
+    this.chart?.clear();
     this.bindEvents();
-    this.chart.load(this.props.data);
+    this.chart?.load(this.props.data);
   };
 
   hideValues = () => {
-    this.chart.hideValues();
+    this.chart?.hideValues();
   };
 
   panBack = () => {
-    this.chart.panBack();
+    this.chart?.panBack();
   };
 
   panForward = () => {
-    this.chart.panForward();
+    this.chart?.panForward();
   };
 
   showValues = () => {
-    this.chart.showValues();
+    this.chart?.showValues();
   };
 }
 

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -133,15 +133,15 @@ const DailyChart = withTranslation(null, { withRef: true })(class DailyChart ext
 
   unmountChart = () => {
     this.log('Unmounting...');
-    this.chart.destroy();
+    this.chart?.destroy();
   };
 
   bindEvents = () => {
-    this.chart.emitter.on('createMessage', this.props.onCreateMessage);
-    this.chart.emitter.on('inTransition', this.props.onTransition);
-    this.chart.emitter.on('messageThread', this.props.onShowMessageThread);
-    this.chart.emitter.on('mostRecent', this.props.onMostRecent);
-    this.chart.emitter.on('navigated', this.handleDatetimeLocationChange);
+    this.chart?.emitter.on('createMessage', this.props.onCreateMessage);
+    this.chart?.emitter.on('inTransition', this.props.onTransition);
+    this.chart?.emitter.on('messageThread', this.props.onShowMessageThread);
+    this.chart?.emitter.on('mostRecent', this.props.onMostRecent);
+    this.chart?.emitter.on('navigated', this.handleDatetimeLocationChange);
   };
 
   initializeChart = (props = this.props, datetime) => {
@@ -151,15 +151,15 @@ const DailyChart = withTranslation(null, { withRef: true })(class DailyChart ext
       throw new Error(t('Cannot create new chart with no data'));
     }
 
-    this.chart.load(props.data);
+    this.chart?.load(props.data);
     if (datetime) {
-      this.chart.locate(datetime);
+      this.chart?.locate(datetime);
     }
     else if (this.state.datetimeLocation !== null) {
-      this.chart.locate(this.state.datetimeLocation);
+      this.chart?.locate(this.state.datetimeLocation);
     }
     else {
-      this.chart.locate();
+      this.chart?.locate();
     }
   };
 
@@ -183,36 +183,36 @@ const DailyChart = withTranslation(null, { withRef: true })(class DailyChart ext
     this.unmountChart();
     this.mountChart(chartProps);
     this.initializeChart(chartProps);
-    this.chart.emitter.emit('inTransition', false);
+    this.chart?.emitter.emit('inTransition', false);
   };
 
   getCurrentDay = () => {
-    return this.chart.getCurrentDay().toISOString();
+    return this.chart?.getCurrentDay().toISOString();
   };
 
   goToMostRecent = () => {
-    this.chart.setAtDate(null, true);
+    this.chart?.setAtDate(null, true);
   };
 
   panBack = () => {
-    this.chart.panBack();
+    this.chart?.panBack();
   };
 
   panForward = () => {
-    this.chart.panForward();
+    this.chart?.panForward();
   };
 
   // methods for messages
   closeMessage = () => {
-    return this.chart.closeMessage();
+    return this.chart?.closeMessage();
   };
 
   createMessage = message => {
-    return this.chart.createMessage(message);
+    return this.chart?.createMessage(message);
   };
 
   editMessage = message => {
-    return this.chart.editMessage(message);
+    return this.chart?.editMessage(message);
   };
 });
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2148,7 +2148,10 @@ export const PatientDataClass = createReactClass({
 
     if (uploads && latestDatum) {
       let chartType = null;
-      defaultChartTypeForPatient = this.deriveChartTypeFromLatestData(latestDatum, latestDiabetesDatum, uploads);
+
+      defaultChartTypeForPatient = !utils.isMobile()
+        ? this.deriveChartTypeFromLatestData(latestDatum, latestDiabetesDatum, uploads)
+        : 'basics';
 
       // Figure out which chart to show based on the current route
       switch(true) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.1",
+  "version": "1.84.2-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.84.2-rc.1",
+  "version": "1.84.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start",


### PR DESCRIPTION
[WEB-3663] 

A JS error was occurring due to various calls within the bgLog or daily data views for mobile users due to the chart not being initialized for mobile users, but lifecycle methods still calling various chart methods.  This was noticed by Dave when his production account, which had SMBG as the latest data, was loading the bgLog view by default and hitting the error state.

With this fixed, I noticed that we were still loading the bgLog view by default if the latest datum was an SMBG, so I've updated the default view to always be 'basics' for mobile users when not specified via a URL param.  This way, the user will see the full list of stats available on the basics view, instead of the SMBG-only stats shown on the BG Log view


[WEB-3663]: https://tidepool.atlassian.net/browse/WEB-3663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ