### PR TITLE
WEB-4611 - Round CGM use before display

### DIFF
--- a/app/components/clinic/BgSummaryCell.js
+++ b/app/components/clinic/BgSummaryCell.js
@@ -6,6 +6,7 @@ import { withTranslation } from 'react-i18next';
 
 import { utils as vizUtils, colors as vizColors } from '@tidepool/viz';
 const { GLYCEMIC_RANGES_PRESET } = vizUtils.constants;
+const { bankersRound } = vizUtils.stat;
 
 import { MGDL_PER_MMOLL, MGDL_UNITS } from '../../core/constants';
 import BgRangeSummary from './BgRangeSummary';
@@ -117,7 +118,7 @@ export const BgSummaryCell = ({
     }, [summary, showExtremeHigh]
   );
 
-  const cgmUsePercent = (summary?.timeCGMUsePercent || 0);
+  const cgmUsePercent = bankersRound((summary?.timeCGMUsePercent || 0), 2);
   const minCgmHours = 24;
   const minCgmPercent = 0.7;
 


### PR DESCRIPTION
WEB-4611

The issue is that the minimum threshold of `70%` is being compared to the unrounded value (e.g. `69.6734%`) instead of the rounded value. The fix is that `69.xyz%` should be treated like `70%` and we should be using the rounded value for all intents and purposes.

The reason we don't need to do it for the _rest_ of the numbers in the tooltip is because the adjustment of the stats is handled by a call within `<BgSummaryCell />` to `reconcileTIRPercentages()`

<img width="665" height="166" alt="image" src="https://github.com/user-attachments/assets/9c7df1a2-fa65-428c-93ac-aa093736d2a1" />
