### PR TITLE
Truncate long 2FA device name on Account Settings

### DIFF
--- a/app/pages/userprofile/userprofile.js
+++ b/app/pages/userprofile/userprofile.js
@@ -260,7 +260,7 @@ ManagePasswordRow.propTypes = {
 };
 
 // Cell shape inside the gray inset panel used by both the 2FA and Recovery Codes
-function InsetCell({ label, children, sx }) {
+function InsetCell({ label, children, sx, truncate, title }) {
   return (
     <Box sx={sx}>
       <Text
@@ -278,11 +278,13 @@ function InsetCell({ label, children, sx }) {
       </Text>
       <Text
         as="div"
+        title={title}
         sx={{
           fontFamily: 'default',
           fontSize: 1,
           lineHeight: 2,
           color: 'black',
+          ...(truncate && { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }),
         }}
       >
         {children}
@@ -295,6 +297,8 @@ InsetCell.propTypes = {
   label: PropTypes.string.isRequired,
   children: PropTypes.node,
   sx: PropTypes.object,
+  truncate: PropTypes.bool,
+  title: PropTypes.string,
 };
 
 function TwoFactorRow({ t, trackMetric, mfaStatus, onSetup2fa, onDisable2fa, onRegenerateCodes, loading, error, onRetry }) {
@@ -363,7 +367,12 @@ function TwoFactorRow({ t, trackMetric, mfaStatus, onSetup2fa, onDisable2fa, onR
             justifyContent: 'space-between',
           }}
         >
-          <InsetCell label={t('Personal device name')} sx={{ flex: ['unset', 1], minWidth: 0 }}>
+          <InsetCell
+            label={t('Personal device name')}
+            sx={{ flex: ['unset', 1], minWidth: 0 }}
+            truncate
+            title={deviceName || undefined}
+          >
             {deviceName || '—'}
           </InsetCell>
           <InsetCell label={t('Created')} sx={{ flex: ['unset', 1], minWidth: 0 }}>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.97.0-feat-blip-2fa.2",
+  "version": "1.97.0-feat-blip-2fa.3",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test yarn jest --verbose",


### PR DESCRIPTION
The 2FA "Personal device name" cell rendered the full name on one line with no overflow handling, so a long name (256-char limit) spilled across the Created column and the panel edge.

Add an opt-in truncate + title prop to InsetCell and enable it on the device-name cell, keeping the device-name and Created cells at an even split so the name truncates with an ellipsis at ~half the row and the row aligns with the Recovery Codes row below. The full name is available on hover.