### PR TITLE
Fix clinic patient list stuck-empty on hard reload

### DIFF
--- a/app/pages/clinicworkspace/ClinicPatients.js
+++ b/app/pages/clinicworkspace/ClinicPatients.js
@@ -1215,7 +1215,9 @@ export const ClinicPatients = (props) => {
   ]);
 
   useEffect(() => {
-    setShowSummaryData(showSummaryDashboard || clinic?.entitlements?.summaryDashboard)
+    // Coerce to boolean so the !isBoolean(showSummaryData) guard at the patientFetchOptions effect
+    // doesn't keep the patient fetch indefinitely blocked when entitlements haven't arrived yet.
+    setShowSummaryData(!!(showSummaryDashboard || clinic?.entitlements?.summaryDashboard));
   }, [showSummaryDashboard, clinic?.entitlements]);
 
   useEffect(() => {

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -1754,7 +1754,9 @@ export function getAllClinics(api, options = {}, cb = _.noop) {
     dispatch(sync.getClinicsRequest());
 
     api.clinics.getAll(options, (err, clinics) => {
-      cb(err, clinics);
+      // Dispatch the success/failure action BEFORE invoking cb so that any caller reading
+      // state from inside the callback sees clinics populated. See getClinicsForClinician for the
+      // detailed rationale.
       if (err) {
         dispatch(sync.getClinicsFailure(
           createActionError(ErrorMessages.ERR_GETTING_CLINICS, err), err
@@ -1768,6 +1770,7 @@ export function getAllClinics(api, options = {}, cb = _.noop) {
           dispatch(fetchClinicMRNSettings(api, clinic.id));
         });
       }
+      cb(err, clinics);
     });
   };
 }
@@ -2668,7 +2671,11 @@ export function getClinicsForClinician(api, clinicianId, options = {}, cb = _.no
     dispatch(sync.getClinicsForClinicianRequest());
 
     api.clinics.getClinicsForClinician(clinicianId, options, (err, clinics) => {
-      cb(err, clinics);
+      // Dispatch the success/failure action BEFORE invoking cb so that any caller reading
+      // state from inside the callback (notably async.login's async.parallel final callback, which
+      // dispatches selectClinic) sees clinics populated. Previously the cb-before-dispatch order
+      // caused selectClinic's `if (clinic)` guard to short-circuit, leaving clinic.entitlements
+      // undefined and the LD context stuck on the 'none' fallback.
       if (err) {
         dispatch(sync.getClinicsForClinicianFailure(
           createActionError(ErrorMessages.ERR_FETCHING_CLINICS_FOR_CLINICIAN, err), err
@@ -2676,6 +2683,7 @@ export function getClinicsForClinician(api, clinicianId, options = {}, cb = _.no
       } else {
         dispatch(sync.getClinicsForClinicianSuccess(clinics, clinicianId, options));
       }
+      cb(err, clinics);
       // fetch EHR and MRN settings for clinics
       _.each(clinics, (clinic) => {
         dispatch(fetchClinicEHRSettings(api, clinic.clinic.id));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.95.2",
+  "version": "1.95.3-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand; JEST_EXIT_CODE=$?; TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start; KARMA_EXIT_CODE=$?; [ $JEST_EXIT_CODE -eq 0 ] && [ $KARMA_EXIT_CODE -eq 0 ]",

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -5599,6 +5599,52 @@ describe('Actions', () => {
         expect(actions).to.eql(expectedActions);
         expect(api.clinics.getAll.callCount).to.equal(1);
       });
+
+      it('should dispatch GET_CLINICS_SUCCESS before invoking cb', () => {
+        // cb must fire AFTER the success dispatch so that any caller
+        // reading state from inside the callback sees clinics populated.
+        let clinics = [
+          {
+            id: '5f85fbe6686e6bb9170ab5d0',
+            address: '1 Address Ln, City Zip',
+            name: 'Clinic1',
+          },
+        ];
+
+        let api = {
+          clinics: {
+            getAll: sinon.stub().callsArgWith(1, null, clinics),
+            getEHRSettings: sinon.stub().callsArgWith(1, null, {}),
+            getMRNSettings: sinon.stub().callsArgWith(1, null, {}),
+          },
+        };
+
+        let store = mockStore({ blip: initialState });
+        let actionTypesAtCbTime = null;
+
+        store.dispatch(async.getAllClinics(api, {}, () => {
+          actionTypesAtCbTime = _.map(store.getActions(), 'type');
+        }));
+
+        expect(actionTypesAtCbTime).to.include('GET_CLINICS_SUCCESS');
+      });
+
+      it('should dispatch GET_CLINICS_FAILURE before invoking cb on error', () => {
+        let api = {
+          clinics: {
+            getAll: sinon.stub().callsArgWith(1, { status: 500, body: 'Error!' }, null),
+          },
+        };
+
+        let store = mockStore({ blip: initialState });
+        let actionTypesAtCbTime = null;
+
+        store.dispatch(async.getAllClinics(api, {}, () => {
+          actionTypesAtCbTime = _.map(store.getActions(), 'type');
+        }));
+
+        expect(actionTypesAtCbTime).to.include('GET_CLINICS_FAILURE');
+      });
     });
 
     describe('createClinic', () => {
@@ -8572,6 +8618,59 @@ describe('Actions', () => {
         expectedActions[1].error = actions[1].error;
         expect(actions).to.eql(expectedActions);
         expect(api.clinics.getClinicsForClinician.callCount).to.equal(1);
+      });
+
+      it('should dispatch GET_CLINICS_FOR_CLINICIAN_SUCCESS before invoking cb', () => {
+        // cb must fire AFTER the success dispatch so that any caller
+        // reading state from inside the callback (notably async.login's async.parallel collector,
+        // which dispatches selectClinic) sees clinics populated. The cb-before-dispatch ordering
+        // caused selectClinic's `if (clinic)` guard to short-circuit and left clinic.entitlements
+        // undefined, which in turn blocked the patient list fetch on hard reload.
+        let clinicianId = 'clinicianId1';
+        let clinics = [
+          {
+            clinic: {
+              id: '5f85fbe6686e6bb9170ab5d0',
+              name: 'Clinic1',
+            },
+            clinician: { id: 'clinicianId1' },
+          },
+        ];
+
+        let api = {
+          clinics: {
+            getClinicsForClinician: sinon.stub().callsArgWith(2, null, clinics),
+            getEHRSettings: sinon.stub().callsArgWith(1, null, {}),
+            getMRNSettings: sinon.stub().callsArgWith(1, null, {}),
+          },
+        };
+
+        let store = mockStore({ blip: initialState });
+        let actionTypesAtCbTime = null;
+
+        store.dispatch(async.getClinicsForClinician(api, clinicianId, {}, () => {
+          actionTypesAtCbTime = _.map(store.getActions(), 'type');
+        }));
+
+        expect(actionTypesAtCbTime).to.include('GET_CLINICS_FOR_CLINICIAN_SUCCESS');
+      });
+
+      it('should dispatch GET_CLINICS_FOR_CLINICIAN_FAILURE before invoking cb on error', () => {
+        let clinicianId = 'clinicianId1';
+        let api = {
+          clinics: {
+            getClinicsForClinician: sinon.stub().callsArgWith(2, { status: 500, body: 'Error!' }, null),
+          },
+        };
+
+        let store = mockStore({ blip: initialState });
+        let actionTypesAtCbTime = null;
+
+        store.dispatch(async.getClinicsForClinician(api, clinicianId, {}, () => {
+          actionTypesAtCbTime = _.map(store.getActions(), 'type');
+        }));
+
+        expect(actionTypesAtCbTime).to.include('GET_CLINICS_FOR_CLINICIAN_FAILURE');
       });
     });
 


### PR DESCRIPTION
# WEB-4589 — Fix patient list showing "no results to show" on refresh

## What was happening

A handful of clinics reported that when they refreshed the patient list page, it would sometimes load empty — with "There are no results to show" — even though the clinic had patients. Clicking away to another page (like Account Settings) and back would make the list appear correctly.

Engineering and the backend team confirmed nothing was wrong with the clinic's data, and the backend wasn't returning empty results. The patient list page just **wasn't asking the backend for the patients in the first place** on the broken loads.

## Why it happened

The page builds the patient list in several steps. On a normal page refresh, two important pieces of information need to land in the app before the patient list can fetch:

1. **The list of clinics** the user belongs to (from the backend)
2. **The selected clinic's plan-tier entitlements** (computed from the clinic data — tells the page which features the clinic gets, like the summary dashboard)

These two pieces have always been fetched at roughly the same time on page refresh, but they finish in slightly different orders depending on network timing. There were two latent issues with how the page handled this:

- **The race:** the code that computes the clinic's entitlements only ran if the clinics list was *already in the app's state* at the moment it was triggered. If it ran a fraction of a second too early — before the clinics list had been stored — it silently did nothing, and entitlements were never computed for the rest of the session.

- **The short-circuit:** when the page later checked "does this clinic have the summary dashboard entitlement?" the JavaScript expression returned `undefined` instead of `false` if entitlements were missing. The page interpreted `undefined` as "still loading, wait" and never proceeded to fetch the patient list.

Together, the race could leave entitlements missing, and the short-circuit made the page wait forever for them — so the patient fetch never fired.

## Why now

The backend team recently sped up the clinics-list API endpoint, which shifted the timing of when things finish on page load just enough to expose this race for some users. Both bugs have existed for a long time — they were just usually masked because the slower endpoint gave the rest of the page time to settle first.

## What was fixed

Two small changes:

1. **In `app/redux/actions/async.js`:** rearranged the order of two lines in the clinics-list fetch logic, so that the app's state is updated *before* the callback fires. Now any code that reads state from inside that callback always sees the clinics, and the entitlements computation never silently no-ops. Applied the same fix to a sibling function (`getAllClinics`) that had the same pattern.

2. **In `app/pages/clinicworkspace/ClinicPatients.js`:** added a `!!` (boolean coercion) to the check that decides whether to wait for entitlements. Now if entitlements legitimately haven't arrived yet, the page proceeds to fetch the basic patient list anyway, and re-fetches with summary data once entitlements do arrive. This is defense-in-depth — if a similar race ever crops up elsewhere, the page degrades to "patients without summary columns" rather than getting stuck.

## Tests

Four new regression tests assert the corrected ordering so this specific bug class hopefully won't regress.
