### PR TITLE
WEB-3693 - Reduce duration of "inviteJustSent" state to 3 seconds

### DIFF
--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -174,7 +174,7 @@ export const getConnectStateUI = (patient, isLoggedInUser, providerName, justInv
   let inviteJustSent;
 
   if (mostRecentConnectionUpdateTime) {
-    const { daysAgo, daysText, hoursAgo, hoursText, minutesAgo, minutesText } = formatTimeAgo(mostRecentConnectionUpdateTime);
+    const { daysAgo, daysText, hoursAgo, hoursText, minutesText } = formatTimeAgo(mostRecentConnectionUpdateTime);
     timeAgo = daysText;
     if (daysAgo < 1)  timeAgo = hoursAgo < 1 ? minutesText : hoursText;
     if (justInvitedProviders[providerName]) inviteJustSent = true;
@@ -356,9 +356,12 @@ export const useJustInvitedProviders = () => {
     setJustInvitedProviders(prev => ({...prev, [providerName]: true }));
   };
 
+  const isInvitationHandler = (handler) => ['sendInvite', 'resendInvite'].includes(handler);
+
   return {
     justInvitedProviders,
     handleProviderInviteSent,
+    isInvitationHandler,
   };
 };
 
@@ -382,7 +385,7 @@ export const DataConnections = (props) => {
   const [processingEmailUpdate, setProcessingEmailUpdate] = useState(false);
   const [patientUpdates, setPatientUpdates] = useState({});
   const [activeHandler, setActiveHandler] = useState(null);
-  const { justInvitedProviders, handleProviderInviteSent } = useJustInvitedProviders();
+  const { justInvitedProviders, handleProviderInviteSent, isInvitationHandler } = useJustInvitedProviders();
   const dataConnectionProps = getDataConnectionProps(patient, isLoggedInUser, selectedClinicId, setActiveHandler, justInvitedProviders);
 
   const {
@@ -526,7 +529,7 @@ export const DataConnections = (props) => {
       if (!fetchingDataSources?.inProgress) dispatch(actions.async.fetchDataSources(api));
     }
 
-    if (['sendInvite', 'resendInvite'].includes(activeHandler?.handler)) {
+    if (isInvitationHandler(activeHandler?.handler)) {
       handleProviderInviteSent(activeHandler?.providerName);
     }
   }, [fetchPatientDetails, selectedClinicId, fetchingDataSources?.inProgress, dispatch]);

--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -346,7 +346,7 @@ export const useJustInvitedProviders = () => {
     }, 3000);
 
     return () => clearTimeout(timeoutId);
-  }, [justInvitedProviders]);
+  }, [justInvitedProviders, initialState]);
 
   const handleProviderInviteSent = (providerName) => {
     if (!providerName) return;

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -622,6 +622,7 @@ describe('DataConnections', () => {
         DataConnections.__Rewire__('useJustInvitedProviders', sinon.stub().returns({
           justInvitedProviders: { dexcom: true, twiist: true },
           handleProviderInviteSent: sinon.stub(),
+          isInvitatationHandler: sinon.stub(),
         }));
       });
 

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -207,10 +207,13 @@ describe('getConnectStateUI', () => {
     }],
   }
 
+  const justInvitedProvidersUI = { dexcom: false, provider123: false };
+  const justInvitedProvidersUIJustSent = { dexcom: false, provider123: true };
+
   context('clinician user', () => {
     it('should define the UI props for the various connection states', () => {
-      const UI = getConnectStateUI(clinicPatient, false, 'provider123');
-      const UIJustSent = getConnectStateUI(clinicPatientJustSent, false, 'provider123');
+      const UI = getConnectStateUI(clinicPatient, false, 'provider123', justInvitedProvidersUI);
+      const UIJustSent = getConnectStateUI(clinicPatientJustSent, false, 'provider123', justInvitedProvidersUIJustSent);
 
       expect(UI.noPendingConnections.message).to.equal(null);
       expect(UI.noPendingConnections.text).to.equal(null);
@@ -254,9 +257,9 @@ describe('getConnectStateUI', () => {
 
   context('patient user', () =>  {
     it('should define the UI props for the various connection states', () => {
-      const UI = getConnectStateUI(userPatient, true, 'provider123');
-      const UINoDataFound = getConnectStateUI(userPatientNoDataFound, true, 'provider123');
-      const UIDataFound = getConnectStateUI(userPatientDataFound, true, 'provider123');
+      const UI = getConnectStateUI(userPatient, true, 'provider123', justInvitedProvidersUI);
+      const UINoDataFound = getConnectStateUI(userPatientNoDataFound, true, 'provider123', justInvitedProvidersUI);
+      const UIDataFound = getConnectStateUI(userPatientDataFound, true, 'provider123', justInvitedProvidersUI);
 
       expect(UI.noPendingConnections.message).to.equal(null);
       expect(UI.noPendingConnections.text).to.equal(null);
@@ -615,6 +618,17 @@ describe('DataConnections', () => {
     });
 
     describe('data connection invite just sent', () => {
+      beforeEach(() => {
+        DataConnections.__Rewire__('useJustInvitedProviders', sinon.stub().returns({
+          justInvitedProviders: { dexcom: true, twiist: true },
+          handleProviderInviteSent: sinon.stub(),
+        }));
+      });
+
+      afterEach(() => {
+        DataConnections.__ResetDependency__('useJustInvitedProviders');
+      });
+
       it('should render all appropriate data connection statuses and messages', () => {
         const store = mockStore(clinicianUserLoggedInState);
         mountWrapper(store, clinicPatients.dataConnectionInviteJustSent);


### PR DESCRIPTION
[WEB-3693]

Sharon pointed out this ticket as a small one that potentially I could help with. In actuality though, I struggled quite a bit on how to implement this given the existing architecture. I realized it would not work to simply replace the `minutesAgo` check with a `secondsAgo` check, since we only re-render every minute. I didn't want us to be re-rendering every second just to make this work, so I looked to find an alternative method based on internal state.

If you had something (simpler) in mind feel free to reject this solution.

https://github.com/user-attachments/assets/ce4af223-c86c-44b4-be74-eb7fe844ad22



[WEB-3693]: https://tidepool.atlassian.net/browse/WEB-3693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ