### PR TITLE
WEB-3570 - Fix Regression due to Site Id missing

### DIFF
--- a/__tests__/unit/app/pages/clinicworkspace/ClinicPatients.test.js
+++ b/__tests__/unit/app/pages/clinicworkspace/ClinicPatients.test.js
@@ -586,7 +586,7 @@ describe('ClinicPatients', ()  => {
             expect(defaultProps.api.clinics.updateClinicSite).toHaveBeenCalledWith(
               'clinicID123', // clinicId,
               'site-2-id', // site id
-              { name: 'Site Zulu' }, // updated site
+              { id: 'site-2-id', name: 'Site Zulu' }, // updated site
               expect.any(Function), // callback fn passed to api
             );
 

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -1360,8 +1360,6 @@ export const ClinicPatients = (props) => {
   }, [api, dispatch, selectedClinicId, trackMetric]);
 
   const handleUpdateClinicSite = useCallback(siteId => {
-    console.log(clinicSites[siteId]);
-
     trackMetric(prefixPopHealthMetric('Edit clinic sites update'), { clinicId: selectedClinicId });
     setSelectedClinicSite(clinicSites[siteId]);
     setShowUpdateClinicSiteDialog(true);

--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -1360,6 +1360,8 @@ export const ClinicPatients = (props) => {
   }, [api, dispatch, selectedClinicId, trackMetric]);
 
   const handleUpdateClinicSite = useCallback(siteId => {
+    console.log(clinicSites[siteId]);
+
     trackMetric(prefixPopHealthMetric('Edit clinic sites update'), { clinicId: selectedClinicId });
     setSelectedClinicSite(clinicSites[siteId]);
     setShowUpdateClinicSiteDialog(true);
@@ -2567,6 +2569,7 @@ export const ClinicPatients = (props) => {
 
   const renderUpdateClinicSiteDialog = useCallback(() => {
     const name = selectedClinicSite?.name || '';
+    const id = selectedClinicSite?.id;
 
     return (
       <Dialog
@@ -2583,7 +2586,7 @@ export const ClinicPatients = (props) => {
           initialValues={{ name }}
           onSubmit={(site, context) => {
             setClinicSiteFormContext(context);
-            handleUpdateClinicSiteConfirm(site);
+            handleUpdateClinicSiteConfirm({ ...site, id });
           }}
           validationSchema={clinicSiteSchema}
         >


### PR DESCRIPTION
[WEB-3570]

There is a regression due to the `id` not being sent when trying to update a clinic site

<img width="1510" height="834" alt="image" src="https://github.com/user-attachments/assets/846e6a33-ed02-454c-b8b2-2bdd7fc09805" />

I'm absolutely confident it was working before. I think there may have been a backend change. The `siteId` is already in the URL, which is why it wasn't needed previously. However, the requirement to have the `id` in the payload matches the [PR Preview API doc](https://developer.tidepool.org/TidepoolApi/pr-preview/pr-159/#tag/Clinics/operation/UpdateSite), so we'll modify the frontend to meet the docs.

[WEB-3570]: https://tidepool.atlassian.net/browse/WEB-3570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ