### PR TITLE
[WEB-4597] Hide edited time for deleted carbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.96.0-rc.8",
+  "version": "1.96.0-rc.9",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.6.1",
-    "@tidepool/viz": "1.56.0-rc.9",
+    "@tidepool/viz": "1.56.0-rc.10",
     "@types/jest": "29.5.14",
     "async": "2.6.4",
     "autoprefixer": "10.4.16",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.6.1",
-    "@tidepool/viz": "1.56.0-rc.7",
+    "@tidepool/viz": "1.56.0-rc.8",
     "@types/jest": "29.5.14",
     "async": "2.6.4",
     "autoprefixer": "10.4.16",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.96.0-rc.4",
+  "version": "1.96.0-rc.5",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6211,9 +6211,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tidepool/viz@npm:1.56.0-rc.9":
-  version: 1.56.0-rc.9
-  resolution: "@tidepool/viz@npm:1.56.0-rc.9"
+"@tidepool/viz@npm:1.56.0-rc.10":
+  version: 1.56.0-rc.10
+  resolution: "@tidepool/viz@npm:1.56.0-rc.10"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -6274,7 +6274,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: 6857d9d0d7a562ce5cc90dad2d747804f2dad6451a1d3ceb509ddda6253d97ed566351091c39dad0ca8759d57fe01448b36321d23177a35ed85b2d54af625d0e
+  checksum: e82c34548fa3107b4ed74f3a60432568a850387070924cbff95f30336df3617804f968eaaea2bb81d4608dfde53ed112ccdb35f86e502fe0059afdc78fd38ab4
   languageName: node
   linkType: hard
 
@@ -8410,7 +8410,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/react-hooks": 8.0.1
     "@testing-library/user-event": 14.6.1
-    "@tidepool/viz": 1.56.0-rc.9
+    "@tidepool/viz": 1.56.0-rc.10
     "@types/jest": 29.5.14
     async: 2.6.4
     autoprefixer: 10.4.16

--- a/yarn.lock
+++ b/yarn.lock
@@ -6211,9 +6211,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tidepool/viz@npm:1.56.0-rc.7":
-  version: 1.56.0-rc.7
-  resolution: "@tidepool/viz@npm:1.56.0-rc.7"
+"@tidepool/viz@npm:1.56.0-rc.8":
+  version: 1.56.0-rc.8
+  resolution: "@tidepool/viz@npm:1.56.0-rc.8"
   dependencies:
     bluebird: 3.7.2
     bows: 1.7.2
@@ -6274,7 +6274,7 @@ __metadata:
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
-  checksum: bbb0a5bf0eec4882c8a9db960bfc8ab6b2fa9520bc2aff756a6d09567d360c0d46fbe703984a3fdaf4f47bf4b1cca0d791c3c24452e0e947802f4c29a47403af
+  checksum: 5b2a61107d7113eb84ae4aa34321b3a87d8c717ac7aa47a13e9623803680261aac94b83e780f5a2b474fbfb3b4f946d3251df184cfeea34de6fba6cb9a45bd06
   languageName: node
   linkType: hard
 
@@ -8410,7 +8410,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/react-hooks": 8.0.1
     "@testing-library/user-event": 14.6.1
-    "@tidepool/viz": 1.56.0-rc.7
+    "@tidepool/viz": 1.56.0-rc.8
     "@types/jest": 29.5.14
     async: 2.6.4
     autoprefixer: 10.4.16


### PR DESCRIPTION
[WEB-4597] 

One more small revision - we need to, due to a lack of proper data from twiist, hide edited time for deleted carbs.

Related PR: https://github.com/tidepool-org/viz/pull/642

[WEB-4597]: https://tidepool.atlassian.net/browse/WEB-4597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ