### PR TITLE
[WEB-4592] Fix patient list stale-overwrite race under slow network

### DIFF
--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -2067,11 +2067,22 @@ export function deletePatientFromClinic(api, clinicId, patientId, cb = _.noop) {
  * @param {Number} [options.sortType] - type of bg data to sort by (cgm|bgm)
  * @param {Number} [options.period] - summary period to sort by (1d|7d|14d|30d)
  */
+// Monotonic sequence counter used by fetchPatientsForClinic to ignore stale responses when multiple
+// fetches are in flight simultaneously (e.g. the showSummaryData boolean coercion fix can dispatch a
+// non-summary fetch followed by a summary fetch on the same page load; under slow network conditions
+// the older one can otherwise return last and overwrite the newer correctly-filtered result).
+let latestPatientsFetchSeq = 0;
+
 export function fetchPatientsForClinic(api, clinicId, options = {}) {
   return (dispatch) => {
+    const seq = ++latestPatientsFetchSeq;
     dispatch(sync.fetchPatientsForClinicRequest());
 
     api.clinics.getPatientsForClinic(clinicId, options, (err, results) => {
+      // If a newer fetch has been dispatched while this one was in flight, abandon this response
+      // entirely. No success/failure dispatch — let the newer fetch be the one that updates state.
+      if (seq !== latestPatientsFetchSeq) return;
+
       if (err) {
         let errMsg = ErrorMessages.ERR_FETCHING_PATIENTS_FOR_CLINIC;
         if (err?.status === 403) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.95.3-rc.1",
+  "version": "1.95.3-rc.2",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose --runInBand; JEST_EXIT_CODE=$?; TZ=UTC NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' yarn karma start; KARMA_EXIT_CODE=$?; [ $JEST_EXIT_CODE -eq 0 ] && [ $KARMA_EXIT_CODE -eq 0 ]",

--- a/test/unit/redux/actions/async.test.js
+++ b/test/unit/redux/actions/async.test.js
@@ -6753,6 +6753,72 @@ describe('Actions', () => {
         expect(actions).to.eql(expectedActions);
         expect(api.clinics.getPatientsForClinic.callCount).to.equal(1);
       });
+
+      it('should abandon stale fetch responses when a newer fetch has been dispatched (stale-overwrite race fix)', () => {
+        // Two fetches are dispatched in sequence (e.g. an early non-summary fetch followed by a
+        // later summary fetch when entitlements arrive). If the older one returns LAST under slow
+        // network conditions, its payload must NOT overwrite the newer one's result.
+        const clinicId = '5f85fbe6686e6bb9170ab5d0';
+        let cbA;
+        let cbB;
+        const api = {
+          clinics: {
+            getPatientsForClinic: sinon.stub()
+              .onFirstCall().callsFake((id, opts, callback) => { cbA = callback; })
+              .onSecondCall().callsFake((id, opts, callback) => { cbB = callback; }),
+          },
+        };
+
+        const store = mockStore({ blip: initialState });
+
+        // Dispatch fetch A (older) — captures cbA
+        store.dispatch(async.fetchPatientsForClinic(api, clinicId, { offset: 0 }));
+        // Dispatch fetch B (newer) — captures cbB
+        store.dispatch(async.fetchPatientsForClinic(api, clinicId, { offset: 0, tags: ['t1'] }));
+
+        // Resolve fetch B first (returns 1 filtered patient)
+        cbB(null, { data: [{ id: 'patient_B' }], meta: { count: 1, totalCount: 1 } });
+        // Resolve fetch A last (would return 99 unfiltered patients — stale)
+        cbA(null, { data: _.times(99, (i) => ({ id: `patient_A_${i}` })), meta: { count: 99, totalCount: 99 } });
+
+        const successActions = _.filter(store.getActions(), { type: 'FETCH_PATIENTS_FOR_CLINIC_SUCCESS' });
+
+        // Only fetch B's SUCCESS should have dispatched; fetch A is silently abandoned.
+        expect(successActions).to.have.length(1);
+        expect(successActions[0].payload.patients).to.eql([{ id: 'patient_B' }]);
+        expect(successActions[0].payload.count).to.equal(1);
+        expect(successActions[0].payload.totalCount).to.equal(1);
+      });
+
+      it('should abandon stale failure responses when a newer fetch has been dispatched', () => {
+        const clinicId = '5f85fbe6686e6bb9170ab5d0';
+        let cbA;
+        let cbB;
+        const api = {
+          clinics: {
+            getPatientsForClinic: sinon.stub()
+              .onFirstCall().callsFake((id, opts, callback) => { cbA = callback; })
+              .onSecondCall().callsFake((id, opts, callback) => { cbB = callback; }),
+          },
+        };
+
+        const store = mockStore({ blip: initialState });
+
+        store.dispatch(async.fetchPatientsForClinic(api, clinicId, { offset: 0 }));
+        store.dispatch(async.fetchPatientsForClinic(api, clinicId, { offset: 0, tags: ['t1'] }));
+
+        // Newer fetch succeeds
+        cbB(null, { data: [{ id: 'patient_B' }], meta: { count: 1, totalCount: 1 } });
+        // Older fetch errors out (stale — must be ignored, no FAILURE dispatched)
+        cbA({ status: 500, body: 'Error!' }, null);
+
+        const actionTypes = _.map(store.getActions(), 'type');
+        const failureCount = _.filter(actionTypes, (t) => t === 'FETCH_PATIENTS_FOR_CLINIC_FAILURE').length;
+        const successCount = _.filter(actionTypes, (t) => t === 'FETCH_PATIENTS_FOR_CLINIC_SUCCESS').length;
+
+        expect(failureCount).to.equal(0);
+        expect(successCount).to.equal(1);
+      });
     });
 
     describe('fetchPatientFromClinic', () => {


### PR DESCRIPTION
[WEB-4592] Fix patient list stale-overwrite race under slow network

When multiple fetchPatientsForClinic dispatches are in flight
simultaneously, an older response arriving last would overwrite the
newer one's correctly-filtered result, then flipping to the unfiltered
set.


[WEB-4592]: https://tidepool.atlassian.net/browse/WEB-4592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ