### PR TITLE
Release candidate test fixes

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -3287,29 +3287,6 @@ export const ClinicPatients = (props) => {
     setShowDeleteDialog,
   ]);
 
-  const EmptyContentNode = () => (
-    <Flex sx={{
-      backgroundColor: vizColors.blue00,
-      justifyContent: 'center',
-      alignItems: 'center',
-      minHeight: '90px',
-      flexDirection: 'column',
-      gap: 2,
-      marginBottom: 4,
-      borderBottom: '1px solid #D1D6E1',
-    }}>
-      <Text className="table-empty-text" sx={{ fontWeight: 'medium' }}>
-        {t('There are no results to show')}
-      </Text>
-
-      <ClearFilterButtons
-        activeFilters={activeFilters}
-        onClearSearch={handleClearSearch}
-        onResetFilters={handleResetFilters}
-      />
-    </Flex>
-  );
-
   const columns = useMemo(() => {
     const cols = [
       {

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "terser": "5.22.0",
     "terser-webpack-plugin": "5.3.9",
     "theme-ui": "0.16.1",
-    "tideline": "1.34.0-rc.1",
+    "tideline": "1.33.1",
     "tidepool-platform-client": "0.63.1",
     "tidepool-standard-action": "0.1.1",
     "ua-parser-js": "1.0.36",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8462,7 +8462,7 @@ __metadata:
     terser: 5.22.0
     terser-webpack-plugin: 5.3.9
     theme-ui: 0.16.1
-    tideline: 1.34.0-rc.1
+    tideline: 1.33.1
     tidepool-platform-client: 0.63.1
     tidepool-standard-action: 0.1.1
     ua-parser-js: 1.0.36
@@ -22218,9 +22218,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tideline@npm:1.34.0-rc.1":
-  version: 1.34.0-rc.1
-  resolution: "tideline@npm:1.34.0-rc.1"
+"tideline@npm:1.33.1":
+  version: 1.33.1
+  resolution: "tideline@npm:1.33.1"
   dependencies:
     bows: 1.7.2
     classnames: 2.3.2
@@ -22241,7 +22241,7 @@ __metadata:
   peerDependencies:
     babel-core: 6.x || 7.0.0-bridge.0
     lodash: ^4.17.21
-  checksum: 2dff80363f553db11b186ab4fcd87a90f0cc8b93bfac6270e73d1e94b345316af9c16b5ac116516d18aeba268683890017d0445ab55f0fbc823b0d17f73c8994
+  checksum: 4536783c0d6b5f848ab4460f6e619369c179221cb320554a9af96bd8e5e7f8220212b4090b00abc3bd2786600a69f612c1d3c23332fadef9016bc15c6beeca2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixing a merge conflict issue when I opted to keep a block of code that for `EmptyContentNode` that should have been removed.

Also, reverted  tideline - I had created a release branch for it, thinking there were changes in this next release for tideline, but there weren't any.