### PR TITLE
[WEB-4649,WEB-4650] Add patientID to clinic review and TIDE drawer metrics

### DIFF
--- a/app/components/clinic/PatientLastReviewed.js
+++ b/app/components/clinic/PatientLastReviewed.js
@@ -67,7 +67,7 @@ export const PatientLastReviewed = ({ api, patientId, recentlyReviewedThresholdD
   }, [revertingClinicPatientLastReviewed]);
 
   const handleReview = () => {
-    trackMetric('Clinic - Mark patient reviewed', { clinicId: selectedClinicId, source: metricSource });
+    trackMetric('Clinic - Mark patient reviewed', { clinicId: selectedClinicId, source: metricSource, patientID: patientId });
     dispatch(actions.async.setClinicPatientLastReviewed(api, selectedClinicId, patientId));
     onReview && onReview();
   };

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -409,7 +409,7 @@ const TideDashboardSection = React.memo(props => {
       const isValidAgpPeriod = ['7d', '14d', '30d'].includes(config?.period);
 
       if (showTideDashboardPatientDrawer && isValidAgpPeriod && !isNoDataGroup) {
-        trackMetric('Tide Dashboard - opened patient in side drawer', { clinicId: selectedClinicId, patientID: patient.id });
+        trackMetric('Tide Dashboard - opened patient in side drawer', { clinicId: selectedClinicId, patientID: patient?.id });
 
         const { search, pathname } = location;
         const params = new URLSearchParams(search);

--- a/app/pages/dashboard/TideDashboard.js
+++ b/app/pages/dashboard/TideDashboard.js
@@ -409,6 +409,8 @@ const TideDashboardSection = React.memo(props => {
       const isValidAgpPeriod = ['7d', '14d', '30d'].includes(config?.period);
 
       if (showTideDashboardPatientDrawer && isValidAgpPeriod && !isNoDataGroup) {
+        trackMetric('Tide Dashboard - opened patient in side drawer', { clinicId: selectedClinicId, patientID: patient.id });
+
         const { search, pathname } = location;
         const params = new URLSearchParams(search);
         params.set('drawerPatientId', patient.id);
@@ -420,7 +422,7 @@ const TideDashboardSection = React.memo(props => {
 
       dispatch(push(`/patients/${patient?.id}/data/trends?dashboard=tide`));
     }
-  }, [dispatch, trackMetric, showTideDashboardPatientDrawer, config]);
+  }, [dispatch, trackMetric, showTideDashboardPatientDrawer, config, selectedClinicId]);
 
   const handleEditPatientDataConnections = useCallback((patient) => {
     editPatientDataConnections(patient, setSelectedPatient, selectedClinicId, trackMetric, setShowDataConnectionsModal, 'dexcom connection status');

--- a/test/unit/pages/ClinicPatients.test.js
+++ b/test/unit/pages/ClinicPatients.test.js
@@ -2875,7 +2875,7 @@ describe('ClinicPatients', () => {
             fireEvent.click(updateButton());
 
             await waitFor(() => {
-              sinon.assert.calledWith(defaultProps.trackMetric, 'Clinic - Mark patient reviewed', sinon.match({ clinicId: 'clinicID123', source: 'Patients list' }));
+              sinon.assert.calledWith(defaultProps.trackMetric, 'Clinic - Mark patient reviewed', sinon.match({ clinicId: 'clinicID123', source: 'Patients list', patientID: 'patient2' }));
 
               sinon.assert.calledWith(
                 defaultProps.api.clinics.setClinicPatientLastReviewed,

--- a/test/unit/pages/TideDashboard.test.js
+++ b/test/unit/pages/TideDashboard.test.js
@@ -782,6 +782,36 @@ describe('TideDashboard', () => {
       ]);
     });
 
+    it('should track a metric and open the side drawer when a patient is clicked with the patient drawer flag enabled', () => {
+      useFlags.mockReturnValue({
+        showTideDashboard: true,
+        showSummaryDashboard: true,
+        tideDashboardCategories: '',
+        showTideDashboardPatientDrawer: true,
+      });
+
+      wrapper = mountWithProviders(
+        <TideDashboard {...defaultProps} />,
+        { store }
+      );
+
+      const dashboardSectionTables = document.querySelectorAll('.dashboard-table');
+      const getTableRow = (tableIndex, rowIndex) => dashboardSectionTables[tableIndex].querySelectorAll('tr')[rowIndex];
+
+      const firstPatientName = getTableRow(0, 2).querySelectorAll('span')[0];
+      expect(firstPatientName.textContent).contains('Charmane Fassman');
+      const expectedPatientId = '6da2c016-263b-92db-1c3e-11ed92f5be4b';
+
+      defaultProps.trackMetric.resetHistory();
+      fireEvent.click(firstPatientName);
+
+      sinon.assert.calledWith(
+        defaultProps.trackMetric,
+        'Tide Dashboard - opened patient in side drawer',
+        sinon.match({ clinicId: 'clinicID123', patientID: expectedPatientId })
+      );
+    });
+
     context('mmol/L preferredBgUnits', () => {
       beforeEach(() => {
         store = mockStore(hasResultsStateMmoll);
@@ -872,7 +902,7 @@ describe('TideDashboard', () => {
           fireEvent.click(updateButton());
 
           await waitFor(() => {
-            sinon.assert.calledWith(defaultProps.trackMetric, 'Clinic - Mark patient reviewed', sinon.match({ clinicId: 'clinicID123', source: 'TIDE dashboard' }));
+            sinon.assert.calledWith(defaultProps.trackMetric, 'Clinic - Mark patient reviewed', sinon.match({ clinicId: 'clinicID123', source: 'TIDE dashboard', patientID: 'ea8ab4da-d4ed-bc6a-dec3-6aa170a99d49' }));
           });
 
           sinon.assert.calledWith(

--- a/test/unit/pages/TideDashboard.test.js
+++ b/test/unit/pages/TideDashboard.test.js
@@ -782,7 +782,7 @@ describe('TideDashboard', () => {
       ]);
     });
 
-    it('should track a metric and open the side drawer when a patient is clicked with the patient drawer flag enabled', () => {
+    it('should track a metric when a patient is clicked to open in the side drawer with the patient drawer flag enabled', () => {
       useFlags.mockReturnValue({
         showTideDashboard: true,
         showSummaryDashboard: true,


### PR DESCRIPTION
[WEB-4649] [WEB-4650]

Add patient analytics: mark-reviewed patientID + TIDE side-drawer open event

Adds patient-level analytics to two clinician workflows:

  - **PROD-482** **WEB-4649** — Include `patientID` (the patient's Tidepool user id) on the
    `Clinic - Mark patient reviewed` event, so reviews can be attributed to a
    specific patient.
  - **PROD-504** **WEB-4650** — Add a new `Tide Dashboard - opened patient in side drawer`
    event, fired when a clinician opens a patient record from the TIDE dashboard
    and it launches in the side drawer.

  Both use the `patientID` property key to match the existing
  `Fetched initial patient data` convention.


[WEB-4649]: https://tidepool.atlassian.net/browse/WEB-4649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-4650]: https://tidepool.atlassian.net/browse/WEB-4650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ