### PR TITLE
WEB-3655 - Bump platform-client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "terser-webpack-plugin": "5.3.9",
     "theme-ui": "0.16.1",
     "tideline": "1.36.0-develop.2",
-    "tidepool-platform-client": "0.63.1",
+    "tidepool-platform-client": "0.64.0-web-3571-delete-sites.3",
     "tidepool-standard-action": "0.1.1",
     "ua-parser-js": "1.0.36",
     "url-loader": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8463,7 +8463,7 @@ __metadata:
     terser-webpack-plugin: 5.3.9
     theme-ui: 0.16.1
     tideline: 1.36.0-develop.2
-    tidepool-platform-client: 0.63.1
+    tidepool-platform-client: 0.64.0-web-3571-delete-sites.3
     tidepool-standard-action: 0.1.1
     ua-parser-js: 1.0.36
     url-loader: 4.1.1
@@ -22245,15 +22245,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tidepool-platform-client@npm:0.63.1":
-  version: 0.63.1
-  resolution: "tidepool-platform-client@npm:0.63.1"
+"tidepool-platform-client@npm:0.64.0-web-3571-delete-sites.3":
+  version: 0.64.0-web-3571-delete-sites.3
+  resolution: "tidepool-platform-client@npm:0.64.0-web-3571-delete-sites.3"
   dependencies:
     async: 0.9.0
     lodash: 4.17.21
     superagent: 5.2.2
     uuid: 3.1.0
-  checksum: 52c992080bf687275e095bd58252dbe50f7858025e8d245d1b1f42dfd16e1ec03bced377754fa5eccfba296a18aa89d0ee8302c4be2059d4376957a325465d01
+  checksum: 3d10c0f97036ec6616c0081e2d8af839df685412dc86446f8ea1c77e4bde71a30cbf460525b45e4582fb6c5ef2269787144e61884dacff1c3d10fe240381f04b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should have been bumped to `0.64.0-web-3571-delete-sites.3` when the feature branch was merged to master

https://github.com/tidepool-org/blip/pull/1596/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R199

I'm not sure how it got reverted back to `0.63.1`