### PR TITLE
[WEB-3771] Informed consent flow tweaks

### DIFF
--- a/__tests__/unit/app/pages/patient/DataDonationConsentDialog.test.js
+++ b/__tests__/unit/app/pages/patient/DataDonationConsentDialog.test.js
@@ -135,6 +135,40 @@ describe('DataDonationConsentDialog', () => {
     });
   });
 
+  describe('personal account + child patient', () => {
+    const props = { accountType: 'personal', patientAgeGroup: 'child' };
+
+    it('shows single step consent flow', () => {
+      renderWithStore(props);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Fuel the next generation of diabetes innovation')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+
+      // Should show caregiver name input
+      expect(screen.getByLabelText(/Parent Or Legal Guardian Name/)).toBeInTheDocument();
+    });
+
+    it('uses caregiver name in signature', async () => {
+      const user = userEvent.setup();
+      renderWithStore(props);
+
+      // Fill in required fields for first step
+      const nameInput = screen.getByLabelText(/Parent Or Legal Guardian Name/);
+      await user.type(nameInput, 'Jane Doe');
+
+      expect(screen.getByText(/Electronic signature: Jane Doe/)).toBeInTheDocument();
+    });
+
+    it('disables submit button until form is valid', () => {
+      renderWithStore(props);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
   describe('caregiver account + adult patient', () => {
     const props = { accountType: 'caregiver', patientAgeGroup: 'adult' };
 

--- a/app/pages/patient/DataDonationConsentDialog.js
+++ b/app/pages/patient/DataDonationConsentDialog.js
@@ -60,7 +60,6 @@ export const getConsentText = memoize((accountType, patientAgeGroup, patientName
         primaryConsentInputLabel: t('As their parent or guardian, I have read this form and I give my consent by checking this box and clicking "Submit."'),
         primaryConsentNameInputLabel: t('Parent Or Legal Guardian Name'),
         primaryConsentSignature: t('Electronic signature: {{names}}', { names: caregiverName }),
-        // need the form field, and to pass caregiverName along to backend
       },
     },
     caregiver: {

--- a/app/pages/patient/DataDonationConsentDialog.js
+++ b/app/pages/patient/DataDonationConsentDialog.js
@@ -43,7 +43,7 @@ export const getConsentText = memoize((accountType, patientAgeGroup, patientName
         primaryConsentSignature: t('Electronic signature: {{names}}', { names: patientName }),
       },
       youth: {
-        consentSuccessMessage: t('You assented and {{patientName}} consented on {{consentDate}}.', { consentDate, patientName }),
+        consentSuccessMessage: t('You assented and {{caregiverName}} consented on {{consentDate}}.', { consentDate, caregiverName }),
         primaryConsentQuestion: t('Do you give your consent for {{patientName}} to donate their anonymized data?', { patientName }),
         primaryConsentReviewMessage: t('Please ask your parent or guardian to review and consent on your behalf below.'),
         primaryConsentInputLabel: t('As their parent or guardian, I have read this form and I give my consent by checking this box and clicking "Next."'),
@@ -55,16 +55,12 @@ export const getConsentText = memoize((accountType, patientAgeGroup, patientName
         secondaryConsentSignature: t('Electronic signature: {{names}}', { names: [patientName, caregiverName].join(', ') }),
       },
       child: {
-        consentSuccessMessage: t('You assented and {{patientName}} consented on {{consentDate}}.', { consentDate, patientName }),
+        consentSuccessMessage: t('You consented on behalf of {{patientName}} on {{consentDate}}.', { consentDate, patientName }),
         primaryConsentQuestion: t('Do you give your consent for {{patientName}} to donate their anonymized data?', { patientName }),
-        primaryConsentReviewMessage: t('Please ask your parent or guardian to review and consent on your behalf below.'),
-        primaryConsentInputLabel: t('As their parent or guardian, I have read this form and I give my consent by checking this box and clicking "Next."'),
-        primaryConsentSignature: t('Electronic signature: {{names}}', { names: caregiverName }),
+        primaryConsentInputLabel: t('As their parent or guardian, I have read this form and I give my consent by checking this box and clicking "Submit."'),
         primaryConsentNameInputLabel: t('Parent Or Legal Guardian Name'),
-        secondaryConsentQuestion: t('{{patientName}}, do you want to donate your anonymized data?', { patientName }),
-        secondaryConsentDescription: t('My parent or guardian read The Tidepool Big Data Donation Project Informed Consent Form, explained this project to me, answered my questions about the project, and said that it was all right for me to donate my anonymized data if I wanted to. I understand that the project will get information from my Tidepool account and share it with researchers and others involved in helping to make care for diabetes better. I understand that my participation is voluntary, I don\'t have to do this, and I can opt out at any time. '),
-        secondaryConsentInputLabel: t('Yes - By checking the box and clicking "Submit," I am saying that I want to donate my anonymized data.'),
-        secondaryConsentSignature: t('Electronic signature: {{names}}', { names: [patientName, caregiverName].join(', ') }),
+        primaryConsentSignature: t('Electronic signature: {{names}}', { names: caregiverName }),
+        // need the form field, and to pass caregiverName along to backend
       },
     },
     caregiver: {

--- a/app/pages/patient/DataDonationForm.js
+++ b/app/pages/patient/DataDonationForm.js
@@ -72,9 +72,9 @@ export const DataDonationForm = (props) => {
   const accountType = personUtils.patientIsOtherPerson(user) ? 'caregiver' : 'personal';
   const patientAgeGroup = isChild ? 'child' : (isYouth ? 'youth' : 'adult');
   const patientName = personUtils.patientFullName(user);
-  const caregiverName = accountType === 'caregiver' ? personUtils.fullName(user) : undefined;
   const { [DATA_DONATION_CONSENT_TYPE]: consentDocument } = useSelector((state) => state.blip.consents);
   const currentConsent = useSelector(state => state.blip.consentRecords[DATA_DONATION_CONSENT_TYPE]);
+  const caregiverName = accountType === 'caregiver' ? personUtils.fullName(user) : currentConsent?.parentGuardianName;
   const currentForm = currentConsent ? formSteps.supportedOrganizations : formSteps.dataDonationConsent;
   const fallbackConsentDate = moment().format('MMMM D, YYYY');
   const consentDate = currentConsent?.grantTime ? moment(currentConsent.grantTime).format('MMMM D, YYYY') : fallbackConsentDate;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.88.3-rc.1",
+  "version": "1.88.3-rc.2",
   "private": true,
   "scripts": {
     "test": "concurrently \"TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand\" \"TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start\" --group --success=all",


### PR DESCRIPTION
[WEB-3771] Some tweaks for the consent flow consent dialog and form:

We needed to show different copy for the personal account + child patient scenario (was thought to be impossible in the original scope, but it can actually happen if the child account is started as a custodial one)

I had added copy for this, just in case there turned out to be a way, but it was previously just a copy of the personal account + youth flow.  

Bill and I went over this new scenario and agreed on what we need to show.  It should be single step, collecting the caregiver name, and  modifying the copy a bit.

The other change was a bug fix where I was showing the patient name instead of the caregiver name in the consent success message for the personal + youth scenario, and I needed to get the caregiverName from teh current consent in that scenario since it's not available at the patient profile level in that case, since it's a personal account.

[WEB-3771]: https://tidepool.atlassian.net/browse/WEB-3771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ