### PR TITLE
[WEB-3757] Fix data refresh issues for BG Log

### DIFF
--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1189,45 +1189,57 @@ export const PatientDataClass = createReactClass({
     const chartTypeFromPath = nextProps.match?.params?.chartType;
     const targetDate = utils.parseDatetimeParamToInteger(nextProps.queryParams?.datetime);
 
-    switch(true) {
-      // If the chart is explicitly specified in the URL, we switch to that chart type.
-      case chartTypeFromPath === 'settings':
-        this.handleSwitchToSettings();
-        break;
-      case chartTypeFromPath === 'basics':
-        this.handleSwitchToBasics();
-        break;
-      case chartTypeFromPath === 'daily':
-        this.handleSwitchToDaily(targetDate);
-        break;
-      case chartTypeFromPath === 'trends':
-        this.handleSwitchToTrends(targetDate);
-        break;
-      case chartTypeFromPath === 'bgLog':
-        this.handleSwitchToBgLog(targetDate);
-        break;
+    // If the chart was previously refreshed on settings, we need to refetch the data, since the refresh
+    // would have only fetched the pump settings history, and not all the data we need to render other charts.
+    const needsDataRefetch = this.state.refreshChartType === 'settings' && chartTypeFromPath !== 'settings';
 
-      // If the chart is not specified in the URL, we should switch to the patient's default chart type,
-      // which is derived from the patient's data values. If state.defaultChartTypeForPatient
-      // exists, we should use its value rather than deriving it again using setInitialChartView().
-      case this.state.defaultChartTypeForPatient === 'basics':
-        this.handleSwitchToBasics();
-        break;
-      case this.state.defaultChartTypeForPatient === 'daily':
-        this.handleSwitchToDaily(targetDate);
-        break;
-      case this.state.defaultChartTypeForPatient === 'trends':
-        this.handleSwitchToTrends(targetDate);
-        break;
-      case this.state.defaultChartTypeForPatient === 'bgLog':
-        this.handleSwitchToBgLog(targetDate);
-        break;
+    if (needsDataRefetch) {
+      this.setState({
+        chartType: chartTypeFromPath,
+      }, () => {
+        this.handleRefresh();
+      });
+    } else {
+      switch(true) {
+        // If the chart is explicitly specified in the URL, we switch to that chart type.
+        case chartTypeFromPath === 'settings':
+          this.handleSwitchToSettings();
+          break;
+        case chartTypeFromPath === 'basics':
+          this.handleSwitchToBasics();
+          break;
+        case chartTypeFromPath === 'daily':
+          this.handleSwitchToDaily(targetDate);
+          break;
+        case chartTypeFromPath === 'trends':
+          this.handleSwitchToTrends(targetDate);
+          break;
+        case chartTypeFromPath === 'bgLog':
+          this.handleSwitchToBgLog(targetDate);
+          break;
 
-      // At this point, there is insufficient information; we need to call setInitialChartView() to derive
-      // the default chart type for this patient
-      default:
-        this.setInitialChartView(nextProps);
-        break;
+        // If the chart is not specified in the URL, we should switch to the patient's default chart type,
+        // which is derived from the patient's data values. If state.defaultChartTypeForPatient
+        // exists, we should use its value rather than deriving it again using setInitialChartView().
+        case this.state.defaultChartTypeForPatient === 'basics':
+          this.handleSwitchToBasics();
+          break;
+        case this.state.defaultChartTypeForPatient === 'daily':
+          this.handleSwitchToDaily(targetDate);
+          break;
+        case this.state.defaultChartTypeForPatient === 'trends':
+          this.handleSwitchToTrends(targetDate);
+          break;
+        case this.state.defaultChartTypeForPatient === 'bgLog':
+          this.handleSwitchToBgLog(targetDate);
+          break;
+
+        // At this point, there is insufficient information; we need to call setInitialChartView() to derive
+        // the default chart type for this patient
+        default:
+          this.setInitialChartView(nextProps);
+          break;
+      }
     }
   },
 
@@ -1813,6 +1825,13 @@ export const PatientDataClass = createReactClass({
         }, () => {
           this.props.onRefresh(this.props.currentPatientInViewId, this.state.refreshChartType);
           this.props.removeGeneratedPDFS();
+
+          // Reset the path without the datetime query param if present. This will ensure that the
+          // chart gets set to to the date of the most recent datum when the new data loads
+          if (nextProps.queryParams?.datetime) {
+            const path = `/patients/${this.props.currentPatientInViewId}/data/${this.state.refreshChartType}`;
+            this.props.history.push(path);
+          }
         });
       });
     }

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1204,47 +1204,49 @@ export const PatientDataClass = createReactClass({
       }, () => {
         this.handleRefresh();
       });
-    } else {
-      switch(true) {
-        // If the chart is explicitly specified in the URL, we switch to that chart type.
-        case chartTypeFromPath === 'settings':
-          this.handleSwitchToSettings();
-          break;
-        case chartTypeFromPath === 'basics':
-          this.handleSwitchToBasics();
-          break;
-        case chartTypeFromPath === 'daily':
-          this.handleSwitchToDaily(targetDate);
-          break;
-        case chartTypeFromPath === 'trends':
-          this.handleSwitchToTrends(targetDate);
-          break;
-        case chartTypeFromPath === 'bgLog':
-          this.handleSwitchToBgLog(targetDate);
-          break;
 
-        // If the chart is not specified in the URL, we should switch to the patient's default chart type,
-        // which is derived from the patient's data values. If state.defaultChartTypeForPatient
-        // exists, we should use its value rather than deriving it again using setInitialChartView().
-        case this.state.defaultChartTypeForPatient === 'basics':
-          this.handleSwitchToBasics();
-          break;
-        case this.state.defaultChartTypeForPatient === 'daily':
-          this.handleSwitchToDaily(targetDate);
-          break;
-        case this.state.defaultChartTypeForPatient === 'trends':
-          this.handleSwitchToTrends(targetDate);
-          break;
-        case this.state.defaultChartTypeForPatient === 'bgLog':
-          this.handleSwitchToBgLog(targetDate);
-          break;
+      return;
+    }
 
-        // At this point, there is insufficient information; we need to call setInitialChartView() to derive
-        // the default chart type for this patient
-        default:
-          this.setInitialChartView(nextProps);
-          break;
-      }
+    switch(true) {
+      // If the chart is explicitly specified in the URL, we switch to that chart type.
+      case chartTypeFromPath === 'settings':
+        this.handleSwitchToSettings();
+        break;
+      case chartTypeFromPath === 'basics':
+        this.handleSwitchToBasics();
+        break;
+      case chartTypeFromPath === 'daily':
+        this.handleSwitchToDaily(targetDate);
+        break;
+      case chartTypeFromPath === 'trends':
+        this.handleSwitchToTrends(targetDate);
+        break;
+      case chartTypeFromPath === 'bgLog':
+        this.handleSwitchToBgLog(targetDate);
+        break;
+
+      // If the chart is not specified in the URL, we should switch to the patient's default chart type,
+      // which is derived from the patient's data values. If state.defaultChartTypeForPatient
+      // exists, we should use its value rather than deriving it again using setInitialChartView().
+      case this.state.defaultChartTypeForPatient === 'basics':
+        this.handleSwitchToBasics();
+        break;
+      case this.state.defaultChartTypeForPatient === 'daily':
+        this.handleSwitchToDaily(targetDate);
+        break;
+      case this.state.defaultChartTypeForPatient === 'trends':
+        this.handleSwitchToTrends(targetDate);
+        break;
+      case this.state.defaultChartTypeForPatient === 'bgLog':
+        this.handleSwitchToBgLog(targetDate);
+        break;
+
+      // At this point, there is insufficient information; we need to call setInitialChartView() to derive
+      // the default chart type for this patient
+      default:
+        this.setInitialChartView(nextProps);
+        break;
     }
   },
 

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1191,7 +1191,12 @@ export const PatientDataClass = createReactClass({
 
     // If the chart was previously refreshed on settings, we need to refetch the data, since the refresh
     // would have only fetched the pump settings history, and not all the data we need to render other charts.
-    const needsDataRefetch = this.state.refreshChartType === 'settings' && chartTypeFromPath !== 'settings';
+    const needsDataRefetch = this.state.refreshChartType === 'settings' && _.includes([
+      'basics',
+      'daily',
+      'trends',
+      'bgLog',
+    ], chartTypeFromPath);
 
     if (needsDataRefetch) {
       this.setState({

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.89.0-web-3692-pump-alarms-daily-view.1",
+  "version": "1.89.0-web-3757-bg-log-refresh.1",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",


### PR DESCRIPTION
[WEB-3757]

The primary issue was that the datetime query param could be outside of the range of the fetched data, and it was not properly handled post-refetch.  I ended up trying a few approaches, but decided that the best one was to remove the datetime param after refetch, which allowed the data view to simply fall back to the most recent data time, which is really what we want upon refresh.

I also noticed and fixed a secondary issue that was introduced with our device settings history update - namely that a refresh on the settings view only fetches the pump history.  I added a check within handleRouteChangeEvent to see if the settings view was previously refreshed, and we are now changing to one of the other data views.  In this case, I'm skipping the typical route switch handlers and performing a refresh on the newly-navigated-to chartType, which will fetch the appropriate data and set the view to the most recent data time as desired. 

[WEB-3757]: https://tidepool.atlassian.net/browse/WEB-3757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ