### PR TITLE
[WEB-4721] Keep 2FA banner visible through a cancelled setup

### DIFF
--- a/app/providers/AppBanner/AppBanner.js
+++ b/app/providers/AppBanner/AppBanner.js
@@ -35,19 +35,23 @@ const AppBanner = ({ trackMetric }) => {
   const [bannerActionClicked, setBannerActionClicked] = useState(false);
 
   const completeClickAction = useCallback(() => {
-    persistBannerInteraction && dispatch(async.handleBannerInteraction(api, loggedInUserId, banner?.interactionId, CLICKED_BANNER_ACTION));
-    showModal && setShowModal(false);
+    if (banner?.action?.trackInteraction !== false) {
+      persistBannerInteraction && dispatch(async.handleBannerInteraction(api, loggedInUserId, banner?.interactionId, CLICKED_BANNER_ACTION));
 
-    setBannerInteractedForPatient({
-      [banner?.interactionId]: {
-        ...(bannerInteractedForPatient[banner?.interactionId] || {}),
-        [currentPatientInViewId]: true,
-      },
-    });
+      setBannerInteractedForPatient({
+        [banner?.interactionId]: {
+          ...(bannerInteractedForPatient[banner?.interactionId] || {}),
+          [currentPatientInViewId]: true,
+        },
+      });
+    }
+
+    showModal && setShowModal(false);
 
     // Reset the banner action clicked state to false whenever the click action is completed
     setBannerActionClicked(false);
   }, [
+    banner?.action?.trackInteraction,
     banner?.interactionId,
     bannerInteractedForPatient,
     currentPatientInViewId,
@@ -142,7 +146,7 @@ const AppBanner = ({ trackMetric }) => {
 
     isFunction(banner.action?.handler) && banner.action.handler();
 
-    if (!banner.action?.working?.key && banner.action?.trackInteraction !== false) {
+    if (!banner.action?.working?.key) {
       completeClickAction();
     }
   }

--- a/app/providers/AppBanner/AppBanner.js
+++ b/app/providers/AppBanner/AppBanner.js
@@ -142,7 +142,7 @@ const AppBanner = ({ trackMetric }) => {
 
     isFunction(banner.action?.handler) && banner.action.handler();
 
-    if (!banner.action?.working?.key) {
+    if (!banner.action?.working?.key && banner.action?.trackInteraction !== false) {
       completeClickAction();
     }
   }

--- a/app/providers/AppBanner/appBanners.js
+++ b/app/providers/AppBanner/appBanners.js
@@ -363,6 +363,8 @@ export const appBanners = [
         text: t('Set Up 2FA'),
         metric: 'Enable 2FA banner clicked',
         handler: () => dispatch(push({ pathname: '/profile', state: { openMfaSetup: true } })),
+        // Clicking through to setup shouldn't consume the banner; it stays visible until dismissed or 2FA is enabled
+        trackInteraction: false,
       },
       dismiss: {
         metric: 'Enable 2FA banner dismissed',

--- a/test/unit/app/providers/AppBanner/AppBanner.test.js
+++ b/test/unit/app/providers/AppBanner/AppBanner.test.js
@@ -166,7 +166,7 @@ describe('AppBanner handleClickAction', () => {
     expect(handleBannerInteractionStub.mock.calls.length).to.equal(0);
   });
 
-  it('should NOT complete the click interaction if action.trackInteraction is false', () => {
+  it('should NOT record an interaction if action.trackInteraction is false', () => {
     const handlerStub = sinon.stub();
     createWrapper({
       action: {

--- a/test/unit/app/providers/AppBanner/AppBanner.test.js
+++ b/test/unit/app/providers/AppBanner/AppBanner.test.js
@@ -166,6 +166,25 @@ describe('AppBanner handleClickAction', () => {
     expect(handleBannerInteractionStub.mock.calls.length).to.equal(0);
   });
 
+  it('should NOT complete the click interaction if action.trackInteraction is false', () => {
+    const handlerStub = sinon.stub();
+    createWrapper({
+      action: {
+        text: 'Take Action',
+        metric: 'testMetric',
+        handler: handlerStub,
+        trackInteraction: false,
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Take Action' }));
+
+    // The handler and metric still run, but the click is not recorded as an interaction
+    expect(handlerStub.called).to.be.true;
+    expect(trackMetricStub.calledWith('testMetric')).to.be.true;
+    expect(handleBannerInteractionStub.mock.calls.length).to.equal(0);
+    expect(setBannerInteractedForPatientStub.called).to.be.false;
+  });
+
   it('should call handleBannerInteraction with SEEN_BANNER_ACTION when banner is shown', () => {
     createWrapper({
       show: {

--- a/test/unit/app/providers/AppBanner/appBanners.test.js
+++ b/test/unit/app/providers/AppBanner/appBanners.test.js
@@ -252,6 +252,7 @@ describe('appBanners', () => {
     it('enable2fa should return object with the expected keys', () => {
       const props = getPropsForBanner('enable2fa');
       expect(props).to.have.all.keys(['interactionId', 'label', 'message', 'show', 'action', 'dismiss']);
+      expect(props.action.trackInteraction).to.be.false;
     });
 
     it('enable2fa action handler dispatches a push to /profile with openMfaSetup location state', () => {


### PR DESCRIPTION
[WEB-4721](https://tidepool.atlassian.net/browse/WEB-4721) Keep 2FA banner visible through a cancelled setup
handleClickAction, and set it on the enable2fa banner so clicking
"Set Up 2FA" no longer records a suppressing interaction.

[WEB-4721]: https://tidepool.atlassian.net/browse/WEB-4721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ