### PR TITLE
WEB-4459 - Fix Settings Disappearing

### DIFF
--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -13,6 +13,7 @@ import AddRoundedIcon from '@material-ui/icons/AddRounded';
 import InfoRoundedIcon from '@material-ui/icons/InfoRounded';
 import launchCustomProtocol from 'custom-protocol-detection';
 import { DesktopOnly } from '../mediaqueries';
+import { colors as vizColors } from '@tidepool/viz';
 
 import {
   bindPopover,
@@ -98,8 +99,8 @@ export const useLatestDatumTime = (tidepoolApi = api, uploadId) => {
 
 const SettingsPopover = styled(Popover)`
   .MuiPopover-paper {
-    overflow: hidden;
-  }
+    max-height: 40vh;
+  };
 `;
 
 const Settings = ({
@@ -545,7 +546,7 @@ const Settings = ({
           settingsSelectionPopupState.close();
         }}
       >
-        <DialogContent px={2} py={3} dividers>
+        <DialogContent px={2} py={3} sx={{ borderBottom: 'unset' }}>
           <Box sx={{ alignItems: 'center' }} mb={2}>
             <Text
               sx={{
@@ -564,7 +565,7 @@ const Settings = ({
             name="settings"
             options={settingsOptions}
             variant="vertical"
-            sx={{ fontSize: 0, maxHeight: '40vh' }}
+            sx={{ fontSize: 0 }}
             value={pendingSettings || selectedSettingsId}
             onChange={(event) => {
               setPendingSettings(event.target.value || null);
@@ -572,7 +573,16 @@ const Settings = ({
           />
         </DialogContent>
 
-        <DialogActions sx={{ justifyContent: 'space-between' }} p={1}>
+        <DialogActions
+          sx={{
+            position: 'sticky',
+            bottom: '-8px',
+            borderTop: `1px solid ${vizColors.gray10}`,
+            background: vizColors.white,
+            justifyContent: 'space-between'
+          }}
+          p={1}
+        >
           <Button
             id="cancel-settings-selection"
             sx={{ fontSize: 1 }}

--- a/app/components/chart/settings.js
+++ b/app/components/chart/settings.js
@@ -100,6 +100,7 @@ export const useLatestDatumTime = (tidepoolApi = api, uploadId) => {
 const SettingsPopover = styled(Popover)`
   .MuiPopover-paper {
     max-height: 40vh;
+    padding-bottom: 0;
   };
 `;
 
@@ -576,7 +577,7 @@ const Settings = ({
         <DialogActions
           sx={{
             position: 'sticky',
-            bottom: '-8px',
+            bottom: 0,
             borderTop: `1px solid ${vizColors.gray10}`,
             background: vizColors.white,
             justifyContent: 'space-between'


### PR DESCRIPTION
[WEB-4459]

So the bug is kind of weird.  The `<option>` elements still took up space (had DOM measurements) even though `overflow: hidden` was applied. Typically, the outer container would ignore the size of the grandchildren when determining its own height, but in this case for some weird reason the outer contiainer always took that space into account. Some weird CSS behaviour that is difficult to unset - I couldn't get it to actually ignore the space taken up by the grandchildren.

Here's a visual "demonstration" of the bug so you can see why it's going blank. It's actually just scrolled down, but the scrolling is locked due to `overflow: hidden`. You see that when I un-apply `overflow: hidden` I can scroll to the top and everything is visible.

https://github.com/user-attachments/assets/d30e9ae8-cddb-4716-9659-e0f9af6cde0d

Again, I can't seem to make the popover ignore the size of the grandchildren for some reason, I tried a number of approaches. Some weird CSS properties of the popover. So instead, I am just constraining the height of the entire popover container.

[WEB-4459]: https://tidepool.atlassian.net/browse/WEB-4459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ