### PR TITLE
WEB-4545 fix: Prioritize SMART context clinic selection

### DIFF
--- a/__tests__/unit/app/pages/smartonfhir/smartonfhir.test.js
+++ b/__tests__/unit/app/pages/smartonfhir/smartonfhir.test.js
@@ -738,6 +738,225 @@ describe('SmartOnFhir', () => {
     });
   });
 
+  it('should select the context clinic when the clinician has access to it', async () => {
+    mockApi = {
+      clinics: {
+        getClinicsForClinician: jest.fn().mockImplementation((clinicianId, options, callback) => {
+          callback(null, [{ clinic: { id: 'clinic1' } }]);
+        }),
+        getEHRSettings: jest.fn().mockImplementation((clinicId, callback) => {
+          callback(null, {});
+        }),
+        getMRNSettings: jest.fn().mockImplementation((clinicId, callback) => {
+          callback(null, {});
+        }),
+      },
+      patient: {
+        getAll: jest.fn().mockImplementation((params, callback) => {
+          callback(null, [{ patient: { id: 'user1' }, clinic: { id: 'clinic1' } }]);
+        }),
+      },
+    };
+
+    const contextStore = mockStore({
+      blip: {
+        smartOnFhirData: {
+          patients: {
+            'correlation-123': {
+              mrn: '12345',
+              dob: '1990-01-01',
+            },
+          },
+          context: {
+            clinicId: 'clinic1',
+          },
+        },
+        smartCorrelationId: 'correlation-123',
+        loggedInUserId: 'clinician-123',
+        working: {
+          fetchingPatients: {
+            inProgress: false,
+          },
+        },
+      }
+    });
+
+    render(
+      <Provider store={contextStore}>
+        <MemoryRouter>
+          <SmartOnFhir
+            api={mockApi}
+            window={{ sessionStorage: mockSessionStorage }}
+            trackMetric={mockTrackMetric}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      const selectClinicAction = contextStore.getActions().find(action =>
+        action.type === 'SELECT_CLINIC_SUCCESS'
+      );
+      expect(selectClinicAction).toBeDefined();
+    });
+
+    const selectClinicAction = contextStore.getActions().find(action =>
+      action.type === 'SELECT_CLINIC_SUCCESS'
+    );
+    expect(selectClinicAction.payload.clinicId).toBe('clinic1');
+  });
+
+  it('should NOT select a clinic when the clinician lacks access to the context clinic', async () => {
+    mockApi = {
+      clinics: {
+        getClinicsForClinician: jest.fn().mockImplementation((clinicianId, options, callback) => {
+          callback(null, [{ clinic: { id: 'clinic1' } }]);
+        }),
+        getEHRSettings: jest.fn().mockImplementation((clinicId, callback) => {
+          callback(null, {});
+        }),
+        getMRNSettings: jest.fn().mockImplementation((clinicId, callback) => {
+          callback(null, {});
+        }),
+      },
+      patient: {
+        getAll: jest.fn(),
+      },
+    };
+
+    const contextStore = mockStore({
+      blip: {
+        smartOnFhirData: {
+          patients: {
+            'correlation-123': {
+              mrn: '12345',
+              dob: '1990-01-01',
+            },
+          },
+          context: {
+            clinicId: 'clinic2',
+          },
+        },
+        smartCorrelationId: 'correlation-123',
+        loggedInUserId: 'clinician-123',
+        working: {
+          fetchingPatients: {
+            inProgress: false,
+          },
+        },
+      }
+    });
+
+    render(
+      <Provider store={contextStore}>
+        <MemoryRouter>
+          <SmartOnFhir
+            api={mockApi}
+            window={{ sessionStorage: mockSessionStorage }}
+            trackMetric={mockTrackMetric}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockTrackMetric).toHaveBeenCalledWith('Direct Connect Clinician Not In Clinic');
+    });
+
+    const selectClinicAction = contextStore.getActions().find(action =>
+      action.type === 'SELECT_CLINIC_SUCCESS'
+    );
+    expect(selectClinicAction).toBeUndefined();
+  });
+
+  it('should NOT select a clinic when no context clinicId is provided', async () => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SmartOnFhir
+            api={mockApi}
+            window={{ sessionStorage: mockSessionStorage }}
+            trackMetric={mockTrackMetric}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockTrackMetric).toHaveBeenCalledWith('Direct Connect Patient Lookup Success');
+    });
+
+    const selectClinicAction = store.getActions().find(action =>
+      action.type === 'SELECT_CLINIC_SUCCESS'
+    );
+    expect(selectClinicAction).toBeUndefined();
+  });
+
+  it('should NOT select the context clinic when the patient lookup fails', async () => {
+    mockApi = {
+      clinics: {
+        getClinicsForClinician: jest.fn().mockImplementation((clinicianId, options, callback) => {
+          callback(null, [{ clinic: { id: 'clinic1' } }]);
+        }),
+        getEHRSettings: jest.fn().mockImplementation((clinicId, callback) => {
+          callback(null, {});
+        }),
+        getMRNSettings: jest.fn().mockImplementation((clinicId, callback) => {
+          callback(null, {});
+        }),
+      },
+      patient: {
+        getAll: jest.fn().mockImplementation((params, callback) => {
+          callback(null, []);
+        }),
+      },
+    };
+
+    const contextStore = mockStore({
+      blip: {
+        smartOnFhirData: {
+          patients: {
+            'correlation-123': {
+              mrn: '12345',
+              dob: '1990-01-01',
+            },
+          },
+          context: {
+            clinicId: 'clinic1',
+          },
+        },
+        smartCorrelationId: 'correlation-123',
+        loggedInUserId: 'clinician-123',
+        working: {
+          fetchingPatients: {
+            inProgress: false,
+          },
+        },
+      }
+    });
+
+    render(
+      <Provider store={contextStore}>
+        <MemoryRouter>
+          <SmartOnFhir
+            api={mockApi}
+            window={{ sessionStorage: mockSessionStorage }}
+            trackMetric={mockTrackMetric}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockTrackMetric).toHaveBeenCalledWith('Direct Connect Patient Not Found');
+    });
+
+    const selectClinicAction = contextStore.getActions().find(action =>
+      action.type === 'SELECT_CLINIC_SUCCESS'
+    );
+    expect(selectClinicAction).toBeUndefined();
+  });
+
   it('should proceed with patient lookup when clinician has clinics', async () => {
     mockApi = {
       clinics: {

--- a/app/pages/patientdata/patientdata.js
+++ b/app/pages/patientdata/patientdata.js
@@ -2435,9 +2435,14 @@ export function getFetchers(dispatchProps, ownProps, stateProps, api, options) {
   ) {
     if (clinicsWithPatient.length > 0) {
       // In most cases, the clinicsWithPatient array will have length of 1. In cases where the same clinician and patient
-      // are in several of the same clinics, we select one arbitrarily, as we have no further information about which
-      // clinic the clinician is arriving from.
-      const clinicToSelect = clinicsWithPatient[0];
+      // are in several of the same clinics, prefer the clinic the SMART-on-FHIR/EHR session launched from when the patient
+      // is a member of it, so that clinic entitlements (e.g. patient tags/sites) bind to the launching clinic. If there is
+      // no SMART context clinic, or the patient is not a member of it, we fall back to selecting one arbitrarily, as we have
+      // no further information about which clinic the clinician is arriving from.
+      const contextClinicId = stateProps.smartOnFhirData?.context?.clinicId;
+      const clinicToSelect = (contextClinicId && clinicsWithPatient.includes(contextClinicId))
+        ? contextClinicId
+        : clinicsWithPatient[0];
       dispatchProps.selectClinic(api, clinicToSelect);
     } else {
       _.forEach(stateProps.clinics, (clinic, clinicId) => {
@@ -2548,6 +2553,7 @@ export function mapStateToProps(state, props) {
     clinic: state.blip.clinics?.[state.blip.selectedClinicId],
     clinics: state.blip.clinics,
     isSmartOnFhirMode: selectIsSmartOnFhirMode(state),
+    smartOnFhirData: state.blip.smartOnFhirData,
   };
 }
 

--- a/app/pages/smartonfhir/smartonfhir.js
+++ b/app/pages/smartonfhir/smartonfhir.js
@@ -55,6 +55,10 @@ export const SmartOnFhir = (props) => {
     dispatch(getClinicsForClinician(api, clinicianId, {}, callback)),
     [dispatch]
   );
+  const selectClinic = useCallback((api, clinicId) =>
+    dispatch(async.selectClinic(api, clinicId)),
+    [dispatch]
+  );
 
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState(null);
@@ -163,12 +167,19 @@ export const SmartOnFhir = (props) => {
             return;
           }
 
+          // Only switch the clinician's selected clinic to the SMART context clinic once the
+          // patient lookup has succeeded, so a failed launch doesn't strand the clinician in a
+          // different clinic's workspace.
+          if (contextClinicId) {
+            selectClinic(api, contextClinicId);
+          }
+
           trackMetric('Direct Connect Patient Lookup Success');
           navigateTo(`/patients/${patient.id}/data`);
         });
       });
     }
-  }, [smartOnFhirData, isProcessing, working.fetchingPatients.inProgress, api, fetchPatients, navigateTo, error, smartCorrelationId, setSmartCorrelationId, windowObj, trackMetric, loggedInUserId, getClinics, handleError]);
+  }, [smartOnFhirData, isProcessing, working.fetchingPatients.inProgress, api, fetchPatients, navigateTo, error, smartCorrelationId, setSmartCorrelationId, windowObj, trackMetric, loggedInUserId, getClinics, selectClinic, handleError]);
 
   if (isProcessing || working.fetchingPatients.inProgress) {
     return (

--- a/test/unit/pages/patientdata.test.js
+++ b/test/unit/pages/patientdata.test.js
@@ -5970,6 +5970,132 @@ describe('PatientData', function () {
       expect(selectClinicResult[1]()).to.equal('fetchPatientData');
       expect(dispatchProps.selectClinic.callCount).to.equal(1);
     });
+
+    it('should select the SMART-on-FHIR context clinic when the patient belongs to multiple clinics and the context clinicId matches one of them', () => {
+      expect(dispatchProps.selectClinic.callCount).to.equal(0);
+      getFetchers(dispatchProps, ownProps, {
+        user: {
+          userid: 'clinician123',
+          isClinicMember: true,
+        },
+        clinics: {
+          clinic1234: {
+            patients: { '12345': {} },
+          },
+          clinic6789: {
+            patients: { '12345': {} },
+          },
+        },
+        selectedClinicId: null,
+        smartOnFhirData: { context: { clinicId: 'clinic6789' } },
+        fetchingPatientFromClinic: {
+          inProgress: false,
+        },
+        fetchingPendingSentInvites: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingClinicsForPatient: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingAssociatedAccounts: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingUserConsentRecords: {
+          inProgress: false,
+          completed: true,
+        },
+      });
+
+      // Should select the context clinic (clinic6789) rather than the first one (clinic1234)
+      expect(dispatchProps.selectClinic.callCount).to.equal(1);
+      expect(dispatchProps.selectClinic.calledWith(undefined, 'clinic6789')).to.be.true;
+    });
+
+    it('should fall back to the first matching clinic when the SMART-on-FHIR context clinicId does not match a clinic the patient belongs to', () => {
+      expect(dispatchProps.selectClinic.callCount).to.equal(0);
+      getFetchers(dispatchProps, ownProps, {
+        user: {
+          userid: 'clinician123',
+          isClinicMember: true,
+        },
+        clinics: {
+          clinic1234: {
+            patients: { '12345': {} },
+          },
+          clinic6789: {
+            patients: { '12345': {} },
+          },
+        },
+        selectedClinicId: null,
+        smartOnFhirData: { context: { clinicId: 'clinicNotAMember' } },
+        fetchingPatientFromClinic: {
+          inProgress: false,
+        },
+        fetchingPendingSentInvites: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingClinicsForPatient: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingAssociatedAccounts: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingUserConsentRecords: {
+          inProgress: false,
+          completed: true,
+        },
+      });
+
+      expect(dispatchProps.selectClinic.callCount).to.equal(1);
+      expect(dispatchProps.selectClinic.calledWith(undefined, 'clinic1234')).to.be.true;
+    });
+
+    it('should fall back to the first matching clinic when the patient belongs to multiple clinics and there is no SMART-on-FHIR context', () => {
+      expect(dispatchProps.selectClinic.callCount).to.equal(0);
+      getFetchers(dispatchProps, ownProps, {
+        user: {
+          userid: 'clinician123',
+          isClinicMember: true,
+        },
+        clinics: {
+          clinic1234: {
+            patients: { '12345': {} },
+          },
+          clinic6789: {
+            patients: { '12345': {} },
+          },
+        },
+        selectedClinicId: null,
+        fetchingPatientFromClinic: {
+          inProgress: false,
+        },
+        fetchingPendingSentInvites: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingClinicsForPatient: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingAssociatedAccounts: {
+          inProgress: false,
+          completed: true,
+        },
+        fetchingUserConsentRecords: {
+          inProgress: false,
+          completed: true,
+        },
+      });
+
+      expect(dispatchProps.selectClinic.callCount).to.equal(1);
+      expect(dispatchProps.selectClinic.calledWith(undefined, 'clinic1234')).to.be.true;
+    });
   });
 
   describe('mapStateToProps', () => {


### PR DESCRIPTION
This pull request enhances how the application selects a clinic context when a clinician accesses patient data via a SMART-on-FHIR/EHR session, especially when the patient belongs to multiple clinics. The updates ensure that, when possible, the clinic chosen matches the one from which the EHR session was launched, improving consistency for entitlements and patient context. The changes also add comprehensive unit tests to cover these scenarios and improve test coverage for edge cases.

Key changes include:

**Clinic selection logic improvements:**

* Updated `getFetchers` in `patientdata.js` to prefer the SMART-on-FHIR/EHR context clinic when selecting a clinic for a patient who belongs to multiple clinics, falling back to the first available clinic if the context clinic is not applicable.
* Passed `smartOnFhirData` through `mapStateToProps` to ensure context information is available for clinic selection.

**Component updates:**

* Added a `selectClinic` callback to `SmartOnFhir` and updated the logic to only switch the clinician’s selected clinic to the SMART context clinic after patient lookup succeeds, preventing context mismatches in case of lookup failure. [[1]](diffhunk://#diff-fa5acd6a321d7752e45bd85e6d7642be858da3b83c206d5cbc48365081e4d2acR58-R61) [[2]](diffhunk://#diff-fa5acd6a321d7752e45bd85e6d7642be858da3b83c206d5cbc48365081e4d2acR170-R182)

**Testing and coverage:**

* Added and expanded unit tests in `patientdata.test.js` to verify that the SMART-on-FHIR context clinic is selected when appropriate, and that the fallback logic works as intended when the context clinic is not available.
* Added new tests in `smartonfhir.test.js` to cover scenarios where the context clinic is selected, not selected due to lack of access, not provided, or patient lookup fails.