### PR TITLE
WEB-3703 - Use custom copy when query is applied to patient list

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withTranslation, Trans } from 'react-i18next';
+import { withTranslation, Trans, useTranslation } from 'react-i18next';
 import moment from 'moment';
 import compact from 'lodash/compact';
 import debounce from 'lodash/debounce';
@@ -165,48 +165,123 @@ const ClearButton = styled.button`
   text-decoration: underline;
 `;
 
-const hasAppliedFilters = (activeFilters = {}) => {
+export const PATIENT_LIST_QUERY_STATE = {
+  FILTER_AND_SEARCH: 'FILTER_AND_SEARCH',
+  FILTER_ONLY: 'FILTER_ONLY',
+  SEARCH_ONLY: 'SEARCH_ONLY',
+  NONE: 'NONE',
+};
+
+export const getPatientListQueryState = (
+  activeFilters = {},
+  patientListSearchTextInput = '',
+) => {
   const { lastData, lastDataType, timeCGMUsePercent, timeInRange, patientTags } = activeFilters;
 
-  return (
+  const hasFiltersActive = (
     lastData ||
     lastDataType ||
     timeCGMUsePercent ||
     timeInRange?.length > 0 ||
     patientTags?.length > 0
   );
-};
 
-const ClearFilterButtons = withTranslation()(({ t, activeFilters = {}, onClearSearch, onResetFilters }) => {
-  const { patientListSearchTextInput } = useSelector(state => state.blip.patientListFilters);
-
-  const hasFiltersActive = hasAppliedFilters(activeFilters);
   const hasSearchActive = !!patientListSearchTextInput;
 
-  if (!hasSearchActive && !hasFiltersActive) return null;
+  if (hasFiltersActive && hasSearchActive) {
+    return PATIENT_LIST_QUERY_STATE.FILTER_AND_SEARCH;
+  } else if (hasFiltersActive) {
+    return PATIENT_LIST_QUERY_STATE.FILTER_ONLY;
+  } else if (hasSearchActive) {
+    return PATIENT_LIST_QUERY_STATE.SEARCH_ONLY;
+  }
+
+  return PATIENT_LIST_QUERY_STATE.NONE;
+};
+
+const EmptyContentNode = ({ patientListQueryState, children }) => {
+  const { t } = useTranslation();
+  const { FILTER_AND_SEARCH, FILTER_ONLY, SEARCH_ONLY, NONE } = PATIENT_LIST_QUERY_STATE;
+
+  const emptyContentCopyDefs = {
+    [FILTER_AND_SEARCH]: t('There are no patient accounts with the current filter(s) that match your search'),
+    [FILTER_ONLY]: t('There are no patient accounts with the current filter(s)'),
+    [SEARCH_ONLY]: t('There are no patient accounts that match your search'),
+    [NONE]: t('There are no results to show'),
+  };
+
+  const emptyContentCopy = emptyContentCopyDefs[patientListQueryState] || emptyContentCopyDefs[NONE];
 
   return (
-    <Box>
-      { hasFiltersActive &&
-        <ClearButton
-          className='reset-filters-button'
-          onClick={onResetFilters}>{t('Reset Filters')}
-        </ClearButton> }
-      { hasSearchActive && hasFiltersActive &&
-        <>{' '}{t('or')}{' '}</> }
-      { hasSearchActive &&
-        <ClearButton
-          className='clear-search-button'
-          onClick={onClearSearch}>{t('Clear Search')}
-        </ClearButton> }
-    </Box>
+    <Flex sx={{
+      backgroundColor: colorPalette.primary.bluePrimary00,
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '90px',
+      flexDirection: 'column',
+      gap: 2,
+      marginBottom: 4,
+      borderBottom: '1px solid #D1D6E1',
+    }}>
+      <Text className="table-empty-text" sx={{ fontWeight: 'medium' }}>
+        {emptyContentCopy}
+      </Text>
+
+      {children}
+    </Flex>
   );
+};
+
+const ClearFilterButtons = withTranslation()(({ t, patientListQueryState, onClearSearch, onResetFilters }) => {
+  const { FILTER_AND_SEARCH, FILTER_ONLY, SEARCH_ONLY, NONE } = PATIENT_LIST_QUERY_STATE;
+
+  switch(patientListQueryState) {
+    case SEARCH_ONLY:
+      return (
+        <ClearButton className='clear-search-button' onClick={onClearSearch}>
+          {t('Clear Search')}
+        </ClearButton>
+      );
+
+    case FILTER_ONLY:
+      return (
+        <ClearButton className='reset-filters-button' onClick={onResetFilters}>
+          {t('Reset Filters')}
+        </ClearButton>
+      );
+
+    case FILTER_AND_SEARCH:
+      return <>
+        <ClearButton className='reset-filters-button' onClick={onResetFilters}>
+          {t('Reset Filters')}
+        </ClearButton>
+        <>{' '}{t('or')}{' '}</>
+        <ClearButton className='clear-search-button' onClick={onClearSearch}>
+          {t('Clear Search')}
+        </ClearButton>
+      </>;
+
+    case NONE:
+    default:
+      return null;
+  }
 });
 
-const FilterResetBar = withTranslation()(({ t, rightSideContent }) => {
+const FilterResetBar = withTranslation()(({ t, rightSideContent, patientListQueryState }) => {
   const selectedClinicId = useSelector((state) => state.blip.selectedClinicId);
   const clinic = useSelector(state => state.blip.clinics?.[selectedClinicId]);
-  const fetchedPatientTotalCount = clinic?.fetchedPatientTotalCount || 0;
+  const shown = clinic?.fetchedPatientCount || 0;
+
+  const { FILTER_AND_SEARCH, FILTER_ONLY, SEARCH_ONLY, NONE } = PATIENT_LIST_QUERY_STATE;
+
+  const fetchedPatientCountCopyDefs = {
+    [FILTER_AND_SEARCH]: t('Showing {{ shown }} patient accounts with the current filter(s) that match your search', { shown }),
+    [FILTER_ONLY]: t('Showing {{ shown }} patient accounts with the current filter(s)', { shown }),
+    [SEARCH_ONLY]: t('Showing {{ shown }} patient accounts that match your search', { shown }),
+    [NONE]: t('There are no results to show'),
+  };
+
+  const fetchedPatientCountCopy = fetchedPatientCountCopyDefs[patientListQueryState];
 
   return (
     <Flex
@@ -219,13 +294,7 @@ const FilterResetBar = withTranslation()(({ t, rightSideContent }) => {
         justifyContent: 'space-between',
       }}
     >
-      <Text sx={{ fontWeight: 'medium' }}>
-        {t('Showing {{ shown }} of {{ total }} patient accounts', {
-          shown: clinic?.fetchedPatientCount,
-          total: fetchedPatientTotalCount,
-        })}
-      </Text>
-
+      <Text sx={{ fontWeight: 'medium' }}>{fetchedPatientCountCopy}</Text>
       <Box>{rightSideContent}</Box>
     </Flex>
   );
@@ -3211,29 +3280,6 @@ export const ClinicPatients = (props) => {
     setShowDeleteDialog,
   ]);
 
-  const EmptyContentNode = () => (
-    <Flex sx={{
-      backgroundColor: colorPalette.primary.bluePrimary00,
-      justifyContent: 'center',
-      alignItems: 'center',
-      minHeight: '90px',
-      flexDirection: 'column',
-      gap: 2,
-      marginBottom: 4,
-      borderBottom: '1px solid #D1D6E1',
-    }}>
-      <Text className="table-empty-text" sx={{ fontWeight: 'medium' }}>
-        {t('There are no results to show')}
-      </Text>
-
-      <ClearFilterButtons
-        activeFilters={activeFilters}
-        onClearSearch={handleClearSearch}
-        onResetFilters={handleResetFilters}
-      />
-    </Flex>
-  );
-
   const columns = useMemo(() => {
     const cols = [
       {
@@ -3431,24 +3477,26 @@ export const ClinicPatients = (props) => {
     const page = Math.ceil(patientFetchOptions.offset / patientFetchOptions.limit) + 1;
     const sort = patientFetchOptions.sort || defaultPatientFetchOptions.sort;
 
-    const hasActiveFilters = hasAppliedFilters(activeFilters);
-    const hasSearchActive = !!patientListSearchTextInput;
+    const patientListQueryState = getPatientListQueryState(activeFilters, patientListSearchTextInput);
 
-    // Show the Filter Reset Bar only if data exists and any filters are applied
-    const showFilterResetBar = (data?.length > 0) && (hasActiveFilters || hasSearchActive);
+    // Show the Filter Reset Bar only if data exists and any filters/search are applied
+    const showFilterResetBar = (data?.length > 0) && patientListQueryState !== PATIENT_LIST_QUERY_STATE.NONE;
 
     return (
       <Box>
         <Loader show={loading} overlay={true} />
 
         { showFilterResetBar &&
-          <FilterResetBar rightSideContent={
-            <ClearFilterButtons
-              activeFilters={activeFilters}
-              onClearSearch={handleClearSearch}
-              onResetFilters={handleResetFilters}
-            />
-          }/>
+          <FilterResetBar
+            patientListQueryState={patientListQueryState}
+            rightSideContent={
+              <ClearFilterButtons
+                patientListQueryState={patientListQueryState}
+                onClearSearch={handleClearSearch}
+                onResetFilters={handleResetFilters}
+              />
+            }
+          />
         }
 
         <Table
@@ -3461,7 +3509,15 @@ export const ClinicPatients = (props) => {
           onSort={handleSortChange}
           order={sort?.substring(0, 1) === '+' ? 'asc' : 'desc'}
           orderBy={sort?.substring(1)}
-          emptyContentNode={<EmptyContentNode />}
+          emptyContentNode={
+            <EmptyContentNode patientListQueryState={patientListQueryState}>
+              <ClearFilterButtons
+                patientListQueryState={patientListQueryState}
+                onClearSearch={handleClearSearch}
+                onResetFilters={handleResetFilters}
+              />
+            </EmptyContentNode>
+          }
         />
 
         {pageCount > 1 && (

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -237,21 +237,21 @@ const ClearFilterButtons = withTranslation()(({ t, patientListQueryState, onClea
 
   switch(patientListQueryState) {
     case SEARCH_ONLY:
-      return (
+      return <Box>
         <ClearButton className='clear-search-button' onClick={onClearSearch}>
           {t('Clear Search')}
         </ClearButton>
-      );
+      </Box>;
 
     case FILTER_ONLY:
-      return (
+      return <Box>
         <ClearButton className='reset-filters-button' onClick={onResetFilters}>
           {t('Reset Filters')}
         </ClearButton>
-      );
+      </Box>;
 
     case FILTER_AND_SEARCH:
-      return <>
+      return <Box>
         <ClearButton className='reset-filters-button' onClick={onResetFilters}>
           {t('Reset Filters')}
         </ClearButton>
@@ -259,7 +259,7 @@ const ClearFilterButtons = withTranslation()(({ t, patientListQueryState, onClea
         <ClearButton className='clear-search-button' onClick={onClearSearch}>
           {t('Clear Search')}
         </ClearButton>
-      </>;
+      </Box>;
 
     case NONE:
     default:

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -274,6 +274,8 @@ const FilterResetBar = withTranslation()(({ t, rightSideContent, patientListQuer
 
   const { FILTER_AND_SEARCH, FILTER_ONLY, SEARCH_ONLY, NONE } = PATIENT_LIST_QUERY_STATE;
 
+  if (patientListQueryState === PATIENT_LIST_QUERY_STATE.NONE) return null; // hide when no search or filters applied
+
   const fetchedPatientCountCopyDefs = {
     [FILTER_AND_SEARCH]: t('Showing {{ shown }} patient accounts with the current filter(s) that match your search', { shown }),
     [FILTER_ONLY]: t('Showing {{ shown }} patient accounts with the current filter(s)', { shown }),

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -968,7 +968,7 @@ describe('ClinicPatients', () => {
     describe('when Reset Filters button is clicked', function () {
       it('should show the No Results text', () => {
         expect(wrapper.find('.MuiTableRow-root')).to.have.length(1); // only header
-        expect(wrapper.find('.table-empty-text').hostNodes().text()).includes('There are no results to show');
+        expect(wrapper.find('.table-empty-text').hostNodes().text()).includes('There are no patient accounts with the current filter(s)');
       });
 
       it('should remove the active filters from localStorage', function () {


### PR DESCRIPTION
[WEB-3703]

[WEB-3703]: https://tidepool.atlassian.net/browse/WEB-3703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Here is each individual state:

No Filters
<img width="1511" alt="Screenshot 2025-06-03 at 13 16 19" src="https://github.com/user-attachments/assets/7c1f32ec-4abd-43d2-90b3-4fd72a5bf00c" />

Filters + Search, No Matches
<img width="1511" alt="Screenshot 2025-06-03 at 13 11 04" src="https://github.com/user-attachments/assets/48911b25-eb32-4aec-b7cc-25b3223c3a6c" />

Filters, No Matches
<img width="1511" alt="Screenshot 2025-06-03 at 13 11 18" src="https://github.com/user-attachments/assets/a0d05422-c460-4028-a8f2-12e49f4f3e2a" />

Search, No Matches
<img width="1511" alt="Screenshot 2025-06-03 at 13 11 31" src="https://github.com/user-attachments/assets/e9a6bb87-6239-4b14-be72-4e15b6536b70" />

Filters + Search with Matches
<img width="1511" alt="Screenshot 2025-06-03 at 13 13 44" src="https://github.com/user-attachments/assets/9cff4621-8eef-4122-a0b9-6870687f7d3d" />

Search with Matches
<img width="1511" alt="Screenshot 2025-06-03 at 13 14 00" src="https://github.com/user-attachments/assets/0859894e-f189-4b4c-ae78-c2dfa3a78d97" />

Filters with Matches
<img width="1511" alt="Screenshot 2025-06-03 at 13 14 29" src="https://github.com/user-attachments/assets/63ac8102-eba1-4435-977e-e2ff3422805d" />

