### PR TITLE
WEB-3707 - "Copy to Text" button is always disabled in TIDE Drawer

### DIFF
--- a/app/pages/dashboard/PatientDrawer/MenuBar/CGMClipboardButton.js
+++ b/app/pages/dashboard/PatientDrawer/MenuBar/CGMClipboardButton.js
@@ -26,9 +26,9 @@ const CGMClipboardButton = ({ patient, data }) => {
     };
   }, [buttonState]);
 
-  const { count, sampleFrequency } = data?.data?.current?.stats?.sensorUsage || {};
+  const { count, sampleInterval } = data?.data?.current?.stats?.sensorUsage || {};
 
-  const hoursOfCGMData = (count * sampleFrequency) / MS_IN_HOUR;
+  const hoursOfCGMData = (count * sampleInterval) / MS_IN_HOUR;
 
   const isDataInsufficient = !hoursOfCGMData || hoursOfCGMData < 24;
 
@@ -39,8 +39,8 @@ const CGMClipboardButton = ({ patient, data }) => {
 
   return (
     <Button disabled={isDataInsufficient} onClick={handleCopy} variant="secondary">
-      {buttonState === STATE.CLICKED 
-        ? <Box>{t('Copied ✓')}</Box> 
+      {buttonState === STATE.CLICKED
+        ? <Box>{t('Copied ✓')}</Box>
         : <Box>{t('Copy as Text')}</Box>
       }
     </Button>

--- a/test/unit/pages/dashboard/PatientDrawer/CGMStatistics/index.test.js
+++ b/test/unit/pages/dashboard/PatientDrawer/CGMStatistics/index.test.js
@@ -18,8 +18,8 @@ const agpCGM = {
     'current': {
       'aggregationsByDate': {},
       'stats': {
-        'averageGlucose': { 
-          'averageGlucose': 121.4013071783735, 
+        'averageGlucose': {
+          'averageGlucose': 121.4013071783735,
           'total': 8442,
         },
         'bgExtents': {
@@ -29,8 +29,8 @@ const agpCGM = {
           'newestDatum': { 'time': 1736783190269 },
           'oldestDatum': { 'time': 1734249705225 },
         },
-        'coefficientOfVariation': { 
-          'coefficientOfVariation': 49.82047988955789, 
+        'coefficientOfVariation': {
+          'coefficientOfVariation': 49.82047988955789,
           'total': 8442,
         },
         'glucoseManagementIndicator': {
@@ -42,7 +42,7 @@ const agpCGM = {
           'sensorUsage': 2532600000,
           'sensorUsageAGP': 99.95264030310206,
           'total': 2592000000,
-          'sampleFrequency': 300000,
+          'sampleInterval': 300000,
           'count': 8442,
         },
         'timeInRange': {
@@ -108,10 +108,10 @@ const agpCGM = {
     'types': { 'cbg': {} },
     'bgPrefs': {
       'bgUnits': 'mg/dL',
-      'bgClasses': { 
-        'low': { 'boundary': 70 }, 
-        'target': { 'boundary': 180 }, 
-        'very-low': { 'boundary': 54 }, 
+      'bgClasses': {
+        'low': { 'boundary': 70 },
+        'target': { 'boundary': 180 },
+        'very-low': { 'boundary': 54 },
         'high': { 'boundary': 250 },
       },
       'bgBounds': {

--- a/test/unit/pages/dashboard/PatientDrawer/MenuBar/CGMClipboardButton.test.js
+++ b/test/unit/pages/dashboard/PatientDrawer/MenuBar/CGMClipboardButton.test.js
@@ -32,7 +32,7 @@ const pdf = {
               'sensorUsage': 2532600000,
               'sensorUsageAGP': 99.95264030310206,
               'total': 2592000000,
-              'sampleFrequency': 300000,
+              'sampleInterval': 300000,
               'count': 8442,
             },
           },
@@ -70,11 +70,11 @@ describe('PatientDrawer/MenuBar/CGMClipboardButton', () => {
   describe('When data is insufficient due to being BGM patient', () => {
     const insufficientAgpCGM = _.cloneDeep(pdf.data.agpCGM);
     insufficientAgpCGM.data.current.stats = {
-      sensorUsage: { 
-        sensorUsage: 0, 
-        sensorUsageAGP: 0, 
-        total: 2592000000, 
-        sampleFrequency: 300000, 
+      sensorUsage: {
+        sensorUsage: 0,
+        sensorUsageAGP: 0,
+        total: 2592000000,
+        sampleInterval: 300000,
         count: 0,
       },
     };


### PR DESCRIPTION
[WEB-3707]

Looks like it was renamed recently in Viz. Because `sampleFrequency` is `undefined` here, the button thinks that data is insufficient even when it is not, so it disables itself

```js
  const { count, sampleFrequency } = data?.data?.current?.stats?.sensorUsage || {};

  const hoursOfCGMData = (count * sampleFrequency) / MS_IN_HOUR;

  const isDataInsufficient = !hoursOfCGMData || hoursOfCGMData < 24;
```

[WEB-3707]: https://tidepool.atlassian.net/browse/WEB-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ