### PR TITLE
[WEB-4709] Reset clinic-details form on action change

### DIFF
--- a/app/pages/clinicdetails/clinicdetails.js
+++ b/app/pages/clinicdetails/clinicdetails.js
@@ -378,8 +378,8 @@ export const ClinicDetails = (props) => {
 
   useEffect(() => {
       formikContext.resetForm();
-      // The route pattern is shared across actions, so this component instance
-      // persists across the step change and would keep a stale submitting flag.
+      // The component stays mounted between actions, so clear the previous
+      // action's submitting flag.
       setSubmitting(false);
   }, [action]);
 

--- a/app/pages/clinicdetails/clinicdetails.js
+++ b/app/pages/clinicdetails/clinicdetails.js
@@ -378,6 +378,9 @@ export const ClinicDetails = (props) => {
 
   useEffect(() => {
       formikContext.resetForm();
+      // The route pattern is shared across actions, so this component instance
+      // persists across the step change and would keep a stale submitting flag.
+      setSubmitting(false);
   }, [action]);
 
   const formActions = [{

--- a/test/unit/pages/clinicdetails.test.js
+++ b/test/unit/pages/clinicdetails.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, fireEvent, waitFor, cleanup, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router';
 import configureStore from 'redux-mock-store';
@@ -40,6 +40,7 @@ describe('ClinicDetails', () => {
   let wrapper;
   let store;
   let mockMutate;
+  let history;
 
   const defaultProps = {
     trackMetric: sinon.stub(),
@@ -185,7 +186,10 @@ describe('ClinicDetails', () => {
       <Provider store={store}>
         <ToastProvider>
           <MemoryRouter initialEntries={[`/clinic-details/${route}`]}>
-            <Route path='/clinic-details/:action' children={() => <ClinicDetails {...defaultProps} />} />
+            <Route path='/clinic-details/:action' children={(routeProps) => {
+              history = routeProps.history;
+              return <ClinicDetails {...defaultProps} />;
+            }} />
           </MemoryRouter>
         </ToastProvider>
       </Provider>
@@ -304,6 +308,36 @@ describe('ClinicDetails', () => {
             clinic: { role: 'endocrinologist' },
           },
         });
+      });
+    });
+
+    context('profile form followed by the clinic creation step', () => {
+      beforeEach(() => {
+        createWrapper('profile', defaultState);
+      });
+
+      it('should not leave the submit button in a processing state after the action changes', async () => {
+        const { container } = wrapper;
+
+        fireEvent.change(container.querySelector('input[name="firstName"]'), { target: { name: 'firstName', value: 'Bill' } });
+        fireEvent.change(container.querySelector('input[name="lastName"]'), { target: { name: 'lastName', value: 'Bryerson' } });
+        fireEvent.change(container.querySelector('select[name="role"]'), { target: { name: 'role', value: 'endocrinologist' } });
+
+        await waitFor(() => {
+          expect(container.querySelector('button#submit').disabled).to.be.false;
+        });
+
+        fireEvent.click(container.querySelector('button#submit'));
+
+        await waitFor(() => {
+          expect(container.querySelector('button#submit').classList.contains('processing')).to.be.true;
+        });
+
+        await act(async () => {
+          history.push('/clinic-details/new');
+        });
+
+        expect(container.querySelector('button#submit').classList.contains('processing')).to.be.false;
       });
     });
 


### PR DESCRIPTION
[WEB-4709]
- ClinicDetails component persists across route changes within the
  same route pattern, causing the form's submitting flag to remain
  stale when navigating between steps
- Add setSubmitting(false) call in the action-change useEffect to
  reset the form state on each step transition
- Extract history from route props in test setup to enable
  programmatic navigation between steps
- Add test verifying the processing state clears when navigating
  from profile form to clinic creation step

[WEB-4709]: https://tidepool.atlassian.net/browse/WEB-4709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ