### PR TITLE
[WEB-2826] Only enable Abbott data provider via an LD flag

### DIFF
--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -103,6 +103,7 @@ appContext.render = async Component => {
     context: ldContext,
     options: { streaming: true },
     flags: {
+      'showAbbottProvider': false,
       'showExtremeHigh': false,
       'showPrescriptions': false,
       'showRpmReport': false,

--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -38,7 +38,7 @@ import { usePrevious } from '../../core/hooks';
 import { clinicPatientFromAccountInfo } from '../../core/personutils';
 import Icon from '../elements/Icon';
 import { useSelector } from 'react-redux';
-import DataConnections, { activeProviders } from '../../components/datasources/DataConnections';
+import DataConnections from '../../components/datasources/DataConnections';
 import DataConnectionsBanner from '../../components/elements/Card/Banners/DataConnections.png';
 import DataConnectionsModal from '../../components/datasources/DataConnectionsModal';
 import Card from '../elements/Card';

--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -43,6 +43,7 @@ export const providers = {
   dexcom: {
     id: 'oauth/dexcom',
     displayName: 'Dexcom',
+    displayOrderIndex: 0,
     restrictedTokenCreate: {
         paths: [
           '/v1/oauth/dexcom',
@@ -54,24 +55,10 @@ export const providers = {
     },
     logoImage: dexcomLogo,
   },
-  twiist: {
-    id: 'oauth/twiist',
-    displayName: 'twiist',
-    restrictedTokenCreate: {
-        paths: [
-          '/v1/oauth/twiist',
-        ],
-    },
-    dataSourceFilter: {
-      providerType: 'oauth',
-      providerName: 'twiist',
-    },
-    logoImage: twiistLogo,
-    indeterminateDataImportTime: true,
-  },
   abbott: {
     id: 'oauth/abbott',
     displayName: 'FreeStyle Libre',
+    displayOrderIndex: 2,
     restrictedTokenCreate: {
         paths: [
           '/v1/oauth/abbott',
@@ -87,9 +74,25 @@ export const providers = {
       message: t('Disconnecting here has stopped new data collection from your FreeStyle Libre device. To fully revoke consent for sharing data with Tidepool, log into your FreeStyle Libre or LibreView app, access the "Connected Apps" page, and click "Manage" and then "Disconnect" next to Tidepool.'),
     },
   },
+  twiist: {
+    id: 'oauth/twiist',
+    displayName: 'twiist',
+    displayOrderIndex: 1,
+    restrictedTokenCreate: {
+        paths: [
+          '/v1/oauth/twiist',
+        ],
+    },
+    dataSourceFilter: {
+      providerType: 'oauth',
+      providerName: 'twiist',
+    },
+    logoImage: twiistLogo,
+    indeterminateDataImportTime: true,
+  },
 };
 
-export const availableProviders = keys(providers);
+export const availableProviders = orderBy(keys(providers), provider => providers[provider].displayOrderIndex);
 
 export const getActiveProviders = (overrides = {}) => {
   const activeProviders = defaults(overrides, {
@@ -683,7 +686,7 @@ DataConnections.propTypes = {
 };
 
 DataConnections.defaultProps = {
-  shownProviders: getActiveProviders(),
+  shownProviders: availableProviders,
   trackMetric: noop,
 };
 

--- a/app/components/datasources/DataConnectionsModal.js
+++ b/app/components/datasources/DataConnectionsModal.js
@@ -9,7 +9,7 @@ import EditIcon from '@material-ui/icons/EditRounded';
 
 import * as actions from '../../redux/actions';
 import Button from './../../components/elements/Button';
-import DataConnections, { activeProviders } from './DataConnections';
+import DataConnections, { availableProviders } from './DataConnections';
 import PatientDetails from './PatientDetails';
 import { clinicPatientFromAccountInfo } from '../../core/personutils';
 import { useToasts } from './../../providers/ToastProvider';
@@ -260,7 +260,7 @@ DataConnectionsModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   patient: PropTypes.object.isRequired,
-  shownProviders: PropTypes.arrayOf(PropTypes.oneOf(activeProviders)),
+  shownProviders: PropTypes.arrayOf(PropTypes.oneOf(availableProviders)),
   trackMetric: PropTypes.func.isRequired,
 };
 

--- a/app/pages/oauth/OAuthConnection.js
+++ b/app/pages/oauth/OAuthConnection.js
@@ -13,7 +13,7 @@ import utils from '../../core/utils';
 import Banner from '../../components/elements/Banner';
 import Button from '../../components/elements/Button';
 import { Title, Subheading, Body1 } from '../../components/elements/FontStyles';
-import { activeProviders, providers } from '../../components/datasources/DataConnections';
+import { availableProviders, providers } from '../../components/datasources/DataConnections';
 
 const { Loader } = vizComponents;
 
@@ -26,7 +26,6 @@ export const OAuthConnection = (props) => {
   const dispatch = useDispatch();
   const [isCustodial, setIsCustodial] = useState();
   const [authStatus, setAuthStatus] = useState();
-
 
   const statusContent = {
     authorized: {
@@ -61,7 +60,7 @@ export const OAuthConnection = (props) => {
     const custodialSignup = queryParams.has('signupEmail') && queryParams.has('signupKey');
     setIsCustodial(custodialSignup);
 
-    if (includes(activeProviders, providerName) && statusContent[status]) {
+    if (includes(availableProviders, providerName) && statusContent[status]) {
       setAuthStatus(statusContent[status]);
     } else {
       setAuthStatus(statusContent.error)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.87.0-web-3769-show-correct--state-with-multiple-provider-connections.1",
+  "version": "1.88.0-web-2826-launchdarkly-abbott-enable.1",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",

--- a/stories/DataConnection.stories.js
+++ b/stories/DataConnection.stories.js
@@ -6,7 +6,7 @@ import map from 'lodash/map';
 import noop from 'lodash/noop';
 
 import baseTheme from '../app/themes/baseTheme';
-import { activeProviders, getDataConnectionProps } from '../app/components/datasources/DataConnections';
+import { availableProviders, getDataConnectionProps } from '../app/components/datasources/DataConnections';
 import DataConnection from '../app/components/datasources/DataConnection';
 import PatientDetails from '../app/components/datasources/PatientDetails';
 import { Divider } from 'theme-ui';
@@ -29,7 +29,7 @@ export default {
 
 const patientWithState = (isClinicContext, state, opts = {}) => ({
   id: 'patient123',
-  dataSources: state ? map(activeProviders, providerName => ({
+  dataSources: state ? map(availableProviders, providerName => ({
     providerName,
     state,
     createdTime: opts.createdTime,
@@ -38,7 +38,7 @@ const patientWithState = (isClinicContext, state, opts = {}) => ({
     lastImportTime: opts.lastImportTime,
     latestDataTime: opts.latestDataTime,
   })) : undefined,
-  connectionRequests: isClinicContext && opts.createdTime ? reduce(activeProviders, (res, providerName) => {
+  connectionRequests: isClinicContext && opts.createdTime ? reduce(availableProviders, (res, providerName) => {
     res[providerName] = [{ providerName, createdTime: opts.createdTime }];
     return res;
   }, {}) : undefined,
@@ -62,7 +62,7 @@ export const ClinicUser = {
       <React.Fragment>
         <Subheading>No Pending Connections</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -74,7 +74,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Invite Just Sent</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -86,7 +86,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Pending</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -98,7 +98,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Pending Reconnection</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -110,7 +110,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Pending Expired</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -122,7 +122,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Connected</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -134,7 +134,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Disconnected</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -146,7 +146,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Error</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -158,7 +158,7 @@ export const ClinicUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Unknown</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -194,7 +194,7 @@ export const PatientUser = {
       <React.Fragment>
         <Subheading>No Pending Connections</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -206,7 +206,7 @@ export const PatientUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Connected</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -218,7 +218,7 @@ export const PatientUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Connected With No Data</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -230,7 +230,7 @@ export const PatientUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Connected With Data</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -242,7 +242,7 @@ export const PatientUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Disconnected</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -254,7 +254,7 @@ export const PatientUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Error</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}
@@ -266,7 +266,7 @@ export const PatientUser = {
         <Divider pt={3} variant="styles.dividerDark" />
         <Subheading>Unknown</Subheading>
 
-        {map(activeProviders, (provider, index) => (
+        {map(availableProviders, (provider, index) => (
           <DataConnection
             my={1}
             key={`provider-${index}`}

--- a/test/unit/components/chart/settings.test.js
+++ b/test/unit/components/chart/settings.test.js
@@ -23,9 +23,10 @@ import moment from 'moment-timezone';
 
 import { ToastProvider } from '../../../../app/providers/ToastProvider.js';
 import DataConnectionsModal from '../../../../app/components/datasources/DataConnectionsModal.js';
-import DataConnections, { activeProviders } from '../../../../app/components/datasources/DataConnections.js';
+import DataConnections, { availableProviders, getActiveProviders } from '../../../../app/components/datasources/DataConnections.js';
 const expect = chai.expect;
 const mockStore = configureStore([thunk]);
+const activeProviders = getActiveProviders();
 
 describe('Settings', () => {
   let wrapper;
@@ -1152,7 +1153,7 @@ describe('Settings', () => {
             clinicPatient: {
               userid: '40',
               dataSources: [
-                { providerName: activeProviders[0], state: 'connected' }
+                { providerName: availableProviders[0], state: 'connected' }
               ],
             },
           };
@@ -1171,7 +1172,7 @@ describe('Settings', () => {
           expect(dataConnectionsModal().length).to.equal(0);
           expect(dataConnectionsCard().length).to.equal(0);
           expect(dataConnectionsWrapper().length).to.equal(1);
-          expect(dataConnectionsWrapper().find(`#data-connection-${activeProviders[0]}`).hostNodes().length).to.equal(1);
+          expect(dataConnectionsWrapper().find(`#data-connection-${availableProviders[0]}`).hostNodes().length).to.equal(1);
           const callCount = props.trackMetric.callCount;
 
           expect(dataConnectionsAddButton().length).to.equal(1);
@@ -1191,8 +1192,8 @@ describe('Settings', () => {
             clinicPatient: {
               userid: '40',
               dataSources: [
-                { providerName: activeProviders[0], state: 'connected' },
-                { providerName: activeProviders[1], state: 'disconnected' }
+                { providerName: availableProviders[0], state: 'connected' },
+                { providerName: availableProviders[1], state: 'disconnected' }
               ],
             },
           };
@@ -1211,8 +1212,8 @@ describe('Settings', () => {
           expect(dataConnectionsModal().length).to.equal(0);
           expect(dataConnectionsCard().length).to.equal(0);
           expect(dataConnectionsWrapper().length).to.equal(1);
-          expect(dataConnectionsWrapper().find(`#data-connection-${activeProviders[0]}`).hostNodes().length).to.equal(1);
-          expect(dataConnectionsWrapper().find(`#data-connection-${activeProviders[1]}`).hostNodes().length).to.equal(0); // disconnected providers should not be shown
+          expect(dataConnectionsWrapper().find(`#data-connection-${availableProviders[0]}`).hostNodes().length).to.equal(1);
+          expect(dataConnectionsWrapper().find(`#data-connection-${availableProviders[1]}`).hostNodes().length).to.equal(0); // disconnected providers should not be shown
         });
       });
 
@@ -1223,7 +1224,7 @@ describe('Settings', () => {
             isUserPatient: false,
             clinicPatient: {
               ...clinicPatient,
-              dataSources: _.map(activeProviders, providerName => ({ providerName, state: 'pending' })),
+              dataSources: _.map(availableProviders, providerName => ({ providerName, state: 'pending' })),
             },
           };
 
@@ -1239,7 +1240,7 @@ describe('Settings', () => {
           wrapper = mount(<Settings {...props} />, { wrappingComponent: providerWrapper(store) });
 
 
-          // No modal, card, or add button
+          // No modal or card
           expect(dataConnectionsModal().length).to.equal(0);
           expect(dataConnectionsCard().length).to.equal(0);
           expect(dataConnectionsAddButton().length).to.equal(1);
@@ -1291,7 +1292,7 @@ describe('Settings', () => {
             blip: {
               ...defaultState.blip,
               dataSources: [
-                { providerName: activeProviders[0], state: 'connected' }
+                { providerName: availableProviders[0], state: 'connected' }
               ],
             }
           };
@@ -1302,7 +1303,7 @@ describe('Settings', () => {
           expect(dataConnectionsModal().length).to.equal(0);
           expect(dataConnectionsCard().length).to.equal(0);
           expect(dataConnectionsWrapper().length).to.equal(1);
-          expect(dataConnectionsWrapper().find(`#data-connection-${activeProviders[0]}`).hostNodes().length).to.equal(1);
+          expect(dataConnectionsWrapper().find(`#data-connection-${availableProviders[0]}`).hostNodes().length).to.equal(1);
           const callCount = props.trackMetric.callCount;
 
           expect(dataConnectionsAddButton().length).to.equal(1);
@@ -1325,14 +1326,14 @@ describe('Settings', () => {
           const state = {
             blip: {
               ...defaultState.blip,
-              dataSources: _.map(activeProviders, providerName => ({ providerName, state: 'pending' })),
+              dataSources: _.map(availableProviders, providerName => ({ providerName, state: 'pending' })),
             }
           };
 
           const store = mockStore(state);
           wrapper = mount(<Settings {...props} />, { wrappingComponent: providerWrapper(store) });
 
-          // No modal, card, or add button
+          // No modal or card
           expect(dataConnectionsModal().length).to.equal(0);
           expect(dataConnectionsCard().length).to.equal(0);
           expect(dataConnectionsAddButton().length).to.equal(1);

--- a/test/unit/components/datasources/DataConnectionsModal.test.js
+++ b/test/unit/components/datasources/DataConnectionsModal.test.js
@@ -67,7 +67,6 @@ describe('DataConnectionsModal', () => {
     onClose: sinon.stub(),
     onBack: sinon.stub(),
     patient: patientWithEmail,
-    shownProviders: availableProviders,
     trackMetric: sinon.stub(),
   };
 

--- a/test/unit/components/datasources/DataConnectionsModal.test.js
+++ b/test/unit/components/datasources/DataConnectionsModal.test.js
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import DataConnectionsModal from '../../../../app/components/datasources/DataConnectionsModal';
-import DataConnections from '../../../../app/components/datasources/DataConnections';
+import DataConnections, { availableProviders } from '../../../../app/components/datasources/DataConnections';
 import { Dialog } from '../../../../app/components/elements/Dialog';
 import { ToastProvider } from '../../../../app/providers/ToastProvider';
 
@@ -67,6 +67,7 @@ describe('DataConnectionsModal', () => {
     onClose: sinon.stub(),
     onBack: sinon.stub(),
     patient: patientWithEmail,
+    shownProviders: availableProviders,
     trackMetric: sinon.stub(),
   };
 
@@ -110,6 +111,7 @@ describe('DataConnectionsModal', () => {
   beforeEach(() => {
     DataConnectionsModal.__Rewire__('api', api);
     DataConnections.__Rewire__('api', api);
+    DataConnections.__Rewire__('getActiveProviders', () => availableProviders);
 
     DataConnectionsModal.__Rewire__('useHistory', sinon.stub().returns({
       location: { query: {}, pathname: '/settings' },
@@ -131,6 +133,7 @@ describe('DataConnectionsModal', () => {
     defaultProps.onBack.resetHistory();
     DataConnections.__ResetDependency__('api');
     DataConnectionsModal.__ResetDependency__('api');
+    DataConnectionsModal.__ResetDependency__('getActiveProviders');
     DataConnectionsModal.__ResetDependency__('useHistory');
   });
 


### PR DESCRIPTION
[WEB-2826] 

This will likely only be needed for a few days when we enable Abbott by default for all users via [WEB-3835], but this pattern should allow us to soft-launch new providers in similar fashion down the line.

[WEB-2826]: https://tidepool.atlassian.net/browse/WEB-2826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3835]: https://tidepool.atlassian.net/browse/WEB-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ