### PR TITLE
[WEB-4615] Fix infinite loading icons on data view after updating patients with no data.

### DIFF
--- a/__tests__/unit/components/navpatientheader/EditPatientDialog.test.js
+++ b/__tests__/unit/components/navpatientheader/EditPatientDialog.test.js
@@ -2,18 +2,30 @@ import React from 'react';
 import { createStore, applyMiddleware } from 'redux';
 import { thunk } from 'redux-thunk';
 import { Provider } from 'react-redux';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ThemeProvider } from 'theme-ui';
+import { utils as vizUtils } from '@tidepool/viz';
 import theme from '../../../../app/themes/baseTheme';
 import EditPatientDialog from '../../../../app/components/navpatientheader/EditPatientDialog';
 import { ToastProvider } from '../../../../app/providers/ToastProvider';
+import { buildGlycemicRangesFromPreset } from '../../../../app/core/glycemicRangesUtils';
+
+// When set by a test, the PatientForm mock feeds this Formik bag back through onFormChange so the
+// dialog's patientFormContext (values / initialValues) is populated.
+let mockFormBag;
 
 jest.mock('../../../../app/components/clinic/PatientForm', () => {
-  return (props) => (
-    <div data-testid="PatientForm" data-is-read-only={props.isReadOnly ? 'true' : 'false'}>
-      PatientForm Mock
-    </div>
-  );
+  const React = require('react');
+  return (props) => {
+    React.useEffect(() => {
+      if (mockFormBag) props.onFormChange(mockFormBag);
+    }, []);
+    return React.createElement(
+      'div',
+      { 'data-testid': 'PatientForm', 'data-is-read-only': props.isReadOnly ? 'true' : 'false' },
+      'PatientForm Mock'
+    );
+  };
 });
 
 jest.mock('../../../../app/core/hooks', () => ({
@@ -88,5 +100,155 @@ describe('EditPatientDialog', () => {
 
     const patientForm = screen.getByTestId('PatientForm');
     expect(patientForm).toHaveAttribute('data-is-read-only', 'false');
+  });
+
+  // --- Failing test A: pins the foreign-update data-worker wipe (theory A / BUG-0019) ---
+  // EditPatientDialog is always mounted in NavPatientHeader and subscribes to the GLOBAL
+  // working.updatingClinicPatient. When a different flow (e.g. adding a data source) updates the
+  // clinic patient, the dialog is closed (isOpen=false) but still fires dataWorkerRemoveDataRequest,
+  // wiping the patient-data view. It should only clear the cache for updates it initiated.
+  describe('data worker cache on a foreign clinic-patient update', () => {
+    const { usePrevious } = require('../../../../app/core/hooks');
+
+    // updatingClinicPatient just transitioned inProgress -> completed
+    const justCompletedUpdateState = {
+      blip: {
+        ...initialState.blip,
+        working: {
+          updatingClinicPatient: { inProgress: false, completed: true, notification: null },
+        },
+      },
+    };
+
+    const renderWithCapturedActions = ({ isOpen }) => {
+      const dispatchedActions = [];
+      const reducer = (state = justCompletedUpdateState, action) => {
+        dispatchedActions.push(action);
+        return state;
+      };
+      const store = createStore(reducer, applyMiddleware(thunk));
+      const onClose = jest.fn();
+
+      render(
+        <Provider store={store}>
+          <ThemeProvider theme={theme}>
+            <ToastProvider>
+              <EditPatientDialog api={{}} trackMetric={jest.fn()} isOpen={isOpen} onClose={onClose} />
+            </ToastProvider>
+          </ThemeProvider>
+        </Provider>
+      );
+
+      return { dispatchedActions, onClose };
+    };
+
+    beforeEach(() => {
+      // prevInProgress = true so the inProgress -> completed transition is detected
+      usePrevious.mockReturnValue(true);
+    });
+
+    it('does NOT dispatch dataWorkerRemoveDataRequest when the dialog is closed (foreign update)', () => {
+      const { dispatchedActions, onClose } = renderWithCapturedActions({ isOpen: false });
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(dispatchedActions.some(a => a.type === 'DATA_WORKER_REMOVE_DATA_REQUEST')).toBe(false);
+    });
+  });
+
+  // The data worker is cleared (forcing a chart-data reprocess) only when a data-affecting field
+  // changed AND the patient actually has chart data to reprocess. Target Range (glycemicRanges) is the
+  // only data-affecting field in the edit form. A no-data patient has nothing to reprocess and clearing
+  // the worker would strand its view on the loader, so it must be skipped there.
+  describe('clearing chart data only when a data-affecting field changed and chart data exists', () => {
+    const { usePrevious } = require('../../../../app/core/hooks');
+
+    const presets = Object.values(vizUtils.constants.GLYCEMIC_RANGES_PRESET);
+    const RANGE_A = buildGlycemicRangesFromPreset(vizUtils.constants.GLYCEMIC_RANGES_PRESET.ADA_STANDARD);
+    const RANGE_B = buildGlycemicRangesFromPreset(
+      presets.find(p => p !== vizUtils.constants.GLYCEMIC_RANGES_PRESET.ADA_STANDARD)
+    );
+
+    afterEach(() => { mockFormBag = undefined; });
+
+    // Renders an open dialog, saves the edit (capturing the clear-data decision), then drives the
+    // update to completion and returns the actions dispatched during that completion. savedRange is the
+    // patient's currently-stored Target Range (the comparison baseline); chartDataSize seeds the data
+    // worker's metaData.size (0 = no-data patient); submittedRange is what the form submits.
+    const saveEditThenComplete = ({ submittedRange, savedRange, frozenInitialRange = savedRange, fullName = 'Same', chartDataSize = 0 }) => {
+      // frozenInitialRange models the form's own (frozen-at-mount) initialValues; the production code
+      // must NOT use it — it compares against the patient's currently-saved range instead.
+      mockFormBag = {
+        values: { fullName, glycemicRanges: submittedRange },
+        initialValues: { fullName: 'Same', glycemicRanges: frozenInitialRange },
+        handleSubmit: jest.fn(),
+      };
+      usePrevious.mockReturnValue(true);
+      const onClose = jest.fn();
+
+      const makeStore = (updatingClinicPatient, actions) => {
+        const state = {
+          blip: {
+            ...initialState.blip,
+            working: { updatingClinicPatient },
+            data: { metaData: { size: chartDataSize } },
+            clinics: {
+              clinic123: {
+                ...initialState.blip.clinics.clinic123,
+                patients: { patient123: { id: 'patient123', glycemicRanges: savedRange } },
+              },
+            },
+          },
+        };
+        return createStore((s = state, action) => { if (actions) actions.push(action); return s; }, applyMiddleware(thunk));
+      };
+
+      const ui = (store) => (
+        <Provider store={store}>
+          <ThemeProvider theme={theme}>
+            <ToastProvider>
+              <EditPatientDialog api={{}} trackMetric={jest.fn()} isOpen={true} onClose={onClose} />
+            </ToastProvider>
+          </ThemeProvider>
+        </Provider>
+      );
+
+      // idle: completed=null so the working-state hook ignores the initial render
+      const { rerender } = render(ui(makeStore({ inProgress: false, completed: null, notification: null })));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      const completedActions = [];
+      rerender(ui(makeStore({ inProgress: false, completed: true, notification: null }, completedActions)));
+
+      return { completedActions, onClose };
+    };
+
+    const cleared = ({ completedActions }) => completedActions.some(a => a.type === 'DATA_WORKER_REMOVE_DATA_REQUEST');
+
+    it('does NOT clear the data worker for a demographic-only edit, even when chart data exists', () => {
+      const result = saveEditThenComplete({ fullName: 'New Name', submittedRange: RANGE_A, savedRange: RANGE_A, chartDataSize: 100 });
+      expect(result.onClose).toHaveBeenCalled();
+      expect(cleared(result)).toBe(false);
+    });
+
+    it('DOES clear the data worker when Target Range changed from the saved value and the patient has chart data', () => {
+      expect(cleared(saveEditThenComplete({ submittedRange: RANGE_B, savedRange: RANGE_A, chartDataSize: 100 }))).toBe(true);
+    });
+
+    it('clears on a SUBSEQUENT Target Range change — compares against the saved value, not the frozen original', () => {
+      // Patient was previously saved as RANGE_B; the form's frozen baseline is still the original mount
+      // value RANGE_A; the clinician now changes the range back to RANGE_A. Comparing against the frozen
+      // baseline would see "no change" and skip the reprocess (the live bug); comparing against the
+      // saved RANGE_B correctly detects the change.
+      expect(cleared(saveEditThenComplete({
+        submittedRange: RANGE_A, savedRange: RANGE_B, frozenInitialRange: RANGE_A, chartDataSize: 100,
+      }))).toBe(true);
+    });
+
+    it('does NOT clear the data worker on a Target Range change for a no-data patient (would strand the loader)', () => {
+      const result = saveEditThenComplete({ submittedRange: RANGE_B, savedRange: RANGE_A, chartDataSize: 0 });
+      expect(result.onClose).toHaveBeenCalled();
+      expect(cleared(result)).toBe(false);
+    });
   });
 });

--- a/__tests__/unit/components/navpatientheader/EditPatientDialog.test.js
+++ b/__tests__/unit/components/navpatientheader/EditPatientDialog.test.js
@@ -2,33 +2,24 @@ import React from 'react';
 import { createStore, applyMiddleware } from 'redux';
 import { thunk } from 'redux-thunk';
 import { Provider } from 'react-redux';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import configureStore from 'redux-mock-store';
 import { ThemeProvider } from 'theme-ui';
 import { utils as vizUtils } from '@tidepool/viz';
-import theme from '../../../../app/themes/baseTheme';
-import EditPatientDialog from '../../../../app/components/navpatientheader/EditPatientDialog';
-import { ToastProvider } from '../../../../app/providers/ToastProvider';
-import { buildGlycemicRangesFromPreset } from '../../../../app/core/glycemicRangesUtils';
+import theme from '@app/themes/baseTheme';
+import EditPatientDialog from '@app/components/navpatientheader/EditPatientDialog';
+import { ToastProvider } from '@app/providers/ToastProvider';
+import { buildGlycemicRangesFromPreset } from '@app/core/glycemicRangesUtils';
+import { GLYCEMIC_RANGE_OPTS } from '@app/components/clinic/PatientForm/SelectGlycemicRanges';
+import { MGDL_UNITS } from '@app/core/constants';
+import { usePrevious } from '@app/core/hooks';
+const { GLYCEMIC_RANGES_PRESET } = vizUtils.constants;
 
-// When set by a test, the PatientForm mock feeds this Formik bag back through onFormChange so the
-// dialog's patientFormContext (values / initialValues) is populated.
-let mockFormBag;
+const mockStore = configureStore([thunk]);
 
-jest.mock('../../../../app/components/clinic/PatientForm', () => {
-  const React = require('react');
-  return (props) => {
-    React.useEffect(() => {
-      if (mockFormBag) props.onFormChange(mockFormBag);
-    }, []);
-    return React.createElement(
-      'div',
-      { 'data-testid': 'PatientForm', 'data-is-read-only': props.isReadOnly ? 'true' : 'false' },
-      'PatientForm Mock'
-    );
-  };
-});
-
-jest.mock('../../../../app/core/hooks', () => ({
+jest.mock('@app/core/hooks', () => ({
+  ...jest.requireActual('@app/core/hooks'),
   useIsFirstRender: jest.fn(() => false),
   usePrevious: jest.fn(),
 }));
@@ -50,6 +41,7 @@ const initialState = {
       },
     },
     working: {
+      fetchingClinicMRNsForPatientFormValidation: { inProgress: false, completed: false, notification: null },
       updatingClinicPatient: { inProgress: false, completed: false, notification: null },
     },
     clinicMRNsForPatientFormValidation: [],
@@ -77,7 +69,7 @@ const renderEditPatientDialog = (storeState = initialState) => {
 };
 
 describe('EditPatientDialog', () => {
-  it('sets isReadOnly=true and disables save button when smartCorrelationId is present', () => {
+  it('sets read-only fields disabled and disables save button when smartCorrelationId is present', () => {
     const smartOnFhirState = {
       blip: {
         ...initialState.blip,
@@ -87,46 +79,45 @@ describe('EditPatientDialog', () => {
 
     renderEditPatientDialog(smartOnFhirState);
 
-    const patientForm = screen.getByTestId('PatientForm');
-    expect(patientForm).toHaveAttribute('data-is-read-only', 'true');
+    expect(screen.getByRole('textbox', { name: /Full Name/i })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /Birthdate/i })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /MRN/i })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /Email/i })).toBeDisabled();
+    expect(screen.getByLabelText(/Diabetes Type/i)).toBeDisabled();
+    expect(screen.getByLabelText('Target Range')).toBeDisabled();
 
     const saveButton = screen.getByRole('button', { name: 'Save Changes' });
     expect(saveButton).toBeInTheDocument();
     expect(saveButton).toBeDisabled();
   });
 
-  it('sets isReadOnly=false when smartCorrelationId is absent', () => {
+  it('sets read-only fields enabled when smartCorrelationId is absent', () => {
     renderEditPatientDialog(initialState);
 
-    const patientForm = screen.getByTestId('PatientForm');
-    expect(patientForm).toHaveAttribute('data-is-read-only', 'false');
+    expect(screen.getByRole('textbox', { name: /Full Name/i })).not.toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /Birthdate/i })).not.toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /MRN/i })).not.toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /Email/i })).not.toBeDisabled();
+    expect(screen.getByLabelText(/Diabetes Type/i)).not.toBeDisabled();
+    expect(screen.getByLabelText('Target Range')).not.toBeDisabled();
   });
 
-  // --- Failing test A: pins the foreign-update data-worker wipe (theory A / BUG-0019) ---
-  // EditPatientDialog is always mounted in NavPatientHeader and subscribes to the GLOBAL
-  // working.updatingClinicPatient. When a different flow (e.g. adding a data source) updates the
-  // clinic patient, the dialog is closed (isOpen=false) but still fires dataWorkerRemoveDataRequest,
-  // wiping the patient-data view. It should only clear the cache for updates it initiated.
+  // The dialog is permanently mounted and subscribes to the global updatingClinicPatient, so it must
+  // only clear the data worker for updates it initiated (isOpen), not foreign ones (e.g. adding a data
+  // source) — clearing on a foreign update would strand the patient-data view on the loader.
   describe('data worker cache on a foreign clinic-patient update', () => {
-    const { usePrevious } = require('../../../../app/core/hooks');
-
-    // updatingClinicPatient just transitioned inProgress -> completed
     const justCompletedUpdateState = {
       blip: {
         ...initialState.blip,
         working: {
+          fetchingClinicMRNsForPatientFormValidation: { inProgress: false, completed: true, notification: null },
           updatingClinicPatient: { inProgress: false, completed: true, notification: null },
         },
       },
     };
 
-    const renderWithCapturedActions = ({ isOpen }) => {
-      const dispatchedActions = [];
-      const reducer = (state = justCompletedUpdateState, action) => {
-        dispatchedActions.push(action);
-        return state;
-      };
-      const store = createStore(reducer, applyMiddleware(thunk));
+    const renderForeignUpdate = ({ isOpen }) => {
+      const store = mockStore(justCompletedUpdateState);
       const onClose = jest.fn();
 
       render(
@@ -139,116 +130,126 @@ describe('EditPatientDialog', () => {
         </Provider>
       );
 
-      return { dispatchedActions, onClose };
+      return { store, onClose };
     };
 
     beforeEach(() => {
-      // prevInProgress = true so the inProgress -> completed transition is detected
       usePrevious.mockReturnValue(true);
     });
 
     it('does NOT dispatch dataWorkerRemoveDataRequest when the dialog is closed (foreign update)', () => {
-      const { dispatchedActions, onClose } = renderWithCapturedActions({ isOpen: false });
+      const { store, onClose } = renderForeignUpdate({ isOpen: false });
 
       expect(onClose).not.toHaveBeenCalled();
-      expect(dispatchedActions.some(a => a.type === 'DATA_WORKER_REMOVE_DATA_REQUEST')).toBe(false);
+      expect(store.getActions().some(a => a.type === 'DATA_WORKER_REMOVE_DATA_REQUEST')).toBe(false);
     });
   });
 
-  // The data worker is cleared (forcing a chart-data reprocess) only when a data-affecting field
-  // changed AND the patient actually has chart data to reprocess. Target Range (glycemicRanges) is the
-  // only data-affecting field in the edit form. A no-data patient has nothing to reprocess and clearing
-  // the worker would strand its view on the loader, so it must be skipped there.
+  // The data worker is cleared (forcing a reprocess) only when Target Range changed AND the patient
+  // has chart data to reprocess; a no-data patient would be stranded on the loader, so it's skipped.
   describe('clearing chart data only when a data-affecting field changed and chart data exists', () => {
-    const { usePrevious } = require('../../../../app/core/hooks');
+    const RANGE_A = buildGlycemicRangesFromPreset(GLYCEMIC_RANGES_PRESET.ADA_STANDARD);
+    const RANGE_B = buildGlycemicRangesFromPreset(GLYCEMIC_RANGES_PRESET.ADA_OLDER_HIGH_RISK);
+    const RANGE_A_LABEL = GLYCEMIC_RANGE_OPTS[MGDL_UNITS][0].label;
+    const RANGE_B_LABEL = GLYCEMIC_RANGE_OPTS[MGDL_UNITS][1].label;
+    const IDLE_UPDATE = { inProgress: false, completed: null, notification: null };
+    const COMPLETED_UPDATE = { inProgress: false, completed: true, notification: null };
 
-    const presets = Object.values(vizUtils.constants.GLYCEMIC_RANGES_PRESET);
-    const RANGE_A = buildGlycemicRangesFromPreset(vizUtils.constants.GLYCEMIC_RANGES_PRESET.ADA_STANDARD);
-    const RANGE_B = buildGlycemicRangesFromPreset(
-      presets.find(p => p !== vizUtils.constants.GLYCEMIC_RANGES_PRESET.ADA_STANDARD)
-    );
-
-    afterEach(() => { mockFormBag = undefined; });
-
-    // Renders an open dialog, saves the edit (capturing the clear-data decision), then drives the
-    // update to completion and returns the actions dispatched during that completion. savedRange is the
-    // patient's currently-stored Target Range (the comparison baseline); chartDataSize seeds the data
-    // worker's metaData.size (0 = no-data patient); submittedRange is what the form submits.
-    const saveEditThenComplete = ({ submittedRange, savedRange, frozenInitialRange = savedRange, fullName = 'Same', chartDataSize = 0 }) => {
-      // frozenInitialRange models the form's own (frozen-at-mount) initialValues; the production code
-      // must NOT use it — it compares against the patient's currently-saved range instead.
-      mockFormBag = {
-        values: { fullName, glycemicRanges: submittedRange },
-        initialValues: { fullName: 'Same', glycemicRanges: frozenInitialRange },
-        handleSubmit: jest.fn(),
-      };
-      usePrevious.mockReturnValue(true);
-      const onClose = jest.fn();
-
-      const makeStore = (updatingClinicPatient, actions) => {
-        const state = {
-          blip: {
-            ...initialState.blip,
-            working: { updatingClinicPatient },
-            data: { metaData: { size: chartDataSize } },
-            clinics: {
-              clinic123: {
-                ...initialState.blip.clinics.clinic123,
-                patients: { patient123: { id: 'patient123', glycemicRanges: savedRange } },
-              },
+    const makeState = ({ savedRange, chartDataSize, updatingClinicPatient }) => ({
+      blip: {
+        ...initialState.blip,
+        working: {
+          fetchingClinicMRNsForPatientFormValidation: { inProgress: false, completed: false, notification: null },
+          updatingClinicPatient,
+        },
+        data: { metaData: { size: chartDataSize } },
+        clinics: {
+          clinic123: {
+            ...initialState.blip.clinics.clinic123,
+            patients: {
+              patient123: { id: 'patient123', fullName: 'John Doe', birthDate: '2000-01-01', glycemicRanges: savedRange },
             },
           },
-        };
-        return createStore((s = state, action) => { if (actions) actions.push(action); return s; }, applyMiddleware(thunk));
-      };
-
-      const ui = (store) => (
-        <Provider store={store}>
-          <ThemeProvider theme={theme}>
-            <ToastProvider>
-              <EditPatientDialog api={{}} trackMetric={jest.fn()} isOpen={true} onClose={onClose} />
-            </ToastProvider>
-          </ThemeProvider>
-        </Provider>
-      );
-
-      // idle: completed=null so the working-state hook ignores the initial render
-      const { rerender } = render(ui(makeStore({ inProgress: false, completed: null, notification: null })));
-
-      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
-
-      const completedActions = [];
-      rerender(ui(makeStore({ inProgress: false, completed: true, notification: null }, completedActions)));
-
-      return { completedActions, onClose };
-    };
-
-    const cleared = ({ completedActions }) => completedActions.some(a => a.type === 'DATA_WORKER_REMOVE_DATA_REQUEST');
-
-    it('does NOT clear the data worker for a demographic-only edit, even when chart data exists', () => {
-      const result = saveEditThenComplete({ fullName: 'New Name', submittedRange: RANGE_A, savedRange: RANGE_A, chartDataSize: 100 });
-      expect(result.onClose).toHaveBeenCalled();
-      expect(cleared(result)).toBe(false);
+        },
+      },
     });
 
-    it('DOES clear the data worker when Target Range changed from the saved value and the patient has chart data', () => {
-      expect(cleared(saveEditThenComplete({ submittedRange: RANGE_B, savedRange: RANGE_A, chartDataSize: 100 }))).toBe(true);
+    const api = { clinics: { getPatientFromClinic: jest.fn(), updateClinicPatient: jest.fn() } };
+    const onClose = jest.fn();
+
+    const ui = (store) => (
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <ToastProvider>
+            <EditPatientDialog api={api} trackMetric={jest.fn()} isOpen={true} onClose={onClose} />
+          </ToastProvider>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    const cleared = store => store.getActions().some(a => a.type === 'DATA_WORKER_REMOVE_DATA_REQUEST');
+
+    beforeEach(() => {
+      onClose.mockClear();
+      usePrevious.mockReturnValue(true);
+      window.HTMLElement.prototype.scrollIntoView = jest.fn();
     });
 
-    it('clears on a SUBSEQUENT Target Range change — compares against the saved value, not the frozen original', () => {
-      // Patient was previously saved as RANGE_B; the form's frozen baseline is still the original mount
-      // value RANGE_A; the clinician now changes the range back to RANGE_A. Comparing against the frozen
-      // baseline would see "no change" and skip the reprocess (the live bug); comparing against the
-      // saved RANGE_B correctly detects the change.
-      expect(cleared(saveEditThenComplete({
-        submittedRange: RANGE_A, savedRange: RANGE_B, frozenInitialRange: RANGE_A, chartDataSize: 100,
-      }))).toBe(true);
+    it('does NOT clear the data worker for a demographic-only edit, even when chart data exists', async () => {
+      const initialState = makeState({ savedRange: RANGE_A, chartDataSize: 100, updatingClinicPatient: IDLE_UPDATE });
+      const { rerender } = render(ui(mockStore(initialState)));
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Full Name/i }), ' Jr');
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      const completedStore = mockStore(makeState({ savedRange: RANGE_A, chartDataSize: 100, updatingClinicPatient: COMPLETED_UPDATE }));
+      rerender(ui(completedStore));
+
+      expect(onClose).toHaveBeenCalled();
+      expect(cleared(completedStore)).toBe(false);
     });
 
-    it('does NOT clear the data worker on a Target Range change for a no-data patient (would strand the loader)', () => {
-      const result = saveEditThenComplete({ submittedRange: RANGE_B, savedRange: RANGE_A, chartDataSize: 0 });
-      expect(result.onClose).toHaveBeenCalled();
-      expect(cleared(result)).toBe(false);
+    it('DOES clear the data worker when Target Range changed from the saved value and the patient has chart data', async () => {
+      const { rerender } = render(ui(mockStore(makeState({ savedRange: RANGE_A, chartDataSize: 100, updatingClinicPatient: IDLE_UPDATE }))));
+
+      await userEvent.click(screen.getByLabelText('Target Range'));
+      await userEvent.click(screen.getByText(RANGE_B_LABEL));
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      const completedStore = mockStore(makeState({ savedRange: RANGE_A, chartDataSize: 100, updatingClinicPatient: COMPLETED_UPDATE }));
+      rerender(ui(completedStore));
+
+      expect(onClose).toHaveBeenCalled();
+      expect(cleared(completedStore)).toBe(true);
+    });
+
+    it('clears on a SUBSEQUENT Target Range change — compares against the saved value, not the frozen original', async () => {
+      const { rerender } = render(ui(mockStore(makeState({ savedRange: RANGE_A, chartDataSize: 100, updatingClinicPatient: IDLE_UPDATE }))));
+      rerender(ui(mockStore(makeState({ savedRange: RANGE_B, chartDataSize: 100, updatingClinicPatient: IDLE_UPDATE }))));
+
+      await userEvent.click(screen.getByLabelText('Target Range'));
+      await userEvent.click(screen.getByText(RANGE_A_LABEL));
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      const completedStore = mockStore(makeState({ savedRange: RANGE_B, chartDataSize: 100, updatingClinicPatient: COMPLETED_UPDATE }));
+      rerender(ui(completedStore));
+
+      expect(onClose).toHaveBeenCalled();
+      expect(cleared(completedStore)).toBe(true);
+    });
+
+    it('does NOT clear the data worker on a Target Range change for a no-data patient (would strand the loader)', async () => {
+      const { rerender } = render(ui(mockStore(makeState({ savedRange: RANGE_A, chartDataSize: 0, updatingClinicPatient: IDLE_UPDATE }))));
+
+      await userEvent.click(screen.getByLabelText('Target Range'));
+      await userEvent.click(screen.getByText(RANGE_B_LABEL));
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      const completedStore = mockStore(makeState({ savedRange: RANGE_A, chartDataSize: 0, updatingClinicPatient: COMPLETED_UPDATE }));
+      rerender(ui(completedStore));
+
+      expect(onClose).toHaveBeenCalled();
+      expect(cleared(completedStore)).toBe(false);
     });
   });
 });

--- a/app/components/clinic/PatientForm/SelectGlycemicRanges.js
+++ b/app/components/clinic/PatientForm/SelectGlycemicRanges.js
@@ -15,7 +15,7 @@ import {
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../core/constants';
 const { GLYCEMIC_RANGES_PRESET } = vizUtils.constants;
 
-const GLYCEMIC_RANGE_OPTS = {
+export const GLYCEMIC_RANGE_OPTS = {
   [MGDL_UNITS]: [
     { label: 'Standard (Type 1 and 2): 70-180 mg/dL', value: GLYCEMIC_RANGES_PRESET.ADA_STANDARD },
     { label: 'Older/High Risk (Type 1 and 2): 70-180 mg/dL', value: GLYCEMIC_RANGES_PRESET.ADA_OLDER_HIGH_RISK },

--- a/app/components/navpatientheader/EditPatientDialog.js
+++ b/app/components/navpatientheader/EditPatientDialog.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useIsFirstRender, usePrevious } from '../../core/hooks';
 import { useTranslation } from 'react-i18next';
@@ -10,8 +10,10 @@ import PatientForm from '../clinic/PatientForm';
 import noop from 'lodash/noop';
 import keys from 'lodash/keys';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import { fieldsAreValid } from '../../core/forms';
 import { patientSchema as validationSchema } from '../../core/clinicUtils';
+import { DEFAULT_GLYCEMIC_RANGES } from '../../core/glycemicRangesUtils';
 import { useToasts } from '../../providers/ToastProvider';
 import * as actions from '../../redux/actions';
 
@@ -65,10 +67,25 @@ const EditPatientDialog = ({
   const mrnSettings = useMemo(() => clinic?.mrnSettings ?? {}, [clinic?.mrnSettings]);
   const existingMRNs = useSelector(state => state.blip.clinicMRNsForPatientFormValidation)?.filter(mrn => mrn !== clinicPatient?.mrn) || [];
 
-  const onUpdateSuccess = () => {
-    if (isOpen) onClose();
+  // Check whether the patient-data view currently holds chart data for this patient.
+  const hasChartData = useSelector(state => (state.blip.data?.metaData?.size || 0) > 0);
 
-    dispatch(actions.worker.dataWorkerRemoveDataRequest(null, currentPatientInViewId));
+  // Captured at submit time (before the update lands and the form re-initialises): whether this edit
+  // needs the chart data reprocessed.
+  const shouldClearDataRef = useRef(false);
+
+  const onUpdateSuccess = () => {
+    // updatingClinicPatient is global working state, so this fires for any clinic-patient update
+    // while the header is mounted. Only react when this dialog drove the update — otherwise a
+    // foreign update (e.g. adding a data source) would clear the data worker cache and leave the
+    // patient-data view stuck loading.
+    if (!isOpen) return;
+
+    onClose();
+
+    if (shouldClearDataRef.current) {
+      dispatch(actions.worker.dataWorkerRemoveDataRequest(null, currentPatientInViewId));
+    }
   };
 
   const updatingClinicPatient = useUpdatingClinicPatientWorkingState({ onUpdateSuccess });
@@ -76,6 +93,16 @@ const EditPatientDialog = ({
   const [patientFormContext, setPatientFormContext] = useState();
 
   const handleEditPatientConfirm = () => {
+    // Clear the data worker cache (forcing a reprocess) only when a data-affecting field changed AND
+    // there is chart data to reprocess. Target Range (glycemicRanges) is the only data-affecting field
+    // in this form. Compare the submitted value against the patient's currently-saved range (the form's
+    // own initialValues is frozen at mount and wouldn't track prior saves); fall back to the default
+    // range so a patient without a saved range — for whom the form injects the default — doesn't read
+    // as a change. A no-data patient has nothing to reprocess, and clearing would strand its view on
+    // the loader, so skip it there.
+    const savedRange = clinicPatient?.glycemicRanges || DEFAULT_GLYCEMIC_RANGES;
+    const targetRangeChanged = !isEqual(patientFormContext?.values?.glycemicRanges, savedRange);
+    shouldClearDataRef.current = targetRangeChanged && hasChartData;
     patientFormContext?.handleSubmit();
   };
 

--- a/app/components/navpatientheader/EditPatientDialog.js
+++ b/app/components/navpatientheader/EditPatientDialog.js
@@ -67,24 +67,22 @@ const EditPatientDialog = ({
   const mrnSettings = useMemo(() => clinic?.mrnSettings ?? {}, [clinic?.mrnSettings]);
   const existingMRNs = useSelector(state => state.blip.clinicMRNsForPatientFormValidation)?.filter(mrn => mrn !== clinicPatient?.mrn) || [];
 
-  // Check whether the patient-data view currently holds chart data for this patient.
   const hasChartData = useSelector(state => (state.blip.data?.metaData?.size || 0) > 0);
 
-  // Captured at submit time (before the update lands and the form re-initialises): whether this edit
-  // needs the chart data reprocessed.
+  // Captured at submit time: whether this edit needs the chart data reprocessed.
   const shouldClearDataRef = useRef(false);
 
   const onUpdateSuccess = () => {
-    // updatingClinicPatient is global working state, so this fires for any clinic-patient update
-    // while the header is mounted. Only react when this dialog drove the update — otherwise a
-    // foreign update (e.g. adding a data source) would clear the data worker cache and leave the
-    // patient-data view stuck loading.
+    // updatingClinicPatient is global working state, so this fires for any clinic-patient update while
+    // the header is mounted. Only react to updates this dialog drove; a foreign update (e.g. adding a
+    // data source) would otherwise clear the data worker cache and strand the data view on the loader.
     if (!isOpen) return;
 
     onClose();
 
     if (shouldClearDataRef.current) {
       dispatch(actions.worker.dataWorkerRemoveDataRequest(null, currentPatientInViewId));
+      shouldClearDataRef.current = false;
     }
   };
 
@@ -93,13 +91,11 @@ const EditPatientDialog = ({
   const [patientFormContext, setPatientFormContext] = useState();
 
   const handleEditPatientConfirm = () => {
-    // Clear the data worker cache (forcing a reprocess) only when a data-affecting field changed AND
-    // there is chart data to reprocess. Target Range (glycemicRanges) is the only data-affecting field
-    // in this form. Compare the submitted value against the patient's currently-saved range (the form's
-    // own initialValues is frozen at mount and wouldn't track prior saves); fall back to the default
-    // range so a patient without a saved range — for whom the form injects the default — doesn't read
-    // as a change. A no-data patient has nothing to reprocess, and clearing would strand its view on
-    // the loader, so skip it there.
+    // Clear the data worker (forcing a reprocess) only when Target Range (glycemicRanges, the only
+    // data-affecting field here) changed AND there is chart data to reprocess. Compare against the
+    // patient's saved range, not the form's initialValues (frozen at mount, blind to prior saves);
+    // fall back to the default range so a patient without one — for whom the form injects the default —
+    // doesn't read as a change.
     const savedRange = clinicPatient?.glycemicRanges || DEFAULT_GLYCEMIC_RANGES;
     const targetRangeChanged = !isEqual(patientFormContext?.values?.glycemicRanges, savedRange);
     shouldClearDataRef.current = targetRangeChanged && hasChartData;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.96.1",
+  "version": "1.96.2-rc.1",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose",

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -681,6 +681,64 @@ describe('DataConnections', () => {
       });
     });
 
+    // --- Test C: probes the colleague's theory (activeHandler / button spinner never resets) ---
+    // The "Email Invite" spinner is driven by activeHandler, which is cleared on the connect-request
+    // success transition detected via usePrevious. The hypothesis is that across the chained
+    // updateClinicPatient -> connect dispatch, the inProgress:true->false edge is lost in a render
+    // burst so activeHandler never resets. This steps the two completions deterministically and
+    // asserts the spinner clears. If this PASSES, the happy-path logic is correct when not raced —
+    // i.e. the hang is a render-timing race not reproducible at the unit level (needs live
+    // instrumentation), NOT a deterministic logic bug.
+    describe('button processing across the chained updateClinicPatient -> connect', () => {
+      const idle = { inProgress: false, completed: false, notification: null };
+      const storeWith = (working) => mockStore({
+        blip: {
+          ...clinicianUserLoggedInState.blip,
+          working: {
+            updatingClinicPatient: idle,
+            sendingPatientDataProviderConnectRequest: idle,
+            ...working,
+          },
+        },
+      });
+
+      const tree = (store) => (
+        <Provider store={store}>
+          <ToastProvider>
+            <DataConnections {...defaultProps} patient={clinicPatients.dataConnectionUnset} />
+          </ToastProvider>
+        </Provider>
+      );
+
+      it('clears the dexcom button spinner once both phases complete', async () => {
+        const { rerender } = render(tree(storeWith({})));
+        const dexcomBtn = () => container?.querySelector('#data-connection-dexcom .action')
+          || document.querySelector('#data-connection-dexcom .action');
+
+        fireEvent.click(dexcomBtn());
+        // activeHandler set -> button is processing
+        expect(dexcomBtn().classList.contains('processing')).to.be.true;
+
+        // phase 1: updateClinicPatient in progress, then completed (fires the chained connect)
+        rerender(tree(storeWith({ updatingClinicPatient: { inProgress: true, completed: false } })));
+        rerender(tree(storeWith({ updatingClinicPatient: { inProgress: false, completed: true } })));
+
+        // phase 2: connect request in progress, then completed (should clear activeHandler)
+        rerender(tree(storeWith({
+          updatingClinicPatient: { inProgress: false, completed: true },
+          sendingPatientDataProviderConnectRequest: { inProgress: true, completed: false },
+        })));
+        rerender(tree(storeWith({
+          updatingClinicPatient: { inProgress: false, completed: true },
+          sendingPatientDataProviderConnectRequest: { inProgress: false, completed: true },
+        })));
+
+        await waitFor(() => {
+          expect(dexcomBtn()?.classList.contains('processing')).to.not.equal(true);
+        });
+      });
+    });
+
     describe('data connection invite just sent', () => {
       it('should render all appropriate data connection statuses and messages', () => {
         const store = mockStore(clinicianUserLoggedInState);

--- a/test/unit/components/datasources/DataConnections.test.js
+++ b/test/unit/components/datasources/DataConnections.test.js
@@ -681,14 +681,9 @@ describe('DataConnections', () => {
       });
     });
 
-    // --- Test C: probes the colleague's theory (activeHandler / button spinner never resets) ---
-    // The "Email Invite" spinner is driven by activeHandler, which is cleared on the connect-request
-    // success transition detected via usePrevious. The hypothesis is that across the chained
-    // updateClinicPatient -> connect dispatch, the inProgress:true->false edge is lost in a render
-    // burst so activeHandler never resets. This steps the two completions deterministically and
-    // asserts the spinner clears. If this PASSES, the happy-path logic is correct when not raced —
-    // i.e. the hang is a render-timing race not reproducible at the unit level (needs live
-    // instrumentation), NOT a deterministic logic bug.
+    // The "Email Invite" spinner is driven by activeHandler, cleared on the connect-request success
+    // transition detected via usePrevious. Stepping the chained updateClinicPatient -> connect
+    // completions deterministically confirms the spinner clears once both phases complete.
     describe('button processing across the chained updateClinicPatient -> connect', () => {
       const idle = { inProgress: false, completed: false, notification: null };
       const storeWith = (working) => mockStore({


### PR DESCRIPTION
[WEB-4615]

Summary — Fixes the patient-data view sticking on an infinite loading spinner (until
manual refresh) after a clinician edits — or sends a connection invite for — a patient
with no data.

Fix — EditPatientDialog cleared the data-worker cache on every successful clinic-patient
update (it reacts to the global updatingClinicPatient state), which strands a no-data
view on the loader. It now clears only when the dialog drove the update (isOpen) and
Target Range actually changed and the patient has chart data — comparing against the
patient's saved range, not the form's frozen initialValues. Demographic-only edits,
no-data patients, and foreign updates (e.g. adding a data source) no longer clear.

Tests — EditPatientDialog.test.js covers each path (foreign update, demographic-only,
Target Range change with/without data, repeat change); added a DataConnections
chained-dispatch test. Manually verified in a clinic workspace.

[WEB-4615]: https://tidepool.atlassian.net/browse/WEB-4615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ