### PR TITLE
[WEB-4476] Prevent stale stats after panning daily/bgLog charts

### DIFF
--- a/app/components/chart/bgLog.js
+++ b/app/components/chart/bgLog.js
@@ -212,6 +212,8 @@ class BgLog extends Component {
     this.chartType = 'bgLog';
     this.log = bows('BgLog View');
     this.state = this.getInitialState()
+    // Created once so rapid-fire D3 'navigated' events during pan animation properly debounce
+    this.debouncedDateRangeUpdate = _.debounce((...args) => this.props.onUpdateChartDateRange(...args), 250);
   }
 
   getInitialState = () => {
@@ -233,9 +235,7 @@ class BgLog extends Component {
   };
 
   componentWillUnmount = () => {
-    if (this.state.debouncedDateRangeUpdate) {
-      this.state.debouncedDateRangeUpdate.cancel();
-    }
+    this.debouncedDateRangeUpdate.cancel();
   };
 
   render = () => {
@@ -507,22 +507,15 @@ class BgLog extends Component {
       title: this.getTitle(datetimeLocationEndpoints),
     });
 
-    // Update the chart date range in the data component.
-    // We debounce this to avoid excessive updates while panning the view.
-    if (this.state.debouncedDateRangeUpdate) {
-      this.state.debouncedDateRangeUpdate.cancel();
-    }
-
     const dateCeiling = getLocalizedCeiling(datetimeLocationEndpoints[1], _.get(this.props, 'data.timePrefs', {}));
 
     const datetimeLocation = moment.utc(dateCeiling.valueOf())
       .subtract(12, 'hours')
       .toISOString();
 
-    const debouncedDateRangeUpdate = _.debounce(this.props.onUpdateChartDateRange, 250);
-    debouncedDateRangeUpdate(datetimeLocation);
-
-    this.setState({ debouncedDateRangeUpdate });
+    // The debounced function is a stable instance property so that rapid-fire D3 'navigated'
+    // events (emitted on every animation frame during a pan) correctly cancel each other.
+    this.debouncedDateRangeUpdate(datetimeLocation);
   };
 
   handleInTransition = inTransition => {

--- a/app/components/chart/daily.js
+++ b/app/components/chart/daily.js
@@ -269,6 +269,8 @@ class Daily extends Component {
     this.state = this.getInitialState()
     this.chartRef = React.createRef();
     this.headerRef = React.createRef();
+    // Created once so rapid-fire D3 'navigated' events during pan animation properly debounce
+    this.debouncedDateRangeUpdate = _.debounce((...args) => this.props.onUpdateChartDateRange(...args), 250);
   }
 
   getInitialState = () => {
@@ -309,9 +311,7 @@ class Daily extends Component {
   };
 
   componentWillUnmount = () => {
-    if (this.state.debouncedDateRangeUpdate) {
-      this.state.debouncedDateRangeUpdate.cancel();
-    }
+    this.debouncedDateRangeUpdate.cancel();
   };
 
   render = () => {
@@ -667,14 +667,9 @@ class Daily extends Component {
 
     // Update the chart date range in the data component.
     // We debounce this to avoid excessive updates while panning the view.
-    if (this.state.debouncedDateRangeUpdate) {
-      this.state.debouncedDateRangeUpdate.cancel();
-    }
-
-    const debouncedDateRangeUpdate = _.debounce(this.props.onUpdateChartDateRange, 250);
-    debouncedDateRangeUpdate(datetimeLocationEndpoints[0].end.toISOString());
-
-    this.setState({ debouncedDateRangeUpdate });
+    // The debounced function is a stable instance property so that rapid-fire D3 'navigated'
+    // events (emitted on every animation frame during a pan) correctly cancel each other.
+    this.debouncedDateRangeUpdate(datetimeLocationEndpoints[0].end.toISOString());
   };
 
   handleInTransition = inTransition => {

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -1402,7 +1402,7 @@ export const PatientDataClass = createReactClass({
       } else if (queryStats || queryAggregations) {
         const query = {
           bgPrefs: _.get(this.state, 'bgPrefs'),
-          endpoints: _.get(this.state, 'chartEndpoints.current'),
+          endpoints: this.state.endpoints,
           stats: queryStats ? this.getStatsByChartType() : undefined,
           aggregationsByDate: queryAggregations ? this.getAggregationsByChartType() : undefined,
         };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.94.1-rc.5",
+  "version": "1.94.1-rc.6",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand; JEST_EXIT_CODE=$?; TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start; KARMA_EXIT_CODE=$?; [ $JEST_EXIT_CODE -eq 0 ] && [ $KARMA_EXIT_CODE -eq 0 ]",

--- a/test/unit/components/chart/bgLog.test.js
+++ b/test/unit/components/chart/bgLog.test.js
@@ -174,22 +174,20 @@ describe('BG Log', () => {
       expect(state().title).to.equal('Jan 15, 2018 - Jan 28, 2018');
     });
 
-    it('should set a debounced call of the `onUpdateChartDateRange` prop method', () => {
-      sinon.spy(_, 'debounce');
-      sinon.assert.callCount(_.debounce, 0);
-
+    it('should call the `onUpdateChartDateRange` prop method debounced via a stable instance property', () => {
+      expect(instance.debouncedDateRangeUpdate).to.be.a('function');
       expect(state().debouncedDateRangeUpdate).to.be.undefined;
+
+      const debounceStub = sinon.stub(instance, 'debouncedDateRangeUpdate');
 
       instance.handleDatetimeLocationChange([
         '2018-01-15T00:00:00.000Z',
         '2018-01-16T00:00:00.000Z',
       ], chart);
 
-      sinon.assert.callCount(_.debounce, 1);
-      sinon.assert.calledWith(_.debounce, baseProps.onUpdateChartDateRange);
-      expect(state().debouncedDateRangeUpdate).to.be.a('function');
+      sinon.assert.calledOnce(debounceStub);
 
-      _.debounce.restore();
+      debounceStub.restore();
     });
   });
 });

--- a/test/unit/components/chart/daily.test.js
+++ b/test/unit/components/chart/daily.test.js
@@ -310,19 +310,18 @@ describe('Daily', () => {
       expect(instance.state.title).to.equal('Tue, Jan 16, 2018');
     });
 
-    it('should set a debounced call of the `onUpdateChartDateRange` prop method', () => {
-      sinon.spy(_, 'debounce');
-      sinon.assert.callCount(_.debounce, 0);
-
+    it('should call the `onUpdateChartDateRange` prop method debounced via a stable instance property', () => {
+      expect(instance.debouncedDateRangeUpdate).to.be.a('function');
       expect(instance.state.debouncedDateRangeUpdate).to.be.undefined;
+
+      const debounceStub = sinon.stub(instance, 'debouncedDateRangeUpdate');
 
       instance.handleDatetimeLocationChange(endpoints);
 
-      sinon.assert.callCount(_.debounce, 1);
-      sinon.assert.calledWith(_.debounce, baseProps.onUpdateChartDateRange);
-      expect(instance.state.debouncedDateRangeUpdate).to.be.a('function');
+      sinon.assert.calledOnce(debounceStub);
+      sinon.assert.calledWith(debounceStub, endpoints[0].end.toISOString());
 
-      _.debounce.restore();
+      debounceStub.restore();
     });
   });
 

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -1425,7 +1425,7 @@ describe('PatientData', function () {
     });
 
     it('should query stats if enabled via arg, but not by default, nor if querying data', () => {
-      instance.setState({ chartEndpoints: { current: [100, 200] }, bgPrefs: 'bgPrefs' });
+      instance.setState({ endpoints: [100, 200], bgPrefs: 'bgPrefs' });
 
       // queryData set to false and queryStats set undefined
       instance.updateChartPrefs({ trends: 'bar'}, false);
@@ -1452,7 +1452,7 @@ describe('PatientData', function () {
     });
 
     it('should query aggregations if enabled via arg, but not by default, nor if querying data', () => {
-      instance.setState({ chartEndpoints: { current: [100, 200] }, bgPrefs: 'bgPrefs' });
+      instance.setState({ endpoints: [100, 200], bgPrefs: 'bgPrefs' });
 
       // queryData and queryStats set to false and queryAggregations set undefined
       instance.updateChartPrefs({ trends: 'bar'}, false, false);


### PR DESCRIPTION

## Problem
See [WEB-4476]
Two related bugs caused incorrect stats after using the pan buttons on the daily and bgLog chart views.  Note: I was only able to trigger the race condition on the daily chart, but it made sense to me to update the bgLog chart in like manner since it could theoretically happen at some point down the road there too.

**Stale stats after panning**

The pan buttons use a D3 animated transition that emits ~31 `'navigated'` events (one per animation frame). `handleDatetimeLocationChange` was creating a new `_.debounce` instance on each call and storing it via `setState`. Because `setState` is async, `cancel()` always failed — so up to 31 independent debounced queries would fire, racing each other and blocking the final correct query at the destination date.

Mouse drag was unaffected because it fires a single `'navigated'` event on release.

**Stale stats after toggling BGM/CGM following a pan**

`updateChartPrefs` (called by the BGM/CGM toggle with `queryStats: true`) was using `chartEndpoints.current` as the query endpoint. This value is only updated during full data queries, not stats-only pan queries — so after panning, it remained at the pre-pan date.

## Fix

- Move the debounced `onUpdateChartDateRange` call to a stable instance property created once in the constructor, so all `'navigated'` events share the same debounced function and cancel correctly (`daily.js`, `bgLog.js`)
- Use `this.state.endpoints` instead of `chartEndpoints.current` in `updateChartPrefs`, as it is always current (`patientdata.js`)


[WEB-4476]: https://tidepool.atlassian.net/browse/WEB-4476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ