### PR TITLE
[WEB-4619] Reinstate Nightscout Foundation and T1D Exchange as supported donation proceed sharing orgs.

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -43,6 +43,8 @@ export const SUPPORTED_ORGANIZATIONS_OPTIONS = map([
   'Diabetes Youth Families (DYF)',
   'The Diabetes Link',
   'The diaTribe Foundation',
+  'Nightscout Foundation',
+  'T1D Exchange',
 ], (name) => ({ value: name, label: t(name) }));
 
 export const DIABETES_TYPES = () => [

--- a/app/redux/actions/async.js
+++ b/app/redux/actions/async.js
@@ -1442,7 +1442,7 @@ export function fetchUserConsentRecords(api, consentType) {
  * @param {String} consentRecord.grantorType - Allowed values: ['owner', 'parent/guardian']
  * @param {String} consentRecord.type - Type of the consent record (e.g., 'big_data_donation_project')
  * @param {Object} [consentRecord.metadata]
- * @param {String[]} [consentRecord.metadata.supportedOrganizations] - Allowed values: ['ADCES Foundation', 'Beyond Type 1', 'Children With Diabetes', 'The Diabetes Link', 'Diabetes Youth Families (DYF)', 'DiabetesSisters', 'The diaTribe Foundation', 'Breakthrough T1D']
+ * @param {String[]} [consentRecord.metadata.supportedOrganizations] - Allowed values: ['ADCES Foundation', 'Beyond Type 1', 'Children With Diabetes', 'The Diabetes Link', 'Diabetes Youth Families (DYF)', 'DiabetesSisters', 'The diaTribe Foundation', 'Breakthrough T1D', 'Nightscout Foundation', 'T1D Exchange']
  * @param {Number} consentRecord.version - >=1
  */
 export function createUserConsentRecord(api, consentRecord) {
@@ -1470,7 +1470,7 @@ export function createUserConsentRecord(api, consentRecord) {
  * @param {String} recordId - id of the consent record to update
  * @param {Object} updates
  * @param {Object} updates.metadata
- * @param {Array[String]} updates.metadata.supportedOrganizations - Allowed values: ['ADCES Foundation', 'Beyond Type 1', 'Children With Diabetes', 'The Diabetes Link', 'Diabetes Youth Families (DYF)', 'DiabetesSisters', 'The diaTribe Foundation', 'Breakthrough T1D']
+ * @param {Array[String]} updates.metadata.supportedOrganizations - Allowed values: ['ADCES Foundation', 'Beyond Type 1', 'Children With Diabetes', 'The Diabetes Link', 'Diabetes Youth Families (DYF)', 'DiabetesSisters', 'The diaTribe Foundation', 'Breakthrough T1D', 'Nightscout Foundation', 'T1D Exchange']
  */
 export function updateUserConsentRecord(api, recordId, updates) {
   return (dispatch, getState) => {

--- a/test/unit/app/core/constants.test.js
+++ b/test/unit/app/core/constants.test.js
@@ -62,6 +62,8 @@ describe('constants', function() {
       'Diabetes Youth Families (DYF)',
       'The Diabetes Link',
       'The diaTribe Foundation',
+      'Nightscout Foundation',
+      'T1D Exchange',
     ]);
   });
 


### PR DESCRIPTION
[WEB-4619] 

[WEB-4619]: https://tidepool.atlassian.net/browse/WEB-4619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ