### PR TITLE
[WEB-3875] Ensure that Original Carb Value is Displayed with Bolus (in tooltip) when Carb is Later Edited (hotfix) to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.88.1",
+  "version": "1.88.2-rc.0",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.6.1",
-    "@tidepool/viz": "1.49.0",
+    "@tidepool/viz": "1.49.1-rc.0",
     "async": "2.6.4",
     "autoprefixer": "10.4.16",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.6.1",
-    "@tidepool/viz": "1.49.1-rc.0",
+    "@tidepool/viz": "1.49.1",
     "async": "2.6.4",
     "autoprefixer": "10.4.16",
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.88.2-rc.0",
+  "version": "1.88.2",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,9 +6083,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tidepool/viz@npm:1.49.0":
-  version: 1.49.0
-  resolution: "@tidepool/viz@npm:1.49.0"
+"@tidepool/viz@npm:1.49.1-rc.0":
+  version: 1.49.1-rc.0
+  resolution: "@tidepool/viz@npm:1.49.1-rc.0"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -6146,7 +6146,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: bc5fd17dcf97a4484cff2df7dbbbf8fe095adba761fa39fb07ee83f9316be75f0a05c95382907bd5db518e3be3b7ee63661a6167f4117fe6c21ba7c525e7f4be
+  checksum: ad727bde49119ea53eb2029c2ea3b17ddcc90863cbba9acb7b532686bb928d582b1cbca40ca978ef4df262674348e49edf8697b6b7dc2a06cc8a1065f6944b71
   languageName: node
   linkType: hard
 
@@ -8335,7 +8335,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/react-hooks": 8.0.1
     "@testing-library/user-event": 14.6.1
-    "@tidepool/viz": 1.49.0
+    "@tidepool/viz": 1.49.1-rc.0
     async: 2.6.4
     autoprefixer: 10.4.16
     babel-core: 7.0.0-bridge.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,9 +6083,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tidepool/viz@npm:1.49.1-rc.0":
-  version: 1.49.1-rc.0
-  resolution: "@tidepool/viz@npm:1.49.1-rc.0"
+"@tidepool/viz@npm:1.49.1":
+  version: 1.49.1
+  resolution: "@tidepool/viz@npm:1.49.1"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -6146,7 +6146,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: ad727bde49119ea53eb2029c2ea3b17ddcc90863cbba9acb7b532686bb928d582b1cbca40ca978ef4df262674348e49edf8697b6b7dc2a06cc8a1065f6944b71
+  checksum: 31e1d6aed1775d7830e579c88baa9c024b4808c5ac1661111aa1f5ae685a9af31d8551fa68ac0d29e697b21cf2443ba3f65f7543d5fa7129863a37aae9a4850a
   languageName: node
   linkType: hard
 
@@ -8335,7 +8335,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/react-hooks": 8.0.1
     "@testing-library/user-event": 14.6.1
-    "@tidepool/viz": 1.49.1-rc.0
+    "@tidepool/viz": 1.49.1
     async: 2.6.4
     autoprefixer: 10.4.16
     babel-core: 7.0.0-bridge.0


### PR DESCRIPTION
for [WEB-3875] along with https://github.com/tidepool-org/viz/pull/525
This pull request updates the `DataUtil` utility to prioritize `originalFood` data when determining carbohydrate input for bolus calculations and adds corresponding test cases to ensure the functionality works as expected. This fixes a bug in WEB-3875, where later edits to the carb are displayed in connection with the bolus, even though the underlying dosing decision was based on the original carb value.

### Updates to carbohydrate input logic:
* In `src/utils/DataUtil.js`, modified the `carbInput` assignment to use `d.dosingDecision.originalFood?.nutrition?.carbohydrate?.net` as the primary source, falling back to `d.dosingDecision.food?.nutrition?.carbohydrate?.net` if `originalFood` is not present. This ensures the original carbohydrate value at the time of bolus is preserved when available. (Note that this is only present on a dosingDecision when the carb has been edited.)

### New test cases:
* In `test/utils/DataUtil.test.js`, added a test case to verify that `carbInput` prioritizes carbs in `originalFood` when present, falls back to carbs in the`food` object when `originalFood` is null, and honors explicit zero values in carbs in `originalFood`.

[WEB-3875]: https://tidepool.atlassian.net/browse/WEB-3875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ