### PR TITLE
[WEB-3758] Fix trends range label positions

### DIFF
--- a/app/components/chart/trends.js
+++ b/app/components/chart/trends.js
@@ -489,6 +489,9 @@ const Trends = withTranslation()(class Trends extends PureComponent {
 
               <div id="tidelineContainer" className="patient-data-chart-trends">
                 {dataQueryComplete && this.renderChart()}
+                {dataQueryComplete && this.renderFocusedCbgDateTraceLabel()}
+                {dataQueryComplete && this.renderFocusedSMBGPointLabel()}
+                {dataQueryComplete && this.renderFocusedRangeLabels()}
               </div>
 
               <Flex className="patient-data-footer-outer" mt="20px" mb={5} pl="40px" pr="10px" sx={{alignItems: 'center', justifyContent: 'space-between' }}>
@@ -572,10 +575,6 @@ const Trends = withTranslation()(class Trends extends PureComponent {
                   )}
                 </Flex>
               </Flex>
-
-              {dataQueryComplete && this.renderFocusedCbgDateTraceLabel()}
-              {dataQueryComplete && this.renderFocusedSMBGPointLabel()}
-              {dataQueryComplete && this.renderFocusedRangeLabels()}
             </Box>
 
             <Box className="patient-data-sidebar" variant="containers.patientDataSidebar">

--- a/app/pages/patientdata/patientdata.less
+++ b/app/pages/patientdata/patientdata.less
@@ -227,6 +227,7 @@
 }
 
 .patient-data-chart-trends {
+  position: relative;
   width: 100%;
   height: 520px;
   overflow: hidden;


### PR DESCRIPTION
[WEB-3758]

CSS positioning regression, likely from when I moved the container styles to the theme layer prior to our mobile work.

Just needed the items rendering within a relative-positioned chart area again.

[WEB-3758]: https://tidepool.atlassian.net/browse/WEB-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ