### PR TITLE
[WEB-3839] Remove personal user ids from LaunchDarkly and add localStorage overrides

### DIFF
--- a/app/components/datasources/DataConnections.js
+++ b/app/components/datasources/DataConnections.js
@@ -19,12 +19,11 @@ import noop from 'lodash/noop';
 import orderBy from 'lodash/orderBy';
 import reduce from 'lodash/reduce';
 import { utils as vizUtils } from '@tidepool/viz';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import * as actions from '../../redux/actions';
 import { useToasts } from '../../providers/ToastProvider';
 import api from '../../core/api';
-import { useIsFirstRender, usePrevious } from '../../core/hooks';
+import { useIsFirstRender, useLaunchDarklyFlagOverrides, usePrevious } from '../../core/hooks';
 import i18next from '../../core/language';
 import DataConnection from './DataConnection';
 import PatientEmailModal from './PatientEmailModal';
@@ -388,7 +387,7 @@ export const DataConnections = (props) => {
   const [patientUpdates, setPatientUpdates] = useState({});
   const [activeHandler, setActiveHandler] = useState(null);
   const dataConnectionProps = getDataConnectionProps(patient, isLoggedInUser, selectedClinicId, setActiveHandler);
-  const { showAbbottProvider } = useFlags();
+  const { showAbbottProvider } = useLaunchDarklyFlagOverrides();
   const activeProviders = getActiveProviders({ abbott: showAbbottProvider });
 
   const {

--- a/app/core/hooks.js
+++ b/app/core/hooks.js
@@ -220,6 +220,7 @@ export const useDisableScrollOnNumberInput = () => {
  * @returns {Object} - Merged flags from LaunchDarkly and local storage overrides
  */
 export const useLaunchDarklyFlagOverrides = () => {
+  const launchDarklyFlags = useFlags();
   const [launchDarklyOverrides] = useLocalStorage('launchDarklyOverrides', {});
-  return { ...useFlags(), ...launchDarklyOverrides };
+  return { ...launchDarklyFlags, ...launchDarklyOverrides };
 }

--- a/app/core/hooks.js
+++ b/app/core/hooks.js
@@ -3,6 +3,7 @@ import update from 'immutability-helper'
 
 import { useField, useFormikContext } from 'formik';
 import { isPlainObject } from 'lodash';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 // c.f. https://gist.github.com/joshsalverda/d808d92f46a7085be062b2cbde978ae6
 // Avoids some performance issues in Formik's native <FieldArray />
@@ -213,3 +214,12 @@ export const useDisableScrollOnNumberInput = () => {
     document.addEventListener('wheel', function(e){ handleScroll(e); });
   }, []);
 };
+
+/**
+ * Custom hook to use LaunchDarkly flags with local storage overrides
+ * @returns {Object} - Merged flags from LaunchDarkly and local storage overrides
+ */
+export const useLaunchDarklyFlagOverrides = () => {
+  const [launchDarklyOverrides] = useLocalStorage('launchDarklyOverrides', {});
+  return { ...useFlags(), ...launchDarklyOverrides };
+}

--- a/app/redux/utils/launchDarklyMiddleware.js
+++ b/app/redux/utils/launchDarklyMiddleware.js
@@ -41,7 +41,7 @@ const launchDarklyMiddleware = () => (storeAPI) => (next) => (action) => {
       const role = personUtils.isClinicianAccount(user) ? 'clinician' : 'personal';
 
       ldContext.user = {
-        key: user?.userid,
+        key: role === 'clinician' ? user?.userid : defaultUserContext.key,
         role,
         application: 'Web',
       };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.88.0-web-3826-remove-personal-user-id-from-ld.1",
+  "version": "1.88.0-rc.4",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.88.0-rc.3",
+  "version": "1.88.0-web-3826-remove-personal-user-id-from-ld.1",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",

--- a/test/unit/redux/utils/launchDarklyMiddleware.test.js
+++ b/test/unit/redux/utils/launchDarklyMiddleware.test.js
@@ -159,7 +159,7 @@ describe('launchDarklyMiddleware', () => {
 
       expect(ldContext.user).to.eql({
        application: 'Web',
-       key: 'userID345',
+       key: 'anon',
        role: 'personal',
       });
     });


### PR DESCRIPTION
[WEB-3839]

It was deemed to be preferable to not send personal user IDs to LD in favor of allowing localStorage overrides in order to facilitate testing for personal user accounts prior to making the abbott provider feature globally accessible on prod. 

[WEB-3835]: https://tidepool.atlassian.net/browse/WEB-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3839]: https://tidepool.atlassian.net/browse/WEB-3839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ