### PR TITLE
[WEB-4710] Ensure 2FA banner is shown correctly when switching between clinics

### DIFF
--- a/app/providers/AppBanner/AppBannerProvider.js
+++ b/app/providers/AppBanner/AppBannerProvider.js
@@ -63,7 +63,7 @@ const AppBannerProvider = ({ children }) => {
   // exemption is decided on complete data rather than suppressing the banner on first load.
   const partialClinicAdminCount = filter(clinic?.clinicians, { roles: ['CLINIC_ADMIN'] }).length;
   const rosterFetchNeeded = isClinician && !isSSO && !!selectedClinicId && partialClinicAdminCount === 1 && loggedInUserIsClinicAdmin;
-  const { data: fetchedClinicians } = useGetCliniciansForClinicQuery(selectedClinicId, { skip: !rosterFetchNeeded });
+  const { currentData: fetchedClinicians } = useGetCliniciansForClinicQuery(selectedClinicId, { skip: !rosterFetchNeeded });
 
   const clinicAdminCount = fetchedClinicians
     ? filter(fetchedClinicians, { roles: ['CLINIC_ADMIN'] }).length

--- a/test/unit/app/providers/AppBanner/AppBannerProvider.test.js
+++ b/test/unit/app/providers/AppBanner/AppBannerProvider.test.js
@@ -107,7 +107,7 @@ describe('AppBannerProvider', () => {
     useGetMfaStatusQuery.mockReturnValue({ data: undefined });
     // Default: full clinician roster not fetched; sole-admin calc falls back to clinic.clinicians.
     useGetCliniciansForClinicQuery.mockClear();
-    useGetCliniciansForClinicQuery.mockReturnValue({ data: undefined });
+    useGetCliniciansForClinicQuery.mockReturnValue({ data: undefined, currentData: undefined });
 
     store = mockStore(initialState);
   });
@@ -886,12 +886,39 @@ describe('AppBannerProvider', () => {
       // clinic.clinicians still holds only the viewer (sole admin), but the fetched roster shows
       // multiple admins, so the exemption resolves false and the banner appears without navigation.
       useGetMfaStatusQuery.mockReturnValue({ data: { enabled: false } });
-      useGetCliniciansForClinicQuery.mockReturnValue({
-        data: [{ roles: ['CLINIC_ADMIN'] }, { roles: ['CLINIC_ADMIN'] }],
-      });
+      const roster = [{ roles: ['CLINIC_ADMIN'] }, { roles: ['CLINIC_ADMIN'] }];
+      useGetCliniciansForClinicQuery.mockReturnValue({ data: roster, currentData: roster });
       const contextData = renderAt(makeState({ clinicians: { clinician1: { roles: ['CLINIC_ADMIN'] } } }));
       expect(contextData.hasBanner).toBe(true);
       expect(contextData.banner.id).toEqual('enable2fa');
+    });
+
+    it('ignores a previously viewed clinic\'s roster when the query is skipped for the selected clinic', () => {
+      // Switching back from a sole-admin workspace leaves that clinic's roster on the hook's data
+      // field. The selected clinic already shows two admins, so the query is skipped and the
+      // exemption must come from clinic.clinicians, not the stale roster.
+      useGetMfaStatusQuery.mockReturnValue({ data: { enabled: false } });
+      useGetCliniciansForClinicQuery.mockReturnValue({
+        data: [{ roles: ['CLINIC_ADMIN'] }],
+        currentData: undefined,
+      });
+      const contextData = renderAt(makeState());
+      expect(useGetCliniciansForClinicQuery).toHaveBeenLastCalledWith('clinic1', { skip: true });
+      expect(contextData.hasBanner).toBe(true);
+      expect(contextData.banner.id).toEqual('enable2fa');
+    });
+
+    it('ignores a previously viewed clinic\'s roster while the selected clinic\'s roster is in flight', () => {
+      // The stale roster shows two admins while the sole admin of the selected clinic is fetching
+      // their own roster; the exemption holds until that fetch resolves.
+      useGetMfaStatusQuery.mockReturnValue({ data: { enabled: false } });
+      useGetCliniciansForClinicQuery.mockReturnValue({
+        data: [{ roles: ['CLINIC_ADMIN'] }, { roles: ['CLINIC_ADMIN'] }],
+        currentData: undefined,
+      });
+      const contextData = renderAt(makeState({ clinicians: { clinician1: { roles: ['CLINIC_ADMIN'] } } }));
+      expect(useGetCliniciansForClinicQuery).toHaveBeenLastCalledWith('clinic1', { skip: false });
+      expect(contextData.hasBanner).toBe(false);
     });
   });
 });


### PR DESCRIPTION
[WEB-4710]
• Replace `data` with `currentData` from RTK Query hook to
  prevent using cached results from previous clinic queries
  when switching between clinics.

• RTK Query's `data` field persists values from previous
  requests on the hook; `currentData` only contains data
  from the active query, ensuring correct behavior when
  skip conditions change.

• Update mock return values in tests to include both `data`
  and `currentData` fields for RTK Query hook parity.

• Add test case for skipped queries: verifies that stale
  roster data is ignored when the query is skipped for the
  selected clinic.

• Add test case for in-flight queries: verifies that stale
  roster data is ignored while the selected clinic's roster
  is being fetched, preserving the 2FA exemption until the
  current request resolves.

[WEB-4710]: https://tidepool.atlassian.net/browse/WEB-4710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ